### PR TITLE
Allow own-group pages to accept optional viewedGroupId

### DIFF
--- a/app/(routes)/effort/page.tsx
+++ b/app/(routes)/effort/page.tsx
@@ -18,9 +18,9 @@ import { PayOffEffortChart } from '@/app/components/PayOffEffortChart';
 
 export async function fetchPayOffPageData(
 	_params: DefaultPageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<PayOffStatsData | null> {
-	return fetchPayOffStats(groupId);
+	return fetchPayOffStats(viewedGroupId);
 }
 
 function formatAvgEncounters(n: number | null | undefined): string {
@@ -109,7 +109,7 @@ function PayOffPageContent({
 	data
 }: {
 	data: PayOffStatsData;
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	return (
 		<PageWrapper>
@@ -126,9 +126,14 @@ function PayOffPageContent({
 	);
 }
 
-export default function PayOffPage() {
+export default function PayOffPage({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
 	return (
 		<BootstrapPageData<PayOffStatsData>
+			viewedGroupId={viewedGroupId}
 			getCacheKeys={() => ['sessions', 'pay-off']}
 			dataFetcher={fetchPayOffPageData}
 			PageComponent={PayOffPageContent}

--- a/app/(routes)/mistakes/page.tsx
+++ b/app/(routes)/mistakes/page.tsx
@@ -13,11 +13,11 @@ import { MistakesTable } from '@/app/components/MistakesTable';
 
 export async function fetchMistakes(
 	_: DefaultPageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<DiscrepenciesResult[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
-		.rpc('find_discrepencies', { ringing_group_filter: groupId })
+		.rpc('find_discrepencies', { ringing_group_filter: viewedGroupId })
 		.then(catchSupabaseErrors) as Promise<DiscrepenciesResult[]>;
 }
 
@@ -29,9 +29,14 @@ function ListMistakes({ data }: { data: DiscrepenciesResult[] }) {
 		</PageWrapper>
 	);
 }
-export default async function MistakesPage() {
+export default async function MistakesPage({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
 	return (
 		<BootstrapPageData<DiscrepenciesResult[]>
+			viewedGroupId={viewedGroupId}
 			getCacheKeys={() => ['mistakes']}
 			dataFetcher={fetchMistakes}
 			PageComponent={ListMistakes}

--- a/app/(routes)/page.tsx
+++ b/app/(routes)/page.tsx
@@ -141,7 +141,7 @@ function getStatConfigs(
 }
 
 async function fetchRecentSessions(
-	groupId: number
+	viewedGroupId: number
 ): Promise<SessionWithEncountersCount[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
@@ -149,7 +149,7 @@ async function fetchRecentSessions(
 		.select(
 			'id, visit_date, location_id, ringing_group_id, location:Locations(location_name), encounters:Encounters(count)'
 		)
-		.eq('ringing_group_id', groupId)
+		.eq('ringing_group_id', viewedGroupId)
 		.order('visit_date', { ascending: false })
 		.limit(3)
 		.then(catchSupabaseErrors) as Promise<SessionWithEncountersCount[]>;
@@ -157,7 +157,7 @@ async function fetchRecentSessions(
 
 async function fetchInitialData(
 	_: DefaultPageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<PageModel> {
 	const statConfigs = getStatConfigs(new Date());
 	return {
@@ -169,7 +169,7 @@ async function fetchInitialData(
 							...panel.dataArguments,
 							filters: {
 								...(panel.dataArguments.filters ?? {}),
-								ringing_group_filter: groupId
+								ringing_group_filter: viewedGroupId
 							},
 							result_limit: 1
 						});
@@ -186,16 +186,16 @@ async function fetchInitialData(
 				};
 			})
 		),
-		recentSessions: await fetchRecentSessions(groupId)
+		recentSessions: await fetchRecentSessions(viewedGroupId)
 	};
 }
 
 function RecentSessions({
 	data,
-	groupId
+	viewedGroupId
 }: {
 	data: SessionWithEncountersCount[];
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	return (
 		<div>
@@ -203,7 +203,7 @@ function RecentSessions({
 			<BoxyList>
 				<SessionsByDay
 					sessions={data}
-					groupId={groupId}
+					viewedGroupId={viewedGroupId}
 					dateFormat="EEEE do MMMM"
 				/>
 			</BoxyList>
@@ -212,22 +212,30 @@ function RecentSessions({
 }
 function HomePageContent({
 	data,
-	groupId
+	viewedGroupId
 }: {
 	data: PageModel;
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	return (
 		<PageWrapper>
-			<RecentSessions data={data.recentSessions} groupId={groupId} />
-			<StatsAccordion data={data.stats} groupId={groupId} />
+			<RecentSessions
+				data={data.recentSessions}
+				viewedGroupId={viewedGroupId}
+			/>
+			<StatsAccordion data={data.stats} viewedGroupId={viewedGroupId} />
 		</PageWrapper>
 	);
 }
 
-export default async function Home() {
+export default async function Home({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
 	return (
 		<BootstrapPageData<PageModel>
+			viewedGroupId={viewedGroupId}
 			getCacheKeys={() => ['home-stats']}
 			dataFetcher={fetchInitialData}
 			PageComponent={HomePageContent}

--- a/app/(routes)/retraps/page.tsx
+++ b/app/(routes)/retraps/page.tsx
@@ -13,12 +13,12 @@ import { NotableRetrapsTable } from '@/app/components/NotableRetrapsTable';
 
 async function fetchNotableRetraps(
 	_: DefaultPageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<NotableRetrapsResult[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
 		.rpc('notable_retraps', {
-			ringing_group_filter: groupId,
+			ringing_group_filter: viewedGroupId,
 			result_limit_per_species: 5,
 			min_proven_age: 3,
 			min_encounter_count: 6
@@ -34,9 +34,14 @@ function ListNotableRetraps({ data }: { data: NotableRetrapsResult[] }) {
 		</PageWrapper>
 	);
 }
-export default async function NotableRetrapsPage() {
+export default async function NotableRetrapsPage({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
 	return (
 		<BootstrapPageData<NotableRetrapsResult[]>
+			viewedGroupId={viewedGroupId}
 			getCacheKeys={() => ['notable-retraps']}
 			dataFetcher={fetchNotableRetraps}
 			PageComponent={ListNotableRetraps}

--- a/app/(routes)/sessions/page.tsx
+++ b/app/(routes)/sessions/page.tsx
@@ -13,7 +13,7 @@ import {
 
 export async function fetchAllSessions(
 	params: DefaultPageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<SessionWithEncountersCount[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
@@ -21,29 +21,34 @@ export async function fetchAllSessions(
 		.select(
 			'id, visit_date, location: Locations(id, location_name), encounters:Encounters(count)'
 		)
-		.eq('ringing_group_id', groupId)
+		.eq('ringing_group_id', viewedGroupId)
 		.order('visit_date', { ascending: false })
 		.then(catchSupabaseErrors) as Promise<SessionWithEncountersCount[]>;
 }
 
 function ListAllSessions({
 	data,
-	groupId
+	viewedGroupId
 }: {
 	data: SessionWithEncountersCount[];
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	return (
 		<PageWrapper>
 			<PrimaryHeading>Session history</PrimaryHeading>
-			<SessionHistoryCalendar sessions={data} groupId={groupId} />
+			<SessionHistoryCalendar sessions={data} viewedGroupId={viewedGroupId} />
 		</PageWrapper>
 	);
 }
 
-export default async function SessionsPage() {
+export default async function SessionsPage({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
 	return (
 		<BootstrapPageData<SessionWithEncountersCount[]>
+			viewedGroupId={viewedGroupId}
 			getCacheKeys={() => ['sessions']}
 			dataFetcher={fetchAllSessions}
 			PageComponent={ListAllSessions}

--- a/app/(routes)/species/[speciesName]/page.tsx
+++ b/app/(routes)/species/[speciesName]/page.tsx
@@ -23,31 +23,31 @@ export type FullFatPageData = {
 };
 export type PageData = FullFatPageData | { speciesId: number };
 
-function getTopSessions(species: string, groupId: number) {
+function getTopSessions(species: string, viewedGroupId: number) {
 	return getTopPeriodsByMetric({
 		temporal_unit: 'day',
 		metric_name: 'encounters',
 		filters: {
 			species_filter: species,
-			ringing_group_filter: groupId
+			ringing_group_filter: viewedGroupId
 		} as TopMetricsFilterParams,
 		result_limit: 5
 	}) as Promise<TopPeriodsResult[]>;
 }
 
-async function getSpeciesStats(species: string, groupId: number) {
+async function getSpeciesStats(species: string, viewedGroupId: number) {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
 		.rpc('aggregate_stats', {
 			species_name_filter: species,
-			ringing_group_filter: groupId
+			ringing_group_filter: viewedGroupId
 		})
 		.then(catchSupabaseErrors) as Promise<AggregateStatsRow[]>;
 }
 
 async function fetchSpeciesData(
 	params: PageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<PageData | null> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	const { id: speciesId } = (await supabase
@@ -60,9 +60,9 @@ async function fetchSpeciesData(
 		throw new Error(`Species ${params.speciesName} not found`);
 	}
 	const [topSessions, birds, speciesStats] = await Promise.all([
-		getTopSessions(params.speciesName, groupId),
-		fetchPageOfBirds(speciesId, groupId),
-		getSpeciesStats(params.speciesName, groupId)
+		getTopSessions(params.speciesName, viewedGroupId),
+		fetchPageOfBirds(speciesId, viewedGroupId),
+		getSpeciesStats(params.speciesName, viewedGroupId)
 	]);
 	if (birds.length === 0) {
 		return {
@@ -78,10 +78,13 @@ async function fetchSpeciesData(
 	};
 }
 
-export default async function SpeciesPage(props: PageProps) {
+export default async function SpeciesPage(
+	props: PageProps & { viewedGroupId?: number }
+) {
 	return (
 		<BootstrapPageData<PageData, PageProps, PageParams>
 			pageProps={props}
+			viewedGroupId={props.viewedGroupId}
 			getCacheKeys={(params: PageParams) => ['species', params.speciesName]}
 			dataFetcher={fetchSpeciesData}
 			PageComponent={SingleSpeciesPage}

--- a/app/(routes)/species/page.tsx
+++ b/app/(routes)/species/page.tsx
@@ -15,12 +15,12 @@ export type PageData = {
 	years: number[];
 };
 
-async function fetchYears(groupId: number): Promise<number[]> {
+async function fetchYears(viewedGroupId: number): Promise<number[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	const dates = (await supabase
 		.from('Sessions')
 		.select('visit_date')
-		.eq('ringing_group_id', groupId)
+		.eq('ringing_group_id', viewedGroupId)
 		.order('visit_date', { ascending: false })
 		.then(catchSupabaseErrors)) as { visit_date: string }[];
 
@@ -31,11 +31,11 @@ async function fetchYears(groupId: number): Promise<number[]> {
 
 async function fetchInitialPageData(
 	_: DefaultPageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<PageData> {
 	const [speciesStats, years] = await Promise.all([
-		fetchSpeciesData(groupId),
-		fetchYears(groupId)
+		fetchSpeciesData(viewedGroupId),
+		fetchYears(viewedGroupId)
 	]);
 	return {
 		speciesStats,
@@ -43,9 +43,14 @@ async function fetchInitialPageData(
 	};
 }
 
-export default async function AllSpeciesPage() {
+export default async function AllSpeciesPage({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
 	return (
 		<BootstrapPageData<PageData>
+			viewedGroupId={viewedGroupId}
 			getCacheKeys={() => ['species']}
 			dataFetcher={fetchInitialPageData}
 			PageComponent={MultiSpeciesStatsTable}


### PR DESCRIPTION
## Summary

- Each own-group page default export now accepts an optional `viewedGroupId` prop
- When provided, this is forwarded to `BootstrapPageData`, which uses it instead of the cookie group for data fetching
- Affected pages: home, sessions, species, species/[name], effort, mistakes, retraps

This has no visible behaviour change for own-group users. It sets up the pages for reuse from cross-group route wrappers (next PR) without code duplication.

## Test plan
- [ ] `npm run qa` passes
- [ ] Own-group pages still work normally (viewedGroupId defaults to cookie group)

🤖 Generated with [Claude Code](https://claude.com/claude-code)