### PR TITLE
Add GroupDataSharing table and extend RLS for cross-group reads

### DIFF
--- a/supabase/schema/schemas/public/tables/"Birds".sql
+++ b/supabase/schema/schemas/public/tables/"Birds".sql
@@ -16,21 +16,26 @@ SELECT
 	USING (
 		(
 			(
-				(
-					(
-						(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
-					)
-				)::bigint = ANY (ringing_group_ids)
-			)
+				(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
+			)::bigint = ANY (ringing_group_ids)
 			OR (
 				(ringing_group_ids = '{}'::BIGINT[])
 				AND (
 					(
-						(
-							(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
-						)
+						(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
 					)::bigint IS NOT NULL
 				)
+			)
+			OR EXISTS (
+				SELECT
+					1
+				FROM
+					public."GroupDataSharing" gds
+					JOIN unnest(ringing_group_ids) gid ON gid = gds.from_group_id
+				WHERE
+					gds.to_group_id = (
+						(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
+					)::bigint
 			)
 		)
 	);

--- a/supabase/schema/schemas/public/tables/"Encounters".sql
+++ b/supabase/schema/schemas/public/tables/"Encounters".sql
@@ -54,12 +54,19 @@ EXECUTE FUNCTION public.trg_update_bird_ringing_group_id ();
 CREATE POLICY group_encounters_access ON public."Encounters" FOR
 SELECT
 	USING (
-		(
-			ringing_group_id = (
-				(
+		ringing_group_id = (
+			(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
+		)::bigint
+		OR EXISTS (
+			SELECT
+				1
+			FROM
+				public."GroupDataSharing"
+			WHERE
+				from_group_id = ringing_group_id
+				AND to_group_id = (
 					(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
-				)
-			)::bigint
+				)::bigint
 		)
 	);
 

--- a/supabase/schema/schemas/public/tables/"GroupDataSharing".sql
+++ b/supabase/schema/schemas/public/tables/"GroupDataSharing".sql
@@ -1,0 +1,39 @@
+CREATE SEQUENCE public."GroupDataSharing_id_seq";
+
+CREATE TABLE public."GroupDataSharing" (
+	id bigint DEFAULT nextval('public."GroupDataSharing_id_seq"'::regclass) NOT NULL,
+	from_group_id bigint NOT NULL,
+	to_group_id bigint NOT NULL,
+	created_at timestamptz NOT NULL DEFAULT NOW(),
+	CONSTRAINT no_self_share CHECK (from_group_id <> to_group_id),
+	CONSTRAINT unique_share UNIQUE (from_group_id, to_group_id)
+);
+
+COMMENT ON TABLE public."GroupDataSharing" IS 'from_group_id shares their data with to_group_id';
+
+CREATE POLICY group_data_sharing_select ON public."GroupDataSharing" FOR
+SELECT
+	USING (
+		to_group_id = (
+			(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
+		)::bigint
+	);
+
+ALTER SEQUENCE public."GroupDataSharing_id_seq" OWNED BY public."GroupDataSharing".id;
+
+ALTER TABLE public."GroupDataSharing" ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public."GroupDataSharing"
+ADD CONSTRAINT "GroupDataSharing_pkey" PRIMARY KEY (id);
+
+ALTER TABLE public."GroupDataSharing"
+ADD CONSTRAINT group_data_sharing_from_group_id_fkey FOREIGN KEY (from_group_id) REFERENCES public."RingingGroups" (id) ON DELETE CASCADE;
+
+ALTER TABLE public."GroupDataSharing"
+ADD CONSTRAINT group_data_sharing_to_group_id_fkey FOREIGN KEY (to_group_id) REFERENCES public."RingingGroups" (id) ON DELETE CASCADE;
+
+GRANT ALL ON public."GroupDataSharing" TO anon;
+
+GRANT ALL ON public."GroupDataSharing" TO authenticated;
+
+GRANT ALL ON public."GroupDataSharing" TO service_role;

--- a/supabase/schema/schemas/public/tables/"Locations".sql
+++ b/supabase/schema/schemas/public/tables/"Locations".sql
@@ -9,12 +9,19 @@ CREATE INDEX idx_locations_ringing_group_id ON public."Locations" (ringing_group
 CREATE POLICY group_locations_access ON public."Locations" FOR
 SELECT
 	USING (
-		(
-			ringing_group_id = (
-				(
+		ringing_group_id = (
+			(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
+		)::bigint
+		OR EXISTS (
+			SELECT
+				1
+			FROM
+				public."GroupDataSharing"
+			WHERE
+				from_group_id = ringing_group_id
+				AND to_group_id = (
 					(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
-				)
-			)::bigint
+				)::bigint
 		)
 	);
 

--- a/supabase/schema/schemas/public/tables/"Sessions".sql
+++ b/supabase/schema/schemas/public/tables/"Sessions".sql
@@ -17,12 +17,19 @@ EXECUTE FUNCTION public.trg_set_session_generated_fields ();
 CREATE POLICY group_sessions_access ON public."Sessions" FOR
 SELECT
 	USING (
-		(
-			ringing_group_id = (
-				(
+		ringing_group_id = (
+			(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
+		)::bigint
+		OR EXISTS (
+			SELECT
+				1
+			FROM
+				public."GroupDataSharing"
+			WHERE
+				from_group_id = ringing_group_id
+				AND to_group_id = (
 					(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
-				)
-			)::bigint
+				)::bigint
 		)
 	);
 


### PR DESCRIPTION
## Summary

- Creates `GroupDataSharing` table (`from_group_id` → `to_group_id`): non-commutative, non-transitive, no self-share, RLS so each group sees only rows where they are the recipient
- Extends SELECT policies on `Sessions`, `Encounters`, `Locations`, and `Birds` to allow reads where a `GroupDataSharing` row grants access from the viewed group to the logged-in group
- The JWT always carries the **logged-in** group's ID — no JWT switching. RLS handles the cross-group access transparently

**After merging:** run `npm run db:schema:apply` then `npm run db:types` to apply the migration and regenerate TypeScript types.

## Test plan
- [ ] Apply schema locally: `npm run db:schema:apply`
- [ ] Regenerate types: `npm run db:types`
- [ ] `npm run qa` passes after type regeneration
- [ ] Insert a `GroupDataSharing` row and verify the recipient group can query the other group's Sessions/Encounters/Birds via the authenticated client
- [ ] Verify the donor group cannot query the recipient's data (non-commutative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)