### PR TITLE
Add cross-group route tree under /group/[id]/

### DIFF
--- a/app/group/[id]/effort/page.tsx
+++ b/app/group/[id]/effort/page.tsx
@@ -1,0 +1,10 @@
+import PayOffPage from '@/app/(routes)/effort/page';
+
+export default async function CrossGroupEffortPage({
+	params
+}: {
+	params: Promise<{ id: string }>;
+}) {
+	const { id } = await params;
+	return <PayOffPage viewedGroupId={Number(id)} />;
+}

--- a/app/group/[id]/layout.tsx
+++ b/app/group/[id]/layout.tsx
@@ -1,0 +1,37 @@
+import { notFound, redirect } from 'next/navigation';
+import { getGroupCookie } from '@/app/actions/group-cookie';
+import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
+
+export default async function CrossGroupLayout({
+	children,
+	params
+}: {
+	children: React.ReactNode;
+	params: Promise<{ id: string }>;
+}) {
+	const { id } = await params;
+	const viewedGroupId = Number(id);
+	const loggedInGroupId = await getGroupCookie();
+
+	if (!loggedInGroupId) {
+		redirect('/');
+	}
+
+	if (viewedGroupId === loggedInGroupId) {
+		redirect('/');
+	}
+
+	const supabase = await getAuthenticatedSupabaseClient();
+	const { data } = await supabase
+		.from('GroupDataSharing')
+		.select('id')
+		.eq('from_group_id', viewedGroupId)
+		.eq('to_group_id', loggedInGroupId)
+		.maybeSingle();
+
+	if (!data) {
+		notFound();
+	}
+
+	return children;
+}

--- a/app/group/[id]/mistakes/page.tsx
+++ b/app/group/[id]/mistakes/page.tsx
@@ -1,0 +1,10 @@
+import MistakesPage from '@/app/(routes)/mistakes/page';
+
+export default async function CrossGroupMistakesPage({
+	params
+}: {
+	params: Promise<{ id: string }>;
+}) {
+	const { id } = await params;
+	return <MistakesPage viewedGroupId={Number(id)} />;
+}

--- a/app/group/[id]/page.tsx
+++ b/app/group/[id]/page.tsx
@@ -1,0 +1,10 @@
+import Home from '@/app/(routes)/page';
+
+export default async function CrossGroupHome({
+	params
+}: {
+	params: Promise<{ id: string }>;
+}) {
+	const { id } = await params;
+	return <Home viewedGroupId={Number(id)} />;
+}

--- a/app/group/[id]/retraps/page.tsx
+++ b/app/group/[id]/retraps/page.tsx
@@ -1,0 +1,10 @@
+import NotableRetrapsPage from '@/app/(routes)/retraps/page';
+
+export default async function CrossGroupRetrapsPage({
+	params
+}: {
+	params: Promise<{ id: string }>;
+}) {
+	const { id } = await params;
+	return <NotableRetrapsPage viewedGroupId={Number(id)} />;
+}

--- a/app/group/[id]/session/[date]/page.tsx
+++ b/app/group/[id]/session/[date]/page.tsx
@@ -1,0 +1,24 @@
+import { BootstrapPageData } from '@/app/components/layout/BootstrapPageData';
+import {
+	fetchSessionData,
+	SessionSummary,
+	type DayData,
+	type PageParams
+} from '../_shared';
+
+type PageProps = { params: Promise<{ id: string; date: string }> };
+
+export default async function CrossGroupSessionPage({ params }: PageProps) {
+	const { id, date } = await params;
+	const viewedGroupId = Number(id);
+	return (
+		<BootstrapPageData<DayData, PageProps, PageParams>
+			viewedGroupId={viewedGroupId}
+			getParams={async () => ({ viewedGroupId, date, locationId: undefined })}
+			getCacheKeys={() => ['session', date]}
+			dataFetcher={fetchSessionData}
+			PageComponent={SessionSummary}
+			ttl={3600 * 24 * 7}
+		/>
+	);
+}

--- a/app/group/[id]/session/[date]/site/[locationId]/page.tsx
+++ b/app/group/[id]/session/[date]/site/[locationId]/page.tsx
@@ -1,0 +1,30 @@
+import { BootstrapPageData } from '@/app/components/layout/BootstrapPageData';
+import {
+	fetchSessionData,
+	SessionSummary,
+	type DayData,
+	type PageParams
+} from '../../../_shared';
+
+type PageProps = {
+	params: Promise<{ id: string; date: string; locationId: string }>;
+};
+
+export default async function CrossGroupSessionSitePage({ params }: PageProps) {
+	const { id, date, locationId } = await params;
+	const viewedGroupId = Number(id);
+	return (
+		<BootstrapPageData<DayData, PageProps, PageParams>
+			viewedGroupId={viewedGroupId}
+			getParams={async () => ({
+				viewedGroupId,
+				date,
+				locationId: Number(locationId)
+			})}
+			getCacheKeys={() => ['session', date, `loc-${locationId}`]}
+			dataFetcher={fetchSessionData}
+			PageComponent={SessionSummary}
+			ttl={3600 * 24 * 7}
+		/>
+	);
+}

--- a/app/group/[id]/session/_shared.tsx
+++ b/app/group/[id]/session/_shared.tsx
@@ -1,0 +1,206 @@
+import {
+	SessionTable,
+	type SpeciesWithEncounters
+} from '@/app/components/SingleSessionTable';
+import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
+import { catchSupabaseErrors } from '@/lib/supabase';
+import type { SessionEncounter } from '@/app/models/session';
+import type { LocationRow, SessionRow } from '@/app/models/db';
+import {
+	BadgeList,
+	PageWrapper,
+	PrimaryHeading,
+	printLocationName
+} from '@/app/components/shared/DesignSystem';
+import Link from 'next/link';
+import { format as formatDate } from 'date-fns';
+import { Fragment } from 'react';
+
+export type PageParams = {
+	viewedGroupId: number;
+	date: string;
+	locationId: number | undefined;
+};
+
+export type DayData = {
+	encounters: SessionEncounter[];
+	locations: LocationRow[];
+};
+
+export async function fetchSessionData({
+	viewedGroupId,
+	date,
+	locationId
+}: PageParams): Promise<DayData | null> {
+	const supabase = await getAuthenticatedSupabaseClient();
+	let sessions = (await supabase
+		.from('Sessions')
+		.select(
+			'id, location_id, location:Locations (id, location_name, ringing_group_id)'
+		)
+		.eq('visit_date', date)
+		.eq('ringing_group_id', viewedGroupId)
+		.then(catchSupabaseErrors)) as (SessionRow & { location: LocationRow })[];
+
+	if (!sessions || sessions.length === 0) {
+		return { encounters: [], locations: [] };
+	}
+	const locations = sessions.map((item) => item.location);
+	if (locationId) {
+		sessions = sessions.filter((item) => item.location_id === locationId);
+		if (sessions.length === 0) {
+			return { encounters: [], locations: [] };
+		}
+	}
+
+	const encounters = (await supabase
+		.from('Encounters')
+		.select(
+			`
+			id,
+			session_id,
+			age_code,
+			capture_time,
+			record_type,
+			ringing_group_id,
+			sex,
+			weight,
+			wing_length,
+			bird:Birds (
+				ring_no,
+				species:Species (
+					id,
+					species_name
+				)
+		)
+	`
+		)
+		.in(
+			'session_id',
+			sessions.map((session) => session.id)
+		)
+		.eq('ringing_group_id', viewedGroupId)
+		.then(catchSupabaseErrors)) as SessionEncounter[];
+
+	return {
+		encounters,
+		locations
+	};
+}
+
+function groupBySpecies(
+	encounters: SessionEncounter[]
+): SpeciesWithEncounters[] {
+	const map: Record<string, SessionEncounter[]> = {};
+	encounters.forEach((encounter) => {
+		const species = encounter.bird.species.species_name;
+		map[species] = map[species] || [];
+		map[species].push(encounter);
+	});
+	return Object.entries(map)
+		.map(([species, encounters]) => ({ species, encounters }))
+		.sort((a, b) => {
+			if (a.encounters.length === b.encounters.length) {
+				return a.species.localeCompare(b.species);
+			}
+			return a.encounters.length < b.encounters.length ? 1 : -1;
+		});
+}
+
+function Locations({
+	locations,
+	date,
+	selectedLocation,
+	viewedGroupId
+}: {
+	locations: LocationRow[];
+	date: string;
+	selectedLocation: number | undefined;
+	viewedGroupId: number;
+}) {
+	return (
+		<small className="text-sm text-gray-500 flex flex-wrap gap-2 mt-2">
+			{locations.length === 1
+				? printLocationName(locations[0].location_name)
+				: locations.map((location) => (
+						<Fragment key={location.id}>
+							{selectedLocation && selectedLocation === location.id ? (
+								<span className="badge badge-secondary">
+									{printLocationName(location.location_name)}
+								</span>
+							) : (
+								<Link
+									className="link badge badge-outline"
+									href={`/group/${viewedGroupId}/session/${date}/site/${location.id}`}
+								>
+									{printLocationName(location.location_name)}
+								</Link>
+							)}
+						</Fragment>
+					))}
+			{selectedLocation && locations.length > 1 ? (
+				<>
+					<Link
+						className="link badge badge-outline"
+						href={`/group/${viewedGroupId}/session/${date}`}
+					>
+						View all
+					</Link>
+				</>
+			) : null}
+		</small>
+	);
+}
+
+export function SessionSummary({
+	data: dayData,
+	params: { date, locationId, viewedGroupId }
+}: {
+	data: DayData;
+	params: {
+		date: string;
+		locationId: number | undefined;
+		viewedGroupId: number;
+	};
+}) {
+	const speciesList = groupBySpecies(dayData.encounters);
+
+	if (dayData.locations.length === 0) {
+		return (
+			<PageWrapper>
+				<p>
+					No session found: either no session occurred on this date{' '}
+					{locationId ? 'at this location ' : ''}, or you are not authorised to
+					view it
+				</p>
+			</PageWrapper>
+		);
+	}
+	return (
+		<PageWrapper>
+			<PrimaryHeading>
+				{formatDate(new Date(date), 'EEE do MMMM yyyy')}
+				<br />
+				<Locations
+					locations={dayData.locations}
+					date={date}
+					selectedLocation={locationId}
+					viewedGroupId={viewedGroupId}
+				/>
+			</PrimaryHeading>
+			<BadgeList
+				testId="session-stats"
+				items={[
+					`${dayData.encounters.length} birds`,
+					`${speciesList.length} species`,
+					`${dayData.encounters.filter((encounter) => encounter.record_type === 'N').length} new`,
+					`${dayData.encounters.filter((encounter) => encounter.record_type === 'S').length} retraps`,
+					`${dayData.encounters.filter((encounter) => encounter.age_code > 3).length} adults`,
+					`${dayData.encounters.filter((encounter) => [1, 3].includes(encounter.age_code)).length} juvs`,
+					`${dayData.encounters.filter((encounter) => encounter.age_code === 2).length} unknown age`
+				]}
+			/>
+			<SessionTable speciesList={speciesList} />
+		</PageWrapper>
+	);
+}

--- a/app/group/[id]/sessions/page.tsx
+++ b/app/group/[id]/sessions/page.tsx
@@ -1,0 +1,10 @@
+import SessionsPage from '@/app/(routes)/sessions/page';
+
+export default async function CrossGroupSessionsPage({
+	params
+}: {
+	params: Promise<{ id: string }>;
+}) {
+	const { id } = await params;
+	return <SessionsPage viewedGroupId={Number(id)} />;
+}

--- a/app/group/[id]/species/[speciesName]/page.tsx
+++ b/app/group/[id]/species/[speciesName]/page.tsx
@@ -1,0 +1,13 @@
+import SpeciesPage from '@/app/(routes)/species/[speciesName]/page';
+
+export default async function CrossGroupSingleSpeciesPage(props: {
+	params: Promise<{ id: string; speciesName: string }>;
+}) {
+	const { id, speciesName } = await props.params;
+	return (
+		<SpeciesPage
+			params={Promise.resolve({ speciesName })}
+			viewedGroupId={Number(id)}
+		/>
+	);
+}

--- a/app/group/[id]/species/page.tsx
+++ b/app/group/[id]/species/page.tsx
@@ -1,0 +1,10 @@
+import AllSpeciesPage from '@/app/(routes)/species/page';
+
+export default async function CrossGroupSpeciesPage({
+	params
+}: {
+	params: Promise<{ id: string }>;
+}) {
+	const { id } = await params;
+	return <AllSpeciesPage viewedGroupId={Number(id)} />;
+}


### PR DESCRIPTION
## Summary

- Adds `app/group/[id]/layout.tsx` which enforces authorization: checks a `GroupDataSharing` row exists granting the logged-in group access to the viewed group, otherwise 404. Also redirects to `/` if the user navigates to their own group's `/group/[id]/`
- Adds thin wrapper pages for all cross-group routes:
  - `/group/[id]/` (home)
  - `/group/[id]/sessions`, `/species`, `/species/[name]`, `/effort`, `/mistakes`, `/retraps`
  - `/group/[id]/session/[date]` and `/group/[id]/session/[date]/site/[locationId]`
- Session pages share data-fetching and component logic via `app/group/[id]/session/_shared.tsx`
- Each wrapper simply extracts `viewedGroupId` from URL params and delegates to the corresponding own-group page (from PR 2)

## Test plan
- [ ] `npm run qa` passes
- [ ] Manually insert a `GroupDataSharing` row and verify `/group/[id]/` loads the correct group's data
- [ ] Verify `/group/[ownId]/` redirects to `/`
- [ ] Verify an unauthorized `/group/[id]/` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)