### PR TITLE
Add login modal and gate layout on auth

### DIFF
--- a/app/components/layout/LoginModal.tsx
+++ b/app/components/layout/LoginModal.tsx
@@ -1,0 +1,65 @@
+'use client';
+import { useActionState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { loginGroup } from '@/app/actions/login';
+import type { LoginState } from '@/app/actions/login';
+import type { RingingGroupRow } from '@/app/models/db';
+
+export function LoginModal({ groups }: { groups: RingingGroupRow[] }) {
+	const router = useRouter();
+	const [state, action, isPending] = useActionState<LoginState, FormData>(
+		loginGroup,
+		null
+	);
+
+	useEffect(() => {
+		if (state?.success) {
+			router.refresh();
+		}
+	}, [state, router]);
+
+	const errorKey = state && !state.success ? state.error : 'no-error';
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+			<div className="bg-base-100 rounded-box shadow-xl p-6 w-full max-w-sm">
+				<h2 className="font-bold text-lg mb-4">Login to your group</h2>
+				<form action={action} className="flex flex-col gap-4">
+					<select
+						name="groupId"
+						className="select select-bordered w-full"
+						required
+					>
+						{groups.map((g) => (
+							<option key={g.id} value={g.id}>
+								{g.group_name}
+							</option>
+						))}
+					</select>
+					<input
+						key={errorKey}
+						type="password"
+						name="password"
+						className="input input-bordered w-full"
+						placeholder="Password"
+						required
+					/>
+					{state && !state.success && (
+						<p className="text-error text-sm">{state.error}</p>
+					)}
+					<button
+						type="submit"
+						className="btn btn-primary"
+						disabled={isPending}
+					>
+						{isPending ? (
+							<span className="loading loading-spinner loading-sm" />
+						) : (
+							'Login'
+						)}
+					</button>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import { Suspense } from 'react';
 import { supabase, catchSupabaseErrors } from '@/lib/supabase';
 import { RingingGroupProvider } from './components/layout/RingingGroupProvider';
 import { getGroupCookie } from './actions/group-cookie';
+import { LoginModal } from './components/layout/LoginModal';
 export const metadata: Metadata = {
 	title: 'Top of the Flocks',
 	description: 'Leaderboard for bird ringing data'
@@ -25,10 +26,17 @@ async function AuthorisedView({ children }: { children: React.ReactNode }) {
 		getGroupCookie(),
 		fetchRingingGroups()
 	]);
+
+	if (!initialGroupId) {
+		return <LoginModal groups={groups} />;
+	}
+
+	const selectedGroup = groups.find((g) => g.id === initialGroupId)!;
+
 	return (
 		<Suspense>
 			<RingingGroupProvider initialGroupId={initialGroupId}>
-				<GlobalNav groups={groups} selectedGroupId={initialGroupId} />
+				<GlobalNav groups={[selectedGroup]} selectedGroupId={initialGroupId} />
 				{children}
 			</RingingGroupProvider>
 		</Suspense>


### PR DESCRIPTION
## Summary
- Adds `LoginModal` client component: group select + password field, submits to `loginGroup` action, refreshes page on success
- Updates root layout (`app/layout.tsx`) to gate all content behind auth — shows `LoginModal` when no group cookie is set, otherwise shows the selected group's dashboard

Stacks on #232.

## Test plan
- [ ] `npm run next:dev` — app shows login modal when no cookie present
- [ ] Selecting a group + entering the correct password logs in and shows the dashboard
- [ ] Wrong password shows the error message below the password field
- [ ] `npm run qa` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)