### PR TITLE
Extract Demon CSV import logic into shared lib

### DIFF
--- a/app/api/import/__tests__/route.test.ts
+++ b/app/api/import/__tests__/route.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Transform } from 'node:stream';
+import type { ImportMessage } from '../route';
+
+// group-cookie is mocked globally to return group ID 1 (see vitest.setup.tsx)
+
+vi.mock('@/lib/group-auth', () => ({
+	getAuthenticatedSupabaseClient: vi.fn()
+}));
+
+vi.mock('@/lib/demon-import', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@/lib/demon-import')>();
+	return {
+		...actual,
+		createUpserter: vi.fn(),
+		processEncounterRow: vi.fn()
+	};
+});
+
+const CSV_HEADER =
+	'ring_no,species_name,visit_date,capture_time,loc_id,age,sex,sexing_method,record_type,scheme,breeding_condition,extra_text,moult_code,old_greater_coverts,weight,wing_length,entered_by,nest_link_code,validation_comments,submission_status,filename,new/subsequent,scheme2,ring_no2,pulli_ringed,pulli_alive,provisional_sex,gridref,habitat_1,habitat_2,status_code_1,status_code_2,lure_code_1,lure_code_2,date_measured,time_w,condition,alula,primary_moult,primary_covert_moult_scores,secondary_moult_scores,finding_condition,finding_circumstances,capture_method,metal_mark_info,ringer_initials,ringer_check_initials,processor_initials,extractor_initials,wing_initials,colour_mark_info,metal_mark_position,fat,pectoral_muscle,body_moult,greater_covert_moult_scores,alula_moult_scores,carpal_covert_moult,wing_point,primary_length,bill_length_method,bill_length,head_bill_length,bill_depth_method,bill_depth,tarsus_length_method,tail_moult_scores,tarsus_length,tail_length,claw_length,plumage,tail_diff,lesser_median_covert_moult,underwing_covert_moult,head_moult,upperparts_moult,underparts_moult,permit_no,pullus_stage,date_accuracy,left_leg_below,right_leg_below,left_leg_above,right_leg_above,neck_collar,left_wing_tag,right_wing_tag,nasal_saddle,sample_processed,high_tide_time,finder_name,own,own2,userc1,userc2,email,userc3,userc4,userc5,userv1,userv2,userv3,userv4,userv5,l_primary_moult_scores,l_secondary_moult_scores,l_tail_moult_scores,l_primary_covert_moult_scores,l_greater_covert_moult_scores,l_carpal_covert_moult,l_alula_moult_scores,toe_span';
+
+function makeCsvRow(overrides: Record<string, string> = {}): string {
+	const defaults: Record<string, string> = {
+		ring_no: 'A123456',
+		species_name: 'Blue Tit',
+		visit_date: '01/06/2024',
+		capture_time: '08:30',
+		loc_id: 'Garden Trap',
+		age: '5',
+		sex: 'M',
+		sexing_method: 'P',
+		record_type: 'N',
+		scheme: 'BTO'
+	};
+	const values = { ...defaults, ...overrides };
+	const headers = CSV_HEADER.split(',');
+	return headers.map((h) => values[h] ?? '').join(',');
+}
+
+function makeCsvFile(rows: string[]): File {
+	const content = [CSV_HEADER, ...rows].join('\n');
+	return new File([content], 'test.csv', { type: 'text/csv' });
+}
+
+async function makeRequest(file: File): Promise<Request> {
+	const formData = new FormData();
+	formData.append('csv', file);
+	return new Request('http://localhost/api/import', {
+		method: 'POST',
+		body: formData
+	});
+}
+
+async function readStreamMessages(
+	response: Response
+): Promise<ImportMessage[]> {
+	const reader = response.body!.getReader();
+	const decoder = new TextDecoder();
+	let buffer = '';
+	const messages: ImportMessage[] = [];
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		buffer += decoder.decode(value, { stream: true });
+		const lines = buffer.split('\n');
+		buffer = lines.pop()!;
+		for (const line of lines) {
+			if (line.trim()) messages.push(JSON.parse(line));
+		}
+	}
+	return messages;
+}
+
+describe('POST /api/import', () => {
+	let POST: (request: Request) => Promise<Response>;
+	let mockUpsert: ReturnType<typeof vi.fn>;
+
+	beforeEach(async () => {
+		vi.resetModules();
+		({ POST } = await import('../route'));
+
+		const { getAuthenticatedSupabaseClient } = await import('@/lib/group-auth');
+		const { createUpserter } = await import('@/lib/demon-import');
+		mockUpsert = vi.fn().mockResolvedValue(1);
+		vi.mocked(createUpserter).mockReturnValue(mockUpsert as never);
+		vi.mocked(getAuthenticatedSupabaseClient).mockResolvedValue({} as never);
+	});
+
+	describe('authentication', () => {
+		it('returns 401 when not authenticated', async () => {
+			const { getGroupCookie } = await import('@/app/actions/group-cookie');
+			vi.mocked(getGroupCookie).mockResolvedValueOnce(null);
+
+			const request = await makeRequest(makeCsvFile([makeCsvRow()]));
+			const response = await POST(request);
+			expect(response.status).toBe(401);
+		});
+	});
+
+	describe('request validation', () => {
+		it('returns 400 when no csv file is provided', async () => {
+			const formData = new FormData();
+			const request = new Request('http://localhost/api/import', {
+				method: 'POST',
+				body: formData
+			});
+			const response = await POST(request);
+			expect(response.status).toBe(400);
+		});
+	});
+
+	describe('successful import', () => {
+		beforeEach(async () => {
+			const { processEncounterRow } = await import('@/lib/demon-import');
+			vi.mocked(processEncounterRow).mockResolvedValue({
+				visitDate: '2024-06-01'
+			});
+		});
+
+		it('calls processEncounterRow for each CSV row', async () => {
+			const { processEncounterRow } = await import('@/lib/demon-import');
+			const file = makeCsvFile([
+				makeCsvRow(),
+				makeCsvRow({ ring_no: 'B654321' })
+			]);
+			const response = await POST(await makeRequest(file));
+			await readStreamMessages(response);
+			expect(vi.mocked(processEncounterRow)).toHaveBeenCalledTimes(2);
+		});
+
+		it('streams a complete message with correct counts', async () => {
+			const file = makeCsvFile([
+				makeCsvRow(),
+				makeCsvRow({ ring_no: 'B654321' })
+			]);
+			const response = await POST(await makeRequest(file));
+			const messages = await readStreamMessages(response);
+			const complete = messages.find((m) => m.type === 'complete');
+			expect(complete).toEqual({
+				type: 'complete',
+				processed: 2,
+				successful: 2,
+				failed: 0
+			});
+		});
+
+		it('streams progress every 10 rows', async () => {
+			const rows = Array.from({ length: 25 }, (_, i) =>
+				makeCsvRow({ ring_no: `R${i.toString().padStart(6, '0')}` })
+			);
+			const response = await POST(await makeRequest(makeCsvFile(rows)));
+			const messages = await readStreamMessages(response);
+			const progressMessages = messages.filter((m) => m.type === 'progress');
+			expect(progressMessages).toHaveLength(2);
+			expect(progressMessages[0]).toEqual({ type: 'progress', processed: 10 });
+			expect(progressMessages[1]).toEqual({ type: 'progress', processed: 20 });
+		});
+
+		it('sets response Content-Type to application/x-ndjson', async () => {
+			const response = await POST(
+				await makeRequest(makeCsvFile([makeCsvRow()]))
+			);
+			await readStreamMessages(response);
+			expect(response.headers.get('Content-Type')).toBe('application/x-ndjson');
+		});
+	});
+
+	describe('error handling', () => {
+		it('counts rows where processEncounterRow throws as failed', async () => {
+			const { processEncounterRow } = await import('@/lib/demon-import');
+			vi.mocked(processEncounterRow)
+				.mockResolvedValueOnce({ visitDate: '2024-06-01' })
+				.mockRejectedValueOnce(new Error('DB error'))
+				.mockResolvedValueOnce({ visitDate: '2024-06-02' });
+
+			const file = makeCsvFile([
+				makeCsvRow(),
+				makeCsvRow({ ring_no: 'B000001' }),
+				makeCsvRow({ ring_no: 'C000001' })
+			]);
+			const response = await POST(await makeRequest(file));
+			const messages = await readStreamMessages(response);
+			const complete = messages.find((m) => m.type === 'complete');
+			expect(complete).toEqual({
+				type: 'complete',
+				processed: 3,
+				successful: 2,
+				failed: 1
+			});
+		});
+
+		it('does not count CasualtyEncounterError rows as failed', async () => {
+			const { processEncounterRow, CasualtyEncounterError } =
+				await import('@/lib/demon-import');
+			vi.mocked(processEncounterRow)
+				.mockResolvedValueOnce({ visitDate: '2024-06-01' })
+				.mockRejectedValueOnce(new CasualtyEncounterError());
+
+			const file = makeCsvFile([makeCsvRow(), makeCsvRow({ ring_no: '' })]);
+			const response = await POST(await makeRequest(file));
+			const messages = await readStreamMessages(response);
+			const complete = messages.find((m) => m.type === 'complete');
+			expect(complete).toEqual({
+				type: 'complete',
+				processed: 2,
+				successful: 1,
+				failed: 0
+			});
+		});
+
+		it('streams an error message when csv-parser emits an error', async () => {
+			// Trigger the outer catch in the ReadableStream start function by making
+			// csv-parser emit an error. Per-row errors are caught individually and
+			// counted as failures; only errors from the parsing step itself reach
+			// the outer catch and produce an error NDJSON message.
+			vi.doMock('csv-parser', () => ({
+				default: () => {
+					return new Transform({
+						objectMode: true,
+						transform(
+							_chunk: unknown,
+							_enc: string,
+							callback: (err?: Error) => void
+						) {
+							callback(new Error('CSV parse error'));
+						}
+					});
+				}
+			}));
+			vi.resetModules();
+
+			// Re-apply mocks cleared by resetModules
+			vi.doMock('@/lib/group-auth', () => ({
+				getAuthenticatedSupabaseClient: vi.fn().mockResolvedValue({})
+			}));
+			vi.doMock('@/lib/demon-import', async (importOriginal) => {
+				const actual =
+					await importOriginal<typeof import('@/lib/demon-import')>();
+				return {
+					...actual,
+					createUpserter: vi.fn().mockReturnValue(vi.fn()),
+					processEncounterRow: vi.fn()
+				};
+			});
+
+			const { POST: freshPOST } = await import('../route');
+			const file = makeCsvFile([makeCsvRow()]);
+			const response = await freshPOST(await makeRequest(file));
+			const messages = await readStreamMessages(response);
+			expect(messages.some((m) => m.type === 'error')).toBe(true);
+		});
+	});
+});

--- a/app/api/import/route.ts
+++ b/app/api/import/route.ts
@@ -1,0 +1,119 @@
+import { Readable } from 'stream';
+import csvParser from 'csv-parser';
+import { getGroupCookie } from '@/app/actions/group-cookie';
+import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
+import {
+	createUpserter,
+	processEncounterRow,
+	CasualtyEncounterError,
+	type DemonRow
+} from '@/lib/demon-import';
+
+export const maxDuration = 300;
+
+export type ImportProgressMessage = { type: 'progress'; processed: number };
+export type ImportCompleteMessage = {
+	type: 'complete';
+	processed: number;
+	successful: number;
+	failed: number;
+};
+export type ImportTimeoutMessage = {
+	type: 'timeout';
+	processed: number;
+	startDate: string | null;
+	endDate: string | null;
+};
+export type ImportErrorMessage = { type: 'error'; message: string };
+export type ImportMessage =
+	| ImportProgressMessage
+	| ImportCompleteMessage
+	| ImportTimeoutMessage
+	| ImportErrorMessage;
+
+const TIMEOUT_MS = 280_000;
+
+export async function POST(request: Request): Promise<Response> {
+	const ringingGroupId = await getGroupCookie();
+	if (!ringingGroupId) {
+		return new Response('Unauthorized', { status: 401 });
+	}
+
+	const formData = await request.formData();
+	const file = formData.get('csv') as File | null;
+	if (!file) {
+		return new Response('Missing csv file', { status: 400 });
+	}
+
+	const buffer = Buffer.from(await file.arrayBuffer());
+	const supabaseClient = await getAuthenticatedSupabaseClient();
+	const upsert = createUpserter(supabaseClient);
+	const deadline = Date.now() + TIMEOUT_MS;
+	const encoder = new TextEncoder();
+
+	const stream = new ReadableStream({
+		async start(controller) {
+			function send(message: ImportMessage): void {
+				controller.enqueue(encoder.encode(JSON.stringify(message) + '\n'));
+			}
+
+			let processed = 0;
+			let successful = 0;
+			let failed = 0;
+			let startDate: string | null = null;
+			let endDate: string | null = null;
+
+			try {
+				const rows: DemonRow[] = [];
+				await new Promise<void>((resolve, reject) => {
+					Readable.from(buffer)
+						.pipe(csvParser())
+						.on('data', (row: DemonRow) => rows.push(row))
+						.on('end', resolve)
+						.on('error', reject);
+				});
+
+				for (const row of rows) {
+					if (Date.now() > deadline) {
+						send({ type: 'timeout', processed, startDate, endDate });
+						return;
+					}
+
+					try {
+						const { visitDate } = await processEncounterRow(
+							row,
+							upsert,
+							ringingGroupId
+						);
+						successful++;
+						if (startDate === null || visitDate < startDate)
+							startDate = visitDate;
+						if (endDate === null || visitDate > endDate) endDate = visitDate;
+					} catch (err) {
+						if (!(err instanceof CasualtyEncounterError)) {
+							failed++;
+						}
+					}
+
+					processed++;
+					if (processed % 10 === 0) {
+						send({ type: 'progress', processed });
+					}
+				}
+
+				send({ type: 'complete', processed, successful, failed });
+			} catch (err) {
+				send({
+					type: 'error',
+					message: err instanceof Error ? err.message : String(err)
+				});
+			} finally {
+				controller.close();
+			}
+		}
+	});
+
+	return new Response(stream, {
+		headers: { 'Content-Type': 'application/x-ndjson' }
+	});
+}

--- a/lib/__tests__/demon-import.test.ts
+++ b/lib/__tests__/demon-import.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+	transformEmptyStringsToNull,
+	convertDateFormat,
+	CasualtyEncounterError,
+	processEncounterRow,
+	type DemonRow
+} from '../demon-import';
+
+function makeDemonRow(overrides: Partial<DemonRow> = {}): DemonRow {
+	return {
+		ring_no: 'A123456',
+		species_name: 'Blue Tit',
+		visit_date: '01/06/2024',
+		capture_time: '08:30',
+		loc_id: 'Garden Trap',
+		age: '5',
+		sex: 'M',
+		sexing_method: 'P',
+		record_type: 'N',
+		scheme: 'BTO',
+		breeding_condition: '',
+		extra_text: '',
+		moult_code: '',
+		old_greater_coverts: '',
+		weight: '10.5',
+		wing_length: '65',
+		entered_by: '',
+		nest_link_code: '',
+		validation_comments: '',
+		submission_status: '',
+		filename: '',
+		'new/subsequent': '',
+		scheme2: '',
+		ring_no2: '',
+		pulli_ringed: '',
+		pulli_alive: '',
+		provisional_sex: '',
+		gridref: '',
+		habitat_1: '',
+		habitat_2: '',
+		status_code_1: '',
+		status_code_2: '',
+		lure_code_1: '',
+		lure_code_2: '',
+		date_measured: '',
+		time_w: '',
+		condition: '',
+		alula: '',
+		primary_moult: '',
+		primary_covert_moult_scores: '',
+		secondary_moult_scores: '',
+		finding_condition: '',
+		finding_circumstances: '',
+		capture_method: '',
+		metal_mark_info: '',
+		ringer_initials: '',
+		ringer_check_initials: '',
+		processor_initials: '',
+		extractor_initials: '',
+		wing_initials: '',
+		colour_mark_info: '',
+		metal_mark_position: '',
+		fat: '',
+		pectoral_muscle: '',
+		body_moult: '',
+		greater_covert_moult_scores: '',
+		alula_moult_scores: '',
+		carpal_covert_moult: '',
+		wing_point: '',
+		primary_length: '',
+		bill_length_method: '',
+		bill_length: '',
+		head_bill_length: '',
+		bill_depth_method: '',
+		bill_depth: '',
+		tarsus_length_method: '',
+		tail_moult_scores: '',
+		tarsus_length: '',
+		tail_length: '',
+		claw_length: '',
+		plumage: '',
+		tail_diff: '',
+		lesser_median_covert_moult: '',
+		underwing_covert_moult: '',
+		head_moult: '',
+		upperparts_moult: '',
+		underparts_moult: '',
+		permit_no: '',
+		pullus_stage: '',
+		date_accuracy: '',
+		left_leg_below: '',
+		right_leg_below: '',
+		left_leg_above: '',
+		right_leg_above: '',
+		neck_collar: '',
+		left_wing_tag: '',
+		right_wing_tag: '',
+		nasal_saddle: '',
+		sample_processed: '',
+		high_tide_time: '',
+		finder_name: '',
+		own: '',
+		own2: '',
+		userc1: '',
+		userc2: '',
+		email: '',
+		userc3: '',
+		userc4: '',
+		userc5: '',
+		userv1: '',
+		userv2: '',
+		userv3: '',
+		userv4: '',
+		userv5: '',
+		l_primary_moult_scores: '',
+		l_secondary_moult_scores: '',
+		l_tail_moult_scores: '',
+		l_primary_covert_moult_scores: '',
+		l_greater_covert_moult_scores: '',
+		l_carpal_covert_moult: '',
+		l_alula_moult_scores: '',
+		toe_span: '',
+		...overrides
+	};
+}
+
+describe('transformEmptyStringsToNull', () => {
+	it('converts empty strings to null', () => {
+		expect(transformEmptyStringsToNull({ a: '', b: 'hello' })).toEqual({
+			a: null,
+			b: 'hello'
+		});
+	});
+
+	it('trims whitespace-only strings to null', () => {
+		expect(transformEmptyStringsToNull({ a: '  ' })).toEqual({ a: null });
+	});
+
+	it('trims whitespace from non-empty strings', () => {
+		expect(transformEmptyStringsToNull({ a: ' hello ' })).toEqual({
+			a: 'hello'
+		});
+	});
+
+	it('passes through non-string values unchanged', () => {
+		expect(transformEmptyStringsToNull({ a: 42, b: null, c: true })).toEqual({
+			a: 42,
+			b: null,
+			c: true
+		});
+	});
+});
+
+describe('convertDateFormat', () => {
+	it('converts DD/MM/YYYY to YYYY-MM-DD', () => {
+		expect(convertDateFormat('01/06/2024')).toBe('2024-06-01');
+	});
+});
+
+describe('processEncounterRow', () => {
+	const RINGING_GROUP_ID = 7;
+	let upsert: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		let callCount = 0;
+		upsert = vi.fn().mockImplementation(() => {
+			callCount++;
+			return Promise.resolve(callCount * 10);
+		});
+	});
+
+	it('throws CasualtyEncounterError when ring_no is empty', async () => {
+		const row = makeDemonRow({ ring_no: '' });
+		await expect(
+			processEncounterRow(row, upsert, RINGING_GROUP_ID)
+		).rejects.toBeInstanceOf(CasualtyEncounterError);
+		expect(upsert).not.toHaveBeenCalled();
+	});
+
+	it('upserts Species with the species name', async () => {
+		const row = makeDemonRow({ species_name: 'Blue Tit' });
+		await processEncounterRow(row, upsert, RINGING_GROUP_ID);
+		expect(upsert).toHaveBeenCalledWith(
+			'Species',
+			{ species_name: 'Blue Tit' },
+			'species_name'
+		);
+	});
+
+	it('upserts Bird with ring_no and the species ID returned from Species upsert', async () => {
+		const row = makeDemonRow({ ring_no: 'A123456', species_name: 'Blue Tit' });
+		await processEncounterRow(row, upsert, RINGING_GROUP_ID);
+		const speciesId = 10; // first call returns 10
+		expect(upsert).toHaveBeenCalledWith(
+			'Birds',
+			{ ring_no: 'A123456', species_id: speciesId },
+			'ring_no'
+		);
+	});
+
+	it('upserts Location with loc_id and ringing group ID', async () => {
+		const row = makeDemonRow({ loc_id: 'Garden Trap' });
+		await processEncounterRow(row, upsert, RINGING_GROUP_ID);
+		expect(upsert).toHaveBeenCalledWith(
+			'Locations',
+			{ location_name: 'Garden Trap', ringing_group_id: RINGING_GROUP_ID },
+			'location_name'
+		);
+	});
+
+	it('upserts Session with converted visit_date and location ID', async () => {
+		const row = makeDemonRow({ visit_date: '15/03/2023' });
+		await processEncounterRow(row, upsert, RINGING_GROUP_ID);
+		const locationId = 30; // third call returns 30
+		expect(upsert).toHaveBeenCalledWith(
+			'Sessions',
+			{ visit_date: '2023-03-15', location_id: locationId },
+			'visit_date,location_id'
+		);
+	});
+
+	it('upserts Encounter with bird and session IDs from prior upserts', async () => {
+		const row = makeDemonRow({
+			capture_time: '09:15',
+			record_type: 'N',
+			scheme: 'BTO',
+			sex: 'F',
+			sexing_method: 'P',
+			age: '5',
+			weight: '11.2',
+			wing_length: '67',
+			old_greater_coverts: '3',
+			moult_code: 'M',
+			breeding_condition: 'B',
+			extra_text: 'some note'
+		});
+		await processEncounterRow(row, upsert, RINGING_GROUP_ID);
+		const birdId = 20; // second call returns 20
+		const sessionId = 40; // fourth call returns 40
+		expect(upsert).toHaveBeenCalledWith(
+			'Encounters',
+			expect.objectContaining({
+				bird_id: birdId,
+				session_id: sessionId,
+				capture_time: '09:15',
+				record_type: 'N',
+				scheme: 'BTO',
+				sex: 'F',
+				sexing_method: 'P',
+				age_code: 5,
+				is_juv: false,
+				weight: 11.2,
+				wing_length: 67,
+				old_greater_coverts: 3,
+				moult_code: 'M',
+				breeding_condition: 'B',
+				extra_text: 'some note'
+			}),
+			'bird_id,session_id'
+		);
+	});
+
+	it('converts empty string fields to null in Encounter', async () => {
+		const row = makeDemonRow({
+			breeding_condition: '',
+			moult_code: '',
+			extra_text: '',
+			sexing_method: '',
+			weight: '',
+			wing_length: '',
+			old_greater_coverts: ''
+		});
+		await processEncounterRow(row, upsert, RINGING_GROUP_ID);
+		expect(upsert).toHaveBeenCalledWith(
+			'Encounters',
+			expect.objectContaining({
+				breeding_condition: null,
+				moult_code: null,
+				extra_text: null,
+				sexing_method: null,
+				weight: null,
+				wing_length: null,
+				old_greater_coverts: null
+			}),
+			'bird_id,session_id'
+		);
+	});
+
+	it('parses juvenile age codes (e.g. "3J") into age_code and is_juv', async () => {
+		const row = makeDemonRow({ age: '3J' });
+		await processEncounterRow(row, upsert, RINGING_GROUP_ID);
+		expect(upsert).toHaveBeenCalledWith(
+			'Encounters',
+			expect.objectContaining({ age_code: 3, is_juv: true }),
+			'bird_id,session_id'
+		);
+	});
+
+	it('parses non-juvenile age codes into age_code and is_juv: false', async () => {
+		const row = makeDemonRow({ age: '6' });
+		await processEncounterRow(row, upsert, RINGING_GROUP_ID);
+		expect(upsert).toHaveBeenCalledWith(
+			'Encounters',
+			expect.objectContaining({ age_code: 6, is_juv: false }),
+			'bird_id,session_id'
+		);
+	});
+
+	it('returns the converted visit date', async () => {
+		const row = makeDemonRow({ visit_date: '22/11/2022' });
+		const result = await processEncounterRow(row, upsert, RINGING_GROUP_ID);
+		expect(result.visitDate).toBe('2022-11-22');
+	});
+
+	it('calls upsert exactly 5 times (Species, Birds, Locations, Sessions, Encounters)', async () => {
+		const row = makeDemonRow();
+		await processEncounterRow(row, upsert, RINGING_GROUP_ID);
+		expect(upsert).toHaveBeenCalledTimes(5);
+	});
+});

--- a/lib/demon-import.ts
+++ b/lib/demon-import.ts
@@ -1,0 +1,245 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/supabase.types';
+
+type SpeciesInsert = Database['public']['Tables']['Species']['Insert'];
+type BirdsInsert = Omit<
+	Database['public']['Tables']['Birds']['Insert'],
+	'last_encountered_timestamp'
+>;
+type EncountersInsert = Omit<
+	Database['public']['Tables']['Encounters']['Insert'],
+	'ringing_group_id' | 'max_hatch_year' | 'min_hatch_year'
+>;
+type SessionsInsert = Omit<
+	Database['public']['Tables']['Sessions']['Insert'],
+	'ringing_group_id'
+>;
+type LocationsInsert = Database['public']['Tables']['Locations']['Insert'];
+
+export type DemonColumnNames =
+	| 'entered_by'
+	| 'nest_link_code'
+	| 'validation_comments'
+	| 'submission_status'
+	| 'filename'
+	| 'record_type'
+	| 'new/subsequent'
+	| 'ring_no'
+	| 'scheme'
+	| 'scheme2'
+	| 'ring_no2'
+	| 'species_name'
+	| 'age'
+	| 'pulli_ringed'
+	| 'pulli_alive'
+	| 'sex'
+	| 'sexing_method'
+	| 'provisional_sex'
+	| 'breeding_condition'
+	| 'visit_date'
+	| 'capture_time'
+	| 'loc_id'
+	| 'gridref'
+	| 'habitat_1'
+	| 'habitat_2'
+	| 'status_code_1'
+	| 'status_code_2'
+	| 'lure_code_1'
+	| 'lure_code_2'
+	| 'wing_length'
+	| 'weight'
+	| 'date_measured'
+	| 'time_w'
+	| 'condition'
+	| 'moult_code'
+	| 'alula'
+	| 'old_greater_coverts'
+	| 'primary_moult'
+	| 'primary_covert_moult_scores'
+	| 'secondary_moult_scores'
+	| 'finding_condition'
+	| 'finding_circumstances'
+	| 'capture_method'
+	| 'metal_mark_info'
+	| 'ringer_initials'
+	| 'ringer_check_initials'
+	| 'processor_initials'
+	| 'extractor_initials'
+	| 'wing_initials'
+	| 'colour_mark_info'
+	| 'metal_mark_position'
+	| 'fat'
+	| 'pectoral_muscle'
+	| 'body_moult'
+	| 'greater_covert_moult_scores'
+	| 'alula_moult_scores'
+	| 'carpal_covert_moult'
+	| 'wing_point'
+	| 'primary_length'
+	| 'bill_length_method'
+	| 'bill_length'
+	| 'head_bill_length'
+	| 'bill_depth_method'
+	| 'bill_depth'
+	| 'tarsus_length_method'
+	| 'tail_moult_scores'
+	| 'tarsus_length'
+	| 'tail_length'
+	| 'claw_length'
+	| 'plumage'
+	| 'tail_diff'
+	| 'lesser_median_covert_moult'
+	| 'underwing_covert_moult'
+	| 'head_moult'
+	| 'upperparts_moult'
+	| 'underparts_moult'
+	| 'permit_no'
+	| 'pullus_stage'
+	| 'extra_text'
+	| 'date_accuracy'
+	| 'left_leg_below'
+	| 'right_leg_below'
+	| 'left_leg_above'
+	| 'right_leg_above'
+	| 'neck_collar'
+	| 'left_wing_tag'
+	| 'right_wing_tag'
+	| 'nasal_saddle'
+	| 'sample_processed'
+	| 'high_tide_time'
+	| 'finder_name'
+	| 'own'
+	| 'own2'
+	| 'userc1'
+	| 'userc2'
+	| 'email'
+	| 'userc3'
+	| 'userc4'
+	| 'userc5'
+	| 'userv1'
+	| 'userv2'
+	| 'userv3'
+	| 'userv4'
+	| 'userv5'
+	| 'l_primary_moult_scores'
+	| 'l_secondary_moult_scores'
+	| 'l_tail_moult_scores'
+	| 'l_primary_covert_moult_scores'
+	| 'l_greater_covert_moult_scores'
+	| 'l_carpal_covert_moult'
+	| 'l_alula_moult_scores'
+	| 'toe_span';
+
+export type DemonRow = Record<DemonColumnNames, string>;
+
+export class CasualtyEncounterError extends Error {
+	constructor() {
+		super('Casualty encounters are not to be imported');
+		this.name = 'CasualtyEncounterError';
+	}
+}
+
+export function transformEmptyStringsToNull(
+	obj: Record<string, unknown>
+): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(obj).map(([key, value]) => {
+			if (typeof value === 'string') {
+				const trimmed = value.trim();
+				return [key, trimmed === '' ? null : trimmed];
+			}
+			return [key, value];
+		})
+	);
+}
+
+export function convertDateFormat(dateString: string): string {
+	return dateString.split('/').reverse().join('-');
+}
+
+export function createUpserter(supabaseClient: SupabaseClient) {
+	return async <DataInsertModel>(
+		tableName: string,
+		upsertData: DataInsertModel,
+		uniqueColumn: keyof DataInsertModel
+	): Promise<number> => {
+		const { data: upsertResult, error: upsertError } = await supabaseClient
+			.from(tableName)
+			.upsert(upsertData, {
+				onConflict: uniqueColumn as string,
+				ignoreDuplicates: false
+			})
+			.select('id')
+			.single();
+
+		if (upsertError) throw upsertError;
+		if (!upsertResult)
+			throw new Error(`Upsert to ${tableName} returned no data`);
+		return upsertResult.id;
+	};
+}
+
+export async function processEncounterRow(
+	rawRow: DemonRow,
+	upsert: ReturnType<typeof createUpserter>,
+	ringingGroupId: number
+): Promise<{ visitDate: string }> {
+	const row = transformEmptyStringsToNull(rawRow) as DemonRow;
+	if (!row.ring_no) {
+		throw new CasualtyEncounterError();
+	}
+
+	const speciesId = await upsert<SpeciesInsert>(
+		'Species',
+		{ species_name: row.species_name as string },
+		'species_name'
+	);
+
+	const birdId = await upsert<BirdsInsert>(
+		'Birds',
+		{ ring_no: row.ring_no as string, species_id: speciesId },
+		'ring_no'
+	);
+
+	const locationId = await upsert<LocationsInsert>(
+		'Locations',
+		{ location_name: row.loc_id as string, ringing_group_id: ringingGroupId },
+		'location_name'
+	);
+
+	const visitDate = convertDateFormat(row.visit_date as string);
+
+	const sessionId = await upsert<SessionsInsert>(
+		'Sessions',
+		{ visit_date: visitDate, location_id: locationId },
+		'visit_date,location_id' as keyof SessionsInsert
+	);
+
+	const age_code = Number(String(row.age).replace('J', ''));
+
+	await upsert<EncountersInsert>(
+		'Encounters',
+		{
+			age_code,
+			breeding_condition: row.breeding_condition as string | null,
+			capture_time: row.capture_time as string,
+			extra_text: row.extra_text as string | null,
+			is_juv: String(row.age).endsWith('J'),
+			moult_code: row.moult_code as string | null,
+			old_greater_coverts: row.old_greater_coverts
+				? Number(row.old_greater_coverts)
+				: null,
+			record_type: row.record_type as string,
+			bird_id: birdId,
+			session_id: sessionId,
+			scheme: row.scheme as string,
+			sex: row.sex as string,
+			sexing_method: row.sexing_method as string | null,
+			weight: row.weight ? Number(row.weight) : null,
+			wing_length: row.wing_length ? Number(row.wing_length) : null
+		},
+		'bird_id,session_id' as keyof EncountersInsert
+	);
+
+	return { visitDate };
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 		"react-chartkick": "^0.5.4",
 		"react-dom": "19.1.0",
 		"react-intersection-observer": "^10.0.2",
+		"csv-parser": "^3.2.0",
 		"tailwindcss": "^4.1.18"
 	},
 	"devDependencies": {
@@ -64,7 +65,6 @@
 		"@types/react": "^19",
 		"@types/react-dom": "^19",
 		"@vitejs/plugin-react": "^5.1.3",
-		"csv-parser": "^3.2.0",
 		"eslint": "^9",
 		"eslint-config-next": "15.5.6",
 		"husky": "^9.1.7",

--- a/scripts/import-csv.ts
+++ b/scripts/import-csv.ts
@@ -13,145 +13,15 @@ import fs from 'fs';
 import path from 'path';
 import csvParser from 'csv-parser';
 import { Database } from '../types/supabase.types';
-import type { SupabaseClient } from '@supabase/supabase-js';
+import { createUpserter, processEncounterRow } from '../lib/demon-import';
 
-type SpeciesInsert = Database['public']['Tables']['Species']['Insert'];
-type BirdsInsert = Omit<
-	Database['public']['Tables']['Birds']['Insert'],
-	'last_encountered_timestamp'
->;
-type EncountersInsert = Omit<
-	Database['public']['Tables']['Encounters']['Insert'],
-	'ringing_group_id' | 'max_hatch_year' | 'min_hatch_year'
->;
-type SessionsInsert = Omit<
-	Database['public']['Tables']['Sessions']['Insert'],
-	'ringing_group_id'
->;
 type RingingGroupsInsert =
 	Database['public']['Tables']['RingingGroups']['Insert'];
-type LocationsInsert = Database['public']['Tables']['Locations']['Insert'];
-type EncounterRow = Database['public']['Tables']['Encounters']['Row'];
 
 interface ImportOptions {
 	csvFilePath: string;
 	ringingGroupName: string;
 }
-type DemonColumnNames =
-	| 'entered_by'
-	| 'nest_link_code'
-	| 'validation_comments'
-	| 'submission_status'
-	| 'filename'
-	| 'record_type'
-	| 'new/subsequent'
-	| 'ring_no'
-	| 'scheme'
-	| 'scheme2'
-	| 'ring_no2'
-	| 'species_name'
-	| 'age'
-	| 'pulli_ringed'
-	| 'pulli_alive'
-	| 'sex'
-	| 'sexing_method'
-	| 'provisional_sex'
-	| 'breeding_condition'
-	| 'visit_date'
-	| 'capture_time'
-	| 'loc_id'
-	| 'gridref'
-	| 'habitat_1'
-	| 'habitat_2'
-	| 'status_code_1'
-	| 'status_code_2'
-	| 'lure_code_1'
-	| 'lure_code_2'
-	| 'wing_length'
-	| 'weight'
-	| 'date_measured'
-	| 'time_w'
-	| 'condition'
-	| 'moult_code'
-	| 'alula'
-	| 'old_greater_coverts'
-	| 'primary_moult'
-	| 'primary_covert_moult_scores'
-	| 'secondary_moult_scores'
-	| 'finding_condition'
-	| 'finding_circumstances'
-	| 'capture_method'
-	| 'metal_mark_info'
-	| 'ringer_initials'
-	| 'ringer_check_initials'
-	| 'processor_initials'
-	| 'extractor_initials'
-	| 'wing_initials'
-	| 'colour_mark_info'
-	| 'metal_mark_position'
-	| 'fat'
-	| 'pectoral_muscle'
-	| 'body_moult'
-	| 'greater_covert_moult_scores'
-	| 'alula_moult_scores'
-	| 'carpal_covert_moult'
-	| 'wing_point'
-	| 'primary_length'
-	| 'bill_length_method'
-	| 'bill_length'
-	| 'head_bill_length'
-	| 'bill_depth_method'
-	| 'bill_depth'
-	| 'tarsus_length_method'
-	| 'tail_moult_scores'
-	| 'tarsus_length'
-	| 'tail_length'
-	| 'claw_length'
-	| 'plumage'
-	| 'tail_diff'
-	| 'lesser_median_covert_moult'
-	| 'underwing_covert_moult'
-	| 'head_moult'
-	| 'upperparts_moult'
-	| 'underparts_moult'
-	| 'permit_no'
-	| 'pullus_stage'
-	| 'extra_text'
-	| 'date_accuracy'
-	| 'left_leg_below'
-	| 'right_leg_below'
-	| 'left_leg_above'
-	| 'right_leg_above'
-	| 'neck_collar'
-	| 'left_wing_tag'
-	| 'right_wing_tag'
-	| 'nasal_saddle'
-	| 'sample_processed'
-	| 'high_tide_time'
-	| 'finder_name'
-	| 'own'
-	| 'own2'
-	| 'userc1'
-	| 'userc2'
-	| 'email'
-	| 'userc3'
-	| 'userc4'
-	| 'userc5'
-	| 'userv1'
-	| 'userv2'
-	| 'userv3'
-	| 'userv4'
-	| 'userv5'
-	| 'l_primary_moult_scores'
-	| 'l_secondary_moult_scores'
-	| 'l_tail_moult_scores'
-	| 'l_primary_covert_moult_scores'
-	| 'l_greater_covert_moult_scores'
-	| 'l_carpal_covert_moult'
-	| 'l_alula_moult_scores'
-	| 'toe_span';
-
-type DemonRow = Record<DemonColumnNames, string>;
 
 // create a rate limiter that allows up to 30 API calls per second,
 // with max concurrency of 10
@@ -161,48 +31,6 @@ const limit = pRateLimit({
 	concurrency: 30 // no more than 10 running at once
 	// maxDelay: 2000              // an API call delayed > 2 sec is rejected
 }) as <T>(fn: () => Promise<T>) => Promise<T>;
-
-// Helper function to transform empty strings to null
-function transformEmptyStringsToNull(
-	obj: Record<string, unknown>
-): Record<string, unknown> {
-	return Object.fromEntries(
-		Object.entries(obj).map(([key, value]) => {
-			// Handle string values
-			if (typeof value === 'string') {
-				const trimmed = value.trim();
-				return [key, trimmed === '' ? null : trimmed];
-			}
-			// Return non-string values as-is
-			return [key, value];
-		})
-	);
-}
-
-// Helper function to convert DD/MM/YYYY to YYYY-MM-DD
-function convertDateFormat(dateString: string): string {
-	return dateString.split('/').reverse().join('-');
-}
-
-function createUpserter(supabaseClient: SupabaseClient) {
-	return async <DataInsertModel>(
-		tableName: string,
-		upsertData: DataInsertModel,
-		uniqueColumn: keyof DataInsertModel
-	): Promise<number> => {
-		const { data: upsertResult, error: upsertError } = await supabaseClient
-			.from(tableName)
-			.upsert(upsertData, {
-				onConflict: uniqueColumn as string,
-				ignoreDuplicates: false
-			})
-			.select('id')
-			.single();
-
-		if (upsertError) throw upsertError;
-		return upsertResult.id;
-	};
-}
 
 async function importCSV(options: ImportOptions): Promise<void> {
 	const { csvFilePath, ringingGroupName } = options;
@@ -253,7 +81,7 @@ async function importCSV(options: ImportOptions): Promise<void> {
 				const rowIndex = totalRecords;
 				totalRecords++;
 				const promise = limit(() =>
-					createEncounterWithRelatedData(row)
+					processEncounterRow(row, upsert, ringingGroupId)
 						.then(
 							() => successfulRecords++,
 							(err) => {
@@ -279,88 +107,6 @@ async function importCSV(options: ImportOptions): Promise<void> {
 				console.error('Error reading CSV file:', error);
 				reject(error);
 			});
-
-		async function createEncounterWithRelatedData(row: DemonRow) {
-			row = transformEmptyStringsToNull(row) as DemonRow;
-			if (!row.ring_no) {
-				throw new Error('Casualty encounters are not to be imported');
-			}
-
-			try {
-				// 1. Upsert Species (create if doesn't exist) and get ID
-				const speciesId = await upsert<SpeciesInsert>(
-					'Species',
-					{
-						species_name: row.species_name as string
-					},
-					'species_name'
-				);
-
-				// 2. Upsert Bird (create if doesn't exist) and get ID
-				const birdId = await upsert<BirdsInsert>(
-					'Birds',
-					{
-						ring_no: row.ring_no as string,
-						species_id: speciesId
-					},
-					'ring_no'
-				);
-
-				// 2.5 Upsert Location (create if doesn't exist) and get ID
-				const locationId = await upsert<LocationsInsert>(
-					'Locations',
-					{
-						location_name: row.loc_id as string,
-						ringing_group_id: ringingGroupId as number
-					},
-					'location_name'
-				);
-
-				// 3. Upsert Session (create if doesn't exist) and get ID
-				const visitDate = convertDateFormat(row.visit_date as string);
-
-				const sessionId = await upsert<SessionsInsert>(
-					'Sessions',
-					{
-						visit_date: visitDate,
-						location_id: locationId
-					},
-					'visit_date,location_id' as keyof SessionsInsert
-				);
-
-				// 4. Insert Encounter (always create new)
-				const age_code: number = Number(String(row.age).replace('J', ''));
-
-				const encounterResult = (await upsert<EncountersInsert>(
-					'Encounters',
-					{
-						age_code,
-						breeding_condition: row.breeding_condition as string | null,
-						capture_time: row.capture_time as string,
-						extra_text: row.extra_text as string | null,
-						is_juv: String(row.age).endsWith('J') as boolean,
-						moult_code: row.moult_code as string | null,
-						old_greater_coverts: row.old_greater_coverts
-							? Number(row.old_greater_coverts)
-							: null,
-						record_type: row.record_type as string,
-						bird_id: birdId,
-						session_id: sessionId,
-						scheme: row.scheme as string,
-						sex: row.sex as string,
-						sexing_method: row.sexing_method as string | null,
-						weight: row.weight ? Number(row.weight) : null,
-						wing_length: row.wing_length ? Number(row.wing_length) : null
-					},
-					'bird_id,session_id' as keyof EncountersInsert
-				)) as unknown as EncounterRow;
-
-				return encounterResult;
-			} catch (error) {
-				console.error('Error creating encounter with related data:', error);
-				throw error;
-			}
-		}
 	});
 }
 


### PR DESCRIPTION
## Summary

- Moves `createUpserter`, `processEncounterRow`, `transformEmptyStringsToNull`, `convertDateFormat`, `DemonColumnNames`/`DemonRow` types, and `CasualtyEncounterError` from the CLI script into `lib/demon-import.ts` so they can be shared with the upcoming web import route
- Updates `scripts/import-csv.ts` to import from the new shared module
- Moves `csv-parser` from `devDependencies` to `dependencies` (needed at runtime by the web route)
- Adds 16 unit tests in `lib/__tests__/demon-import.test.ts` covering upsert call shapes, field transforms (empty→null, date format, numeric casting), and age/juv parsing

## Test plan

- [ ] `npm run qa` passes
- [ ] `npm run db:import:local` still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)