### PR TITLE
Migrate session URL and make bird detail global

### DIFF
--- a/app/(routes)/__tests__/session[date].test.tsx
+++ b/app/(routes)/__tests__/session[date].test.tsx
@@ -1,6 +1,6 @@
 import { expect, describe, it } from 'vitest';
 import { render, screen, getAllByRole } from '@testing-library/react';
-import Page from '../session/[...params]/page';
+import Page from '../../group/[id]/session/[date]/page';
 import { verifyTableData } from './helpers/verify-table-data';
 
 describe('session page', () => {
@@ -8,7 +8,7 @@ describe('session page', () => {
 		render(
 			await Page({
 				params: new Promise((resolve) =>
-					resolve({ params: ['group', '1', '2023-09-30'] })
+					resolve({ id: '1', date: '2023-09-30' })
 				)
 			})
 		);
@@ -23,7 +23,7 @@ describe('session page', () => {
 		render(
 			await Page({
 				params: new Promise((resolve) =>
-					resolve({ params: ['group', '1', '2023-09-30'] })
+					resolve({ id: '1', date: '2023-09-30' })
 				)
 			})
 		);
@@ -43,7 +43,7 @@ describe('session page', () => {
 		render(
 			await Page({
 				params: new Promise((resolve) =>
-					resolve({ params: ['group', '1', '2023-09-30'] })
+					resolve({ id: '1', date: '2023-09-30' })
 				)
 			})
 		);

--- a/app/(routes)/bird/[ring]/page.tsx
+++ b/app/(routes)/bird/[ring]/page.tsx
@@ -19,7 +19,7 @@ import { EncountersTimeline } from '@/app/components/EncountersTimeline';
 type PageParams = { ring: string };
 type PageProps = { params: Promise<PageParams> };
 
-async function fetchBirdData({ ring }: PageParams, groupId: number) {
+async function fetchBirdData({ ring }: PageParams, _viewedGroupId: number) {
 	const supabase = await getAuthenticatedSupabaseClient();
 	const bird = (await supabase
 		.from('Birds')
@@ -62,7 +62,6 @@ async function fetchBirdData({ ring }: PageParams, groupId: number) {
 	`
 		)
 		.eq('bird_id', bird.id)
-		.eq('ringing_group_id', groupId)
 		.then(catchSupabaseErrors)) as EncounterOfBird[];
 
 	return { ...bird, encounters } as StandaloneBird;
@@ -70,12 +69,19 @@ async function fetchBirdData({ ring }: PageParams, groupId: number) {
 
 function BirdSummary({
 	params: { ring },
-	data: bird
+	data: bird,
+	viewedGroupId: loggedInGroupId
 }: {
 	params: PageParams;
 	data: StandaloneBird;
+	viewedGroupId: number;
 }) {
 	const enrichedBird = bird.encounters.length ? enrichBird(bird) : null;
+	const sharedEncounterCount = enrichedBird
+		? enrichedBird.encounters.filter(
+				(e) => e.ringing_group_id !== loggedInGroupId
+			).length
+		: 0;
 	return (
 		<PageWrapper>
 			<PrimaryHeading>
@@ -91,13 +97,18 @@ function BirdSummary({
 				<>
 					<BadgeList
 						testId="bird-stats"
-						items={[
-							`${enrichedBird.encounters.length} encounters`,
-							`First: ${formatDate(enrichedBird.firstEncounterDate, 'dd MMMM yyyy')}`,
-							`Last: ${formatDate(enrichedBird.lastEncounterDate, 'dd MMMM yyyy')}`,
-							`Sex: ${enrichedBird.sex}${enrichedBird.sexCertainty < 0.5 ? `?` : ''}`,
-							`Proven Age: ${enrichedBird.proven_age}`
-						]}
+						items={
+							[
+								`${enrichedBird.encounters.length} encounters`,
+								sharedEncounterCount > 0
+									? `${sharedEncounterCount} from another group`
+									: null,
+								`First: ${formatDate(enrichedBird.firstEncounterDate, 'dd MMMM yyyy')}`,
+								`Last: ${formatDate(enrichedBird.lastEncounterDate, 'dd MMMM yyyy')}`,
+								`Sex: ${enrichedBird.sex}${enrichedBird.sexCertainty < 0.5 ? `?` : ''}`,
+								`Proven Age: ${enrichedBird.proven_age}`
+							].filter(Boolean) as string[]
+						}
 					/>
 					<div className="m-2">
 						<EncountersTimeline encounters={enrichedBird.encounters} />

--- a/app/(routes)/bird/page.tsx
+++ b/app/(routes)/bird/page.tsx
@@ -19,7 +19,7 @@ type SearchResult = {
 type SearchParams = { q: string };
 type PageProps = { searchParams: Promise<SearchParams> };
 
-async function searchByRing({ q }: SearchParams) {
+async function searchByRing({ q }: SearchParams, _viewedGroupId: number) {
 	const supabase = await getAuthenticatedSupabaseClient();
 	const uppercaseQuery = q.toUpperCase();
 	const exactMatch = await supabase

--- a/app/components/SessionHistoryCalendar.tsx
+++ b/app/components/SessionHistoryCalendar.tsx
@@ -43,12 +43,12 @@ const groupByMonth = groupByDateMethod('getMonth');
 export function SessionsByDay({
 	sessions,
 	wrapperClasses = '',
-	groupId,
+	viewedGroupId,
 	dateFormat
 }: {
 	sessions: SessionWithEncountersCount[];
 	wrapperClasses?: string;
-	groupId: number;
+	viewedGroupId: number;
 	dateFormat: string;
 }) {
 	const sessionsByDate: Record<string, SessionWithEncountersCount[]> = {};
@@ -71,7 +71,7 @@ export function SessionsByDay({
 							showUnit={true}
 							temporalUnit="day"
 							dateFormat={dateFormat}
-							groupId={groupId}
+							viewedGroupId={viewedGroupId}
 						/>
 					) : (
 						<>
@@ -86,7 +86,7 @@ export function SessionsByDay({
 								showUnit={true}
 								temporalUnit="day"
 								dateFormat={dateFormat}
-								groupId={groupId}
+								viewedGroupId={viewedGroupId}
 							/>{' '}
 							at{' '}
 							{daySessions.map((session, index) => (
@@ -94,7 +94,7 @@ export function SessionsByDay({
 									{index > 0 ? ', ' : null}
 									<NoPrefetchLink
 										className="link"
-										href={`/session/group/${groupId}/${session.visit_date}/site/${session.location.id}`}
+										href={`/group/${viewedGroupId}/session/${session.visit_date}/site/${session.location.id}`}
 									>
 										{printLocationName(session.location.location_name)}
 									</NoPrefetchLink>
@@ -109,16 +109,16 @@ export function SessionsByDay({
 }
 
 function SessionsOfMonth({
-	model: { groupId, monthData: month }
+	model: { viewedGroupId, monthData: month }
 }: {
-	model: { groupId: number; monthData: SessionWithEncountersCount[] };
+	model: { viewedGroupId: number; monthData: SessionWithEncountersCount[] };
 }) {
 	return (
 		<ol className="list-inside list-none py-3">
 			<SessionsByDay
 				sessions={month}
 				wrapperClasses="mb-2"
-				groupId={groupId}
+				viewedGroupId={viewedGroupId}
 				dateFormat="EEEE do"
 			/>
 		</ol>
@@ -153,13 +153,13 @@ function YearHeading({
 }
 
 function MonthsOfYear({
-	model: { yearData, setExpandedMonth, expandedMonth, groupId }
+	model: { yearData, setExpandedMonth, expandedMonth, viewedGroupId }
 }: {
 	model: {
 		yearData: SessionWithEncountersCount[][];
 		setExpandedMonth: (month: string | false) => void;
 		expandedMonth: string | false;
-		groupId: number;
+		viewedGroupId: number;
 	};
 }) {
 	return (
@@ -173,7 +173,7 @@ function MonthsOfYear({
 							id={id}
 							HeadingComponent={MonthHeading}
 							ContentComponent={SessionsOfMonth}
-							model={{ monthData: month, groupId }}
+							model={{ monthData: month, viewedGroupId }}
 							onToggle={setExpandedMonth}
 							expandedId={expandedMonth}
 							icon="calendar-week"
@@ -191,10 +191,10 @@ function getYearString(year: SessionWithEncountersCount[][]) {
 
 export function SessionHistoryCalendar({
 	sessions,
-	groupId
+	viewedGroupId
 }: {
 	sessions: SessionWithEncountersCount[] | null;
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	const calendar = groupByYear(sessions || []).map(groupByMonth);
 	const [expandedMonth, setExpandedMonth] = useState<string | false>(false);
@@ -220,7 +220,7 @@ export function SessionHistoryCalendar({
 							yearData: year,
 							setExpandedMonth,
 							expandedMonth,
-							groupId
+							viewedGroupId
 						}}
 						onToggle={() => {
 							setExpandedYear(yearString);

--- a/app/components/shared/StatOutput.tsx
+++ b/app/components/shared/StatOutput.tsx
@@ -13,7 +13,7 @@ export type StatOutputModel = {
 	dateFormat?: string;
 	classes?: string;
 	location?: LocationRow;
-	groupId?: number;
+	viewedGroupId?: number;
 	link?: boolean;
 };
 
@@ -39,12 +39,12 @@ export function StatOutput({
 	temporalUnit,
 	classes,
 	location,
-	groupId,
+	viewedGroupId,
 	link = true
 }: StatOutputModel) {
-	if (temporalUnit === 'day' && !groupId) {
+	if (temporalUnit === 'day' && !viewedGroupId) {
 		throw new Error(
-			'groupId is required to output stats for day temporal unit'
+			'viewedGroupId is required to output stats for day temporal unit'
 		);
 	}
 	return (
@@ -56,7 +56,7 @@ export function StatOutput({
 			{temporalUnit === 'day' && link ? (
 				<NoPrefetchLink
 					className="link"
-					href={`/session/group/${groupId}/${visitDate}${location ? `/site/${location.id}` : ''}`}
+					href={`/group/${viewedGroupId}/session/${visitDate}${location ? `/site/${location.id}` : ''}`}
 				>
 					{formatDate(
 						new Date(visitDate as string),


### PR DESCRIPTION
## Summary

- Session detail URL migrated from `/session/group/[id]/[date]` to `/group/[id]/session/[date]` and `/group/[id]/session/[date]/site/[locationId]` (no redirect — old URLs simply 404)
- Internal links in `SessionHistoryCalendar` and `StatOutput` updated to the new URL scheme
- Session test updated to use the new URL params shape
- Bird detail (`/bird/[ring]`) now shows encounters from all RLS-accessible groups, not just the logged-in group's encounters
- A badge is added to the bird detail page showing how many encounters are from another group (when > 0)
- The old catch-all session route (`app/(routes)/session/[...params]/`) is deleted

## Test plan
- [ ] `npm run qa` passes
- [ ] Session links from the calendar navigate correctly
- [ ] Bird detail shows all encounters; badge appears when encounters from another group exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)