### PR TITLE
Add CSV import page and nav link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,12 @@ npm run db:import:prod ./path/to/data.csv "Group Name"
 
 The import script (`scripts/import-csv.ts`) upserts Species, RingingGroups, Birds, Locations, Sessions, and Encounters in dependency order, rate-limited to 30 req/s.
 
+Core import logic (types, transforms, `createUpserter`, `processEncounterRow`) lives in `lib/demon-import.ts` and is shared by both the CLI script and the web import route.
+
+### Web import
+
+Logged-in groups can also upload CSVs via the UI at `/import`. The page POSTs to `POST /api/import` (`app/api/import/route.ts`), which streams NDJSON progress back to the browser. Processing is sequential (no rate limiter) and aborts with a date-range summary after 280 seconds. Vercel `maxDuration` is set to 300s.
+
 ## Setting group passwords
 
 After creating a group, set its login password with:

--- a/app/(routes)/import/page.tsx
+++ b/app/(routes)/import/page.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useState, useRef, useCallback } from 'react';
+import {
+	PageWrapper,
+	PrimaryHeading
+} from '@/app/components/shared/DesignSystem';
+import type { ImportMessage } from '@/app/api/import/route';
+
+type ImportState =
+	| { status: 'idle' }
+	| { status: 'processing'; processed: number }
+	| {
+			status: 'complete';
+			processed: number;
+			successful: number;
+			failed: number;
+	  }
+	| {
+			status: 'timeout';
+			processed: number;
+			startDate: string | null;
+			endDate: string | null;
+	  }
+	| { status: 'error'; message: string };
+
+export default function ImportPage() {
+	const [state, setState] = useState<ImportState>({ status: 'idle' });
+	const [fileName, setFileName] = useState<string>('');
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const handleFileChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			setFileName(e.target.files?.[0]?.name ?? '');
+		},
+		[]
+	);
+
+	async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+		e.preventDefault();
+		const file = fileInputRef.current?.files?.[0];
+		if (!file) return;
+
+		setState({ status: 'processing', processed: 0 });
+
+		const formData = new FormData();
+		formData.append('csv', file);
+
+		const response = await fetch('/api/import', {
+			method: 'POST',
+			body: formData
+		});
+
+		if (!response.ok || !response.body) {
+			setState({ status: 'error', message: 'Upload failed' });
+			return;
+		}
+
+		const reader = response.body.getReader();
+		const decoder = new TextDecoder();
+		let buffer = '';
+
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			buffer += decoder.decode(value, { stream: true });
+			const lines = buffer.split('\n');
+			buffer = lines.pop()!;
+			for (const line of lines) {
+				if (!line.trim()) continue;
+				const message = JSON.parse(line) as ImportMessage;
+				switch (message.type) {
+					case 'progress':
+						setState({ status: 'processing', processed: message.processed });
+						break;
+					case 'complete':
+						setState({
+							status: 'complete',
+							processed: message.processed,
+							successful: message.successful,
+							failed: message.failed
+						});
+						break;
+					case 'timeout':
+						setState({
+							status: 'timeout',
+							processed: message.processed,
+							startDate: message.startDate,
+							endDate: message.endDate
+						});
+						break;
+					case 'error':
+						setState({ status: 'error', message: message.message });
+						break;
+				}
+			}
+		}
+	}
+
+	const isProcessing = state.status === 'processing';
+
+	return (
+		<PageWrapper>
+			<PrimaryHeading>Import data</PrimaryHeading>
+			<form onSubmit={handleSubmit} className="flex flex-col gap-4 max-w-md">
+				<label className="flex flex-col gap-1">
+					<span className="text-sm">Upload a csv file exported from Demon</span>
+					<div className="join w-full">
+						<input
+							type="text"
+							readOnly
+							value={fileName}
+							placeholder="No file chosen"
+							className="input input-bordered join-item flex-1 cursor-default"
+							disabled={isProcessing}
+						/>
+						<button
+							type="button"
+							className="btn btn-secondary join-item"
+							disabled={isProcessing}
+							onClick={() => fileInputRef.current?.click()}
+						>
+							Browse
+						</button>
+					</div>
+					<input
+						ref={fileInputRef}
+						type="file"
+						accept=".csv"
+						name="csv"
+						className="hidden"
+						onChange={handleFileChange}
+						disabled={isProcessing}
+					/>
+				</label>
+				<button
+					type="submit"
+					className="btn btn-primary"
+					disabled={isProcessing}
+				>
+					Import
+				</button>
+			</form>
+
+			{isProcessing && (
+				<div className="mt-4 flex items-center gap-2">
+					<span className="loading loading-spinner loading-sm" />
+					{state.processed > 0 && <span>{state.processed} rows processed</span>}
+				</div>
+			)}
+
+			{state.status === 'complete' && (
+				<p className="mt-4">
+					Import complete: {state.successful} rows imported successfully
+					{state.failed > 0 && `, ${state.failed} failed`}.
+				</p>
+			)}
+
+			{state.status === 'timeout' && (
+				<div className="mt-4 flex flex-col gap-2">
+					<p>
+						{state.processed} rows were processed before the request timed out.
+					</p>
+					{state.endDate && (
+						<p>
+							Data up to {state.endDate} was imported. Re-export from Demon with
+							records no older than this date and import again.
+						</p>
+					)}
+				</div>
+			)}
+
+			{state.status === 'error' && (
+				<p className="mt-4 text-error text-sm">{state.message}</p>
+			)}
+		</PageWrapper>
+	);
+}

--- a/app/components/layout/GlobalNav.tsx
+++ b/app/components/layout/GlobalNav.tsx
@@ -245,6 +245,12 @@ export default function GlobalNav({
 								onChange={() => expandersDispatch({ type: 'collapseAll' })}
 							/>
 						)}
+						<NoPrefetchLink
+							href="/import"
+							className="link link-secondary text-sm"
+						>
+							Import data
+						</NoPrefetchLink>
 						<form action={logout}>
 							<button type="submit" className="link link-secondary text-sm">
 								Log out


### PR DESCRIPTION
## Summary

- Adds `/import` page (`app/(routes)/import/page.tsx`): a client component with a styled file picker (hidden `<input type=file>` triggered by a Browse button, file name reflected in a read-only text input), submit button, and state machine covering idle → processing → complete / timeout / error
- Reads the NDJSON stream from `/api/import` and updates the UI progressively (spinner + row count while processing, date range advice on timeout)
- Adds "Import data" link to the user menu dropdown in `GlobalNav`
- Updates CLAUDE.md to document the web import route

Stacked on #237.

## Test plan

- [ ] `npm run qa` passes
- [ ] Log in, open user menu — "Import data" link is visible
- [ ] Navigate to `/import`, upload a Demon CSV, confirm spinner appears then success message
- [ ] Confirm timeout message includes date range when a large file exceeds 280s

🤖 Generated with [Claude Code](https://claude.com/claude-code)