### PR TITLE
Allow own-group pages to accept optional viewedGroupId

### DIFF
--- a/app/(routes)/effort/page.tsx
+++ b/app/(routes)/effort/page.tsx
@@ -18,9 +18,9 @@ import { PayOffEffortChart } from '@/app/components/PayOffEffortChart';
 
 export async function fetchPayOffPageData(
 	_params: DefaultPageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<PayOffStatsData | null> {
-	return fetchPayOffStats(groupId);
+	return fetchPayOffStats(viewedGroupId);
 }
 
 function formatAvgEncounters(n: number | null | undefined): string {
@@ -109,7 +109,7 @@ function PayOffPageContent({
 	data
 }: {
 	data: PayOffStatsData;
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	return (
 		<PageWrapper>
@@ -126,9 +126,14 @@ function PayOffPageContent({
 	);
 }
 
-export default function PayOffPage() {
+export default function PayOffPage({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
 	return (
 		<BootstrapPageData<PayOffStatsData>
+			viewedGroupId={viewedGroupId}
 			getCacheKeys={() => ['sessions', 'pay-off']}
 			dataFetcher={fetchPayOffPageData}
 			PageComponent={PayOffPageContent}

--- a/app/(routes)/mistakes/page.tsx
+++ b/app/(routes)/mistakes/page.tsx
@@ -13,11 +13,11 @@ import { MistakesTable } from '@/app/components/MistakesTable';
 
 export async function fetchMistakes(
 	_: DefaultPageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<DiscrepenciesResult[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
-		.rpc('find_discrepencies', { ringing_group_filter: groupId })
+		.rpc('find_discrepencies', { ringing_group_filter: viewedGroupId })
 		.then(catchSupabaseErrors) as Promise<DiscrepenciesResult[]>;
 }
 
@@ -29,9 +29,14 @@ function ListMistakes({ data }: { data: DiscrepenciesResult[] }) {
 		</PageWrapper>
 	);
 }
-export default async function MistakesPage() {
+export default async function MistakesPage({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
 	return (
 		<BootstrapPageData<DiscrepenciesResult[]>
+			viewedGroupId={viewedGroupId}
 			getCacheKeys={() => ['mistakes']}
 			dataFetcher={fetchMistakes}
 			PageComponent={ListMistakes}

--- a/app/(routes)/page.tsx
+++ b/app/(routes)/page.tsx
@@ -141,7 +141,7 @@ function getStatConfigs(
 }
 
 async function fetchRecentSessions(
-	groupId: number
+	viewedGroupId: number
 ): Promise<SessionWithEncountersCount[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
@@ -149,7 +149,7 @@ async function fetchRecentSessions(
 		.select(
 			'id, visit_date, location_id, ringing_group_id, location:Locations(location_name), encounters:Encounters(count)'
 		)
-		.eq('ringing_group_id', groupId)
+		.eq('ringing_group_id', viewedGroupId)
 		.order('visit_date', { ascending: false })
 		.limit(3)
 		.then(catchSupabaseErrors) as Promise<SessionWithEncountersCount[]>;
@@ -157,7 +157,7 @@ async function fetchRecentSessions(
 
 async function fetchInitialData(
 	_: DefaultPageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<PageModel> {
 	const statConfigs = getStatConfigs(new Date());
 	return {
@@ -169,7 +169,7 @@ async function fetchInitialData(
 							...panel.dataArguments,
 							filters: {
 								...(panel.dataArguments.filters ?? {}),
-								ringing_group_filter: groupId
+								ringing_group_filter: viewedGroupId
 							},
 							result_limit: 1
 						});
@@ -186,16 +186,16 @@ async function fetchInitialData(
 				};
 			})
 		),
-		recentSessions: await fetchRecentSessions(groupId)
+		recentSessions: await fetchRecentSessions(viewedGroupId)
 	};
 }
 
 function RecentSessions({
 	data,
-	groupId
+	viewedGroupId
 }: {
 	data: SessionWithEncountersCount[];
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	return (
 		<div>
@@ -203,7 +203,7 @@ function RecentSessions({
 			<BoxyList>
 				<SessionsByDay
 					sessions={data}
-					groupId={groupId}
+					viewedGroupId={viewedGroupId}
 					dateFormat="EEEE do MMMM"
 				/>
 			</BoxyList>
@@ -212,22 +212,30 @@ function RecentSessions({
 }
 function HomePageContent({
 	data,
-	groupId
+	viewedGroupId
 }: {
 	data: PageModel;
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	return (
 		<PageWrapper>
-			<RecentSessions data={data.recentSessions} groupId={groupId} />
-			<StatsAccordion data={data.stats} groupId={groupId} />
+			<RecentSessions
+				data={data.recentSessions}
+				viewedGroupId={viewedGroupId}
+			/>
+			<StatsAccordion data={data.stats} viewedGroupId={viewedGroupId} />
 		</PageWrapper>
 	);
 }
 
-export default async function Home() {
+export default async function Home({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
 	return (
 		<BootstrapPageData<PageModel>
+			viewedGroupId={viewedGroupId}
 			getCacheKeys={() => ['home-stats']}
 			dataFetcher={fetchInitialData}
 			PageComponent={HomePageContent}

--- a/app/(routes)/retraps/page.tsx
+++ b/app/(routes)/retraps/page.tsx
@@ -13,12 +13,12 @@ import { NotableRetrapsTable } from '@/app/components/NotableRetrapsTable';
 
 async function fetchNotableRetraps(
 	_: DefaultPageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<NotableRetrapsResult[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
 		.rpc('notable_retraps', {
-			ringing_group_filter: groupId,
+			ringing_group_filter: viewedGroupId,
 			result_limit_per_species: 5,
 			min_proven_age: 3,
 			min_encounter_count: 6
@@ -34,9 +34,14 @@ function ListNotableRetraps({ data }: { data: NotableRetrapsResult[] }) {
 		</PageWrapper>
 	);
 }
-export default async function NotableRetrapsPage() {
+export default async function NotableRetrapsPage({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
 	return (
 		<BootstrapPageData<NotableRetrapsResult[]>
+			viewedGroupId={viewedGroupId}
 			getCacheKeys={() => ['notable-retraps']}
 			dataFetcher={fetchNotableRetraps}
 			PageComponent={ListNotableRetraps}

--- a/app/(routes)/sessions/page.tsx
+++ b/app/(routes)/sessions/page.tsx
@@ -13,7 +13,7 @@ import {
 
 export async function fetchAllSessions(
 	params: DefaultPageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<SessionWithEncountersCount[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
@@ -21,29 +21,34 @@ export async function fetchAllSessions(
 		.select(
 			'id, visit_date, location: Locations(id, location_name), encounters:Encounters(count)'
 		)
-		.eq('ringing_group_id', groupId)
+		.eq('ringing_group_id', viewedGroupId)
 		.order('visit_date', { ascending: false })
 		.then(catchSupabaseErrors) as Promise<SessionWithEncountersCount[]>;
 }
 
 function ListAllSessions({
 	data,
-	groupId
+	viewedGroupId
 }: {
 	data: SessionWithEncountersCount[];
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	return (
 		<PageWrapper>
 			<PrimaryHeading>Session history</PrimaryHeading>
-			<SessionHistoryCalendar sessions={data} groupId={groupId} />
+			<SessionHistoryCalendar sessions={data} viewedGroupId={viewedGroupId} />
 		</PageWrapper>
 	);
 }
 
-export default async function SessionsPage() {
+export default async function SessionsPage({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
 	return (
 		<BootstrapPageData<SessionWithEncountersCount[]>
+			viewedGroupId={viewedGroupId}
 			getCacheKeys={() => ['sessions']}
 			dataFetcher={fetchAllSessions}
 			PageComponent={ListAllSessions}

--- a/app/(routes)/species/[speciesName]/page.tsx
+++ b/app/(routes)/species/[speciesName]/page.tsx
@@ -23,31 +23,31 @@ export type FullFatPageData = {
 };
 export type PageData = FullFatPageData | { speciesId: number };
 
-function getTopSessions(species: string, groupId: number) {
+function getTopSessions(species: string, viewedGroupId: number) {
 	return getTopPeriodsByMetric({
 		temporal_unit: 'day',
 		metric_name: 'encounters',
 		filters: {
 			species_filter: species,
-			ringing_group_filter: groupId
+			ringing_group_filter: viewedGroupId
 		} as TopMetricsFilterParams,
 		result_limit: 5
 	}) as Promise<TopPeriodsResult[]>;
 }
 
-async function getSpeciesStats(species: string, groupId: number) {
+async function getSpeciesStats(species: string, viewedGroupId: number) {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
 		.rpc('aggregate_stats', {
 			species_name_filter: species,
-			ringing_group_filter: groupId
+			ringing_group_filter: viewedGroupId
 		})
 		.then(catchSupabaseErrors) as Promise<AggregateStatsRow[]>;
 }
 
 async function fetchSpeciesData(
 	params: PageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<PageData | null> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	const { id: speciesId } = (await supabase
@@ -60,9 +60,9 @@ async function fetchSpeciesData(
 		throw new Error(`Species ${params.speciesName} not found`);
 	}
 	const [topSessions, birds, speciesStats] = await Promise.all([
-		getTopSessions(params.speciesName, groupId),
-		fetchPageOfBirds(speciesId, groupId),
-		getSpeciesStats(params.speciesName, groupId)
+		getTopSessions(params.speciesName, viewedGroupId),
+		fetchPageOfBirds(speciesId, viewedGroupId),
+		getSpeciesStats(params.speciesName, viewedGroupId)
 	]);
 	if (birds.length === 0) {
 		return {
@@ -78,10 +78,13 @@ async function fetchSpeciesData(
 	};
 }
 
-export default async function SpeciesPage(props: PageProps) {
+export default async function SpeciesPage(
+	props: PageProps & { viewedGroupId?: number }
+) {
 	return (
 		<BootstrapPageData<PageData, PageProps, PageParams>
 			pageProps={props}
+			viewedGroupId={props.viewedGroupId}
 			getCacheKeys={(params: PageParams) => ['species', params.speciesName]}
 			dataFetcher={fetchSpeciesData}
 			PageComponent={SingleSpeciesPage}

--- a/app/(routes)/species/page.tsx
+++ b/app/(routes)/species/page.tsx
@@ -15,12 +15,12 @@ export type PageData = {
 	years: number[];
 };
 
-async function fetchYears(groupId: number): Promise<number[]> {
+async function fetchYears(viewedGroupId: number): Promise<number[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	const dates = (await supabase
 		.from('Sessions')
 		.select('visit_date')
-		.eq('ringing_group_id', groupId)
+		.eq('ringing_group_id', viewedGroupId)
 		.order('visit_date', { ascending: false })
 		.then(catchSupabaseErrors)) as { visit_date: string }[];
 
@@ -31,11 +31,11 @@ async function fetchYears(groupId: number): Promise<number[]> {
 
 async function fetchInitialPageData(
 	_: DefaultPageParams,
-	groupId: number
+	viewedGroupId: number
 ): Promise<PageData> {
 	const [speciesStats, years] = await Promise.all([
-		fetchSpeciesData(groupId),
-		fetchYears(groupId)
+		fetchSpeciesData(viewedGroupId),
+		fetchYears(viewedGroupId)
 	]);
 	return {
 		speciesStats,
@@ -43,9 +43,14 @@ async function fetchInitialPageData(
 	};
 }
 
-export default async function AllSpeciesPage() {
+export default async function AllSpeciesPage({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
 	return (
 		<BootstrapPageData<PageData>
+			viewedGroupId={viewedGroupId}
 			getCacheKeys={() => ['species']}
 			dataFetcher={fetchInitialPageData}
 			PageComponent={MultiSpeciesStatsTable}

--- a/app/actions/multi-species-data.ts
+++ b/app/actions/multi-species-data.ts
@@ -4,7 +4,7 @@ import { catchSupabaseErrors } from '@/lib/supabase';
 import type { AggregateStatsRow } from '@/app/models/db';
 
 export async function fetchSpeciesData(
-	groupId: number,
+	viewedGroupId: number,
 	fromDate?: string,
 	toDate?: string
 ): Promise<AggregateStatsRow[]> {
@@ -13,7 +13,7 @@ export async function fetchSpeciesData(
 		.rpc('aggregate_stats', {
 			from_date: fromDate,
 			to_date: toDate,
-			ringing_group_filter: groupId,
+			ringing_group_filter: viewedGroupId,
 			group_by_species: true
 		})
 		.then(catchSupabaseErrors) as Promise<AggregateStatsRow[]>;

--- a/app/actions/pay-off-stats.ts
+++ b/app/actions/pay-off-stats.ts
@@ -8,20 +8,20 @@ export type PayOffStatsData = {
 };
 
 export async function fetchPayOffStats(
-	groupId: number
+	viewedGroupId: number
 ): Promise<PayOffStatsData | null> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	const [yearly, monthly] = await Promise.all([
 		supabase
 			.rpc('aggregate_stats', {
-				ringing_group_filter: groupId,
+				ringing_group_filter: viewedGroupId,
 				group_by_species: false,
 				group_by_time_period: 'year'
 			})
 			.then(catchSupabaseErrors) as Promise<AggregateStatsRow[] | null>,
 		supabase
 			.rpc('aggregate_stats', {
-				ringing_group_filter: groupId,
+				ringing_group_filter: viewedGroupId,
 				group_by_species: false,
 				group_by_time_period: 'month'
 			})

--- a/app/actions/single-species-data.ts
+++ b/app/actions/single-species-data.ts
@@ -14,7 +14,7 @@ import type { SexedGraphableBird } from '@/app/components/WeightAndWingChart';
 import type { AggregateStatsRow } from '@/app/models/db';
 export async function fetchPageOfBirds(
 	speciesId: number,
-	groupId: number,
+	viewedGroupId: number,
 	page: number = 0
 ) {
 	const supabase = await getAuthenticatedSupabaseClient();
@@ -44,7 +44,7 @@ export async function fetchPageOfBirds(
 			)`
 		)
 		.eq('species_id', speciesId)
-		.contains('ringing_group_ids', [groupId])
+		.contains('ringing_group_ids', [viewedGroupId])
 		.order('last_encountered_timestamp', { ascending: false })
 		.range(
 			page * SPECIES_PAGE_BATCH_SIZE,
@@ -56,12 +56,12 @@ export async function fetchPageOfBirds(
 
 export async function fetchNotableRetraps(
 	speciesName: string,
-	groupId: number
+	viewedGroupId: number
 ): Promise<NotableRetrapsResult[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
 		.rpc('notable_retraps', {
-			ringing_group_filter: groupId,
+			ringing_group_filter: viewedGroupId,
 			species_filter: speciesName,
 			result_limit: 10,
 			min_proven_age: 3,
@@ -72,7 +72,7 @@ export async function fetchNotableRetraps(
 
 export async function fetchGraphableEncounterData(
 	speciesId: number,
-	groupId: number
+	viewedGroupId: number
 ): Promise<SexedGraphableBird[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	const paginatedBirdResults = (await supabase
@@ -86,7 +86,7 @@ export async function fetchGraphableEncounterData(
 			)`
 		)
 		.eq('species_id', speciesId)
-		.contains('ringing_group_ids', [groupId])
+		.contains('ringing_group_ids', [viewedGroupId])
 		.then(catchSupabaseErrors)) as GraphableBird[];
 	return paginatedBirdResults.map(
 		(bird) =>
@@ -97,12 +97,15 @@ export async function fetchGraphableEncounterData(
 	);
 }
 
-export async function getSpeciesStatsHistory(species: string, groupId: number) {
+export async function getSpeciesStatsHistory(
+	species: string,
+	viewedGroupId: number
+) {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
 		.rpc('aggregate_stats', {
 			species_name_filter: species,
-			ringing_group_filter: groupId,
+			ringing_group_filter: viewedGroupId,
 			group_by_time_period: 'month'
 		})
 		.then(catchSupabaseErrors) as Promise<AggregateStatsRow[]>;

--- a/app/components/MultiSpeciesStatsTable.tsx
+++ b/app/components/MultiSpeciesStatsTable.tsx
@@ -49,10 +49,10 @@ const sortableColumnConfigs = speciesStatConfigs.reduce(
 
 export function MultiSpeciesStatsTable({
 	data: { speciesStats: initialSpeciesStats, years },
-	groupId
+	viewedGroupId
 }: {
 	data: PageData;
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	const formRef = useRef<HTMLFormElement>(null);
 	const [year, setYear] = useState<number | null>(null);
@@ -67,10 +67,12 @@ export function MultiSpeciesStatsTable({
 			isFirstRender.current = false;
 			return;
 		}
-		fetchSpeciesData(groupId, fromDate ?? undefined, toDate ?? undefined).then(
-			setSpeciesStats
-		);
-	}, [groupId, fromDate, toDate]);
+		fetchSpeciesData(
+			viewedGroupId,
+			fromDate ?? undefined,
+			toDate ?? undefined
+		).then(setSpeciesStats);
+	}, [viewedGroupId, fromDate, toDate]);
 
 	function clearSettings() {
 		setYear(null);

--- a/app/components/SingleSpeciesPage.tsx
+++ b/app/components/SingleSpeciesPage.tsx
@@ -48,10 +48,10 @@ function ConditionalTabPanel({
 
 function NotableRetrapsSection({
 	speciesName,
-	groupId
+	viewedGroupId
 }: {
 	speciesName: string;
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	const [notableRetraps, setNotableRetraps] = useState<NotableRetrapsResult[]>(
 		[]
@@ -59,11 +59,11 @@ function NotableRetrapsSection({
 	const [isLoaded, setIsLoaded] = useState(false);
 	useEffect(() => {
 		if (notableRetraps.length > 0) return;
-		fetchNotableRetraps(speciesName, groupId).then((data) => {
+		fetchNotableRetraps(speciesName, viewedGroupId).then((data) => {
 			setNotableRetraps(data);
 			setIsLoaded(true);
 		});
-	}, [speciesName, groupId, notableRetraps.length]);
+	}, [speciesName, viewedGroupId, notableRetraps.length]);
 	return (
 		<>
 			<SecondaryHeading>Notable Retraps</SecondaryHeading>
@@ -85,10 +85,10 @@ function NotableRetrapsSection({
 
 function SpeciesData({
 	data,
-	groupId
+	viewedGroupId
 }: {
 	data: FullFatPageData;
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	const [loadedBirds, setLoadedBirds] = useState(data.birds);
 	const [page, setPage] = useState(0);
@@ -106,7 +106,11 @@ function SpeciesData({
 	async function loadMoreBirds() {
 		const nextPage = page + 1;
 		setPage(nextPage);
-		const newBirds = await fetchPageOfBirds(data.speciesId, groupId, nextPage);
+		const newBirds = await fetchPageOfBirds(
+			data.speciesId,
+			viewedGroupId,
+			nextPage
+		);
 		setLoadedBirds([
 			...loadedBirds,
 			...newBirds.filter((bird) => !loadedIds.includes(bird.id))
@@ -127,7 +131,7 @@ function SpeciesData({
 	const loadedIds = loadedBirds.map((bird) => bird.id);
 	return (
 		<>
-			<SingleSpeciesStats {...data} groupId={groupId} />
+			<SingleSpeciesStats {...data} viewedGroupId={viewedGroupId} />
 			<nav
 				className="bg-base-200 rounded-field w-fit space-x-1 overflow-x-auto p-1 mt-4"
 				aria-label="Tabs"
@@ -190,7 +194,7 @@ function SpeciesData({
 			>
 				<NotableRetrapsSection
 					speciesName={data.speciesName}
-					groupId={groupId}
+					viewedGroupId={viewedGroupId}
 				/>
 			</ConditionalTabPanel>
 			<ConditionalTabPanel
@@ -198,14 +202,20 @@ function SpeciesData({
 				tabId="stats-history"
 				activeTabId={activeTab}
 			>
-				<StatsHistoryChart speciesName={data.speciesName} groupId={groupId} />
+				<StatsHistoryChart
+					speciesName={data.speciesName}
+					viewedGroupId={viewedGroupId}
+				/>
 			</ConditionalTabPanel>
 			<ConditionalTabPanel
 				loadedTabs={loadedTabs}
 				tabId="size-plot"
 				activeTabId={activeTab}
 			>
-				<WeightVsWingLengthChart speciesId={data.speciesId} groupId={groupId} />
+				<WeightVsWingLengthChart
+					speciesId={data.speciesId}
+					viewedGroupId={viewedGroupId}
+				/>
 			</ConditionalTabPanel>
 		</>
 	);
@@ -218,17 +228,17 @@ function fullFatTypeGuard(data: PageData): data is FullFatPageData {
 export function SingleSpeciesPage({
 	params: { speciesName },
 	data,
-	groupId
+	viewedGroupId
 }: {
 	params: PageParams;
 	data: PageData;
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	return (
 		<PageWrapper>
 			<PrimaryHeading>{speciesName}</PrimaryHeading>
 			{fullFatTypeGuard(data) ? (
-				<SpeciesData data={data} groupId={groupId} />
+				<SpeciesData data={data} viewedGroupId={viewedGroupId} />
 			) : (
 				<p>Not authorised to view any encounter data for this species</p>
 			)}

--- a/app/components/SingleSpeciesStats.tsx
+++ b/app/components/SingleSpeciesStats.tsx
@@ -46,8 +46,8 @@ export function SingleSpeciesStats({
 	topSessions,
 	birds,
 	speciesStats,
-	groupId
-}: FullFatPageData & { groupId: number }) {
+	viewedGroupId
+}: FullFatPageData & { viewedGroupId: number }) {
 	if (!speciesStats) return null;
 	// const NotableRetrapsBirds =
 	// 	speciesStats.max_encountered_bird && speciesStats.max_encountered_bird > 1
@@ -111,7 +111,7 @@ export function SingleSpeciesStats({
 						temporalUnit="day"
 						classes="badge badge-outline"
 						dateFormat="d MMM yyyy"
-						groupId={groupId}
+						viewedGroupId={viewedGroupId}
 					/>
 				))}
 			</li>

--- a/app/components/StatsAccordion.tsx
+++ b/app/components/StatsAccordion.tsx
@@ -29,7 +29,7 @@ export type StatsAccordionModel = {
 };
 
 type AccordionItemModelWithGroupId = AccordionItemModel & {
-	groupId: number;
+	viewedGroupId: number;
 };
 
 function hasData(data: TopPeriodsResult[] | null): data is TopPeriodsResult[] {
@@ -61,7 +61,7 @@ function ContentComponent({
 					...model.definition.dataArguments,
 					filters: {
 						...(model.definition.dataArguments.filters ?? {}),
-						ringing_group_filter: model.groupId
+						ringing_group_filter: model.viewedGroupId
 					},
 					result_limit: 5
 				})
@@ -85,7 +85,7 @@ function ContentComponent({
 		model.definition.id,
 		model.definition.bySpecies,
 		model.definition.dataArguments,
-		model.groupId
+		model.viewedGroupId
 	]);
 
 	return hasData(data) ? (
@@ -104,7 +104,7 @@ function ContentComponent({
 						temporalUnit={
 							model.definition.dataArguments.temporal_unit as TemporalUnit
 						}
-						groupId={model.groupId}
+						viewedGroupId={model.viewedGroupId}
 					/>
 				</li>
 			))}
@@ -133,15 +133,15 @@ function HeadingComponent({ model }: { model: AccordionItemModelWithGroupId }) {
 
 export function StatsAccordion({
 	data,
-	groupId
+	viewedGroupId
 }: {
 	data: StatsAccordionModel[];
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	const [expanded, setExpanded] = useState<string | false>(false);
 	useEffect(() => {
 		setExpanded(false);
-	}, [groupId]);
+	}, [viewedGroupId]);
 	return (
 		<>
 			{data.map(({ heading, stats }) => (
@@ -150,11 +150,11 @@ export function StatsAccordion({
 					<BoxyList>
 						{stats.map((item) => (
 							<AccordionItem
-								key={`${groupId}-${item.definition.id}`}
+								key={`${viewedGroupId}-${item.definition.id}`}
 								id={item.definition.id}
 								HeadingComponent={HeadingComponent}
 								ContentComponent={ContentComponent}
-								model={{ ...item, groupId }}
+								model={{ ...item, viewedGroupId }}
 								onToggle={setExpanded}
 								expandedId={expanded}
 							/>

--- a/app/components/StatsHistoryChart.tsx
+++ b/app/components/StatsHistoryChart.tsx
@@ -73,18 +73,18 @@ function getSizes(statsHistory: AggregateStatsRow[]): LineChartData[] {
 
 export function StatsHistoryChart({
 	speciesName,
-	groupId
+	viewedGroupId
 }: {
 	speciesName: string;
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	const [statsHistory, setStatsHistory] = useState<AggregateStatsRow[]>([]);
 	useEffect(() => {
 		if (statsHistory.length > 0) return;
-		getSpeciesStatsHistory(speciesName, groupId).then((data) => {
+		getSpeciesStatsHistory(speciesName, viewedGroupId).then((data) => {
 			setStatsHistory(data);
 		});
-	}, [speciesName, groupId, statsHistory.length]);
+	}, [speciesName, viewedGroupId, statsHistory.length]);
 	return (
 		<>
 			<SecondaryHeading>Stats History</SecondaryHeading>

--- a/app/components/WeightAndWingChart.tsx
+++ b/app/components/WeightAndWingChart.tsx
@@ -137,10 +137,10 @@ function getChartData(
 
 export function WeightVsWingLengthChart({
 	speciesId,
-	groupId
+	viewedGroupId
 }: {
 	speciesId: number;
-	groupId: number;
+	viewedGroupId: number;
 }) {
 	const [chartGrouping, setChartGrouping] = useState<'sex' | 'age'>('sex');
 	const [graphableEncounterData, setGraphableEncounterData] = useState<
@@ -148,10 +148,10 @@ export function WeightVsWingLengthChart({
 	>([]);
 	useEffect(() => {
 		if (graphableEncounterData.length > 0) return;
-		fetchGraphableEncounterData(speciesId, groupId).then((data) => {
+		fetchGraphableEncounterData(speciesId, viewedGroupId).then((data) => {
 			setGraphableEncounterData(data);
 		});
-	}, [speciesId, groupId, graphableEncounterData.length]);
+	}, [speciesId, viewedGroupId, graphableEncounterData.length]);
 	const chartData = getChartData(graphableEncounterData, chartGrouping);
 	return (
 		<>

--- a/app/components/layout/BootstrapPageData.tsx
+++ b/app/components/layout/BootstrapPageData.tsx
@@ -9,16 +9,17 @@ export type BootstrapPageDataProps<DataType, PagePropsType, ParamsType> = {
 	pageProps?: PagePropsType;
 	loading?: React.ReactNode;
 	ttl?: number;
+	viewedGroupId?: number;
 	getCacheKeys: (params: ParamsType) => string[];
 	getParams?: (pageProps: PagePropsType) => Promise<ParamsType>;
 	dataFetcher: (
 		params: ParamsType,
-		groupId: number
+		viewedGroupId: number
 	) => Promise<DataType | null>;
 	PageComponent: (props: {
 		params: ParamsType;
 		data: DataType;
-		groupId: number;
+		viewedGroupId: number;
 	}) => React.ReactNode;
 };
 
@@ -42,19 +43,19 @@ export async function fetchDataWithCache<DataType, ParamsType>({
 	params,
 	dataFetcher,
 	cacheKeys,
-	groupId,
+	viewedGroupId,
 	ttl = 3600 // 1 hour
 }: {
 	params: ParamsType;
 	dataFetcher: (
 		params: ParamsType,
-		groupId: number
+		viewedGroupId: number
 	) => Promise<DataType | null>;
 	cacheKeys: string[];
-	groupId: number;
+	viewedGroupId: number;
 	ttl?: number;
 }): Promise<DataType | null> {
-	return dataFetcher(params, groupId);
+	return dataFetcher(params, viewedGroupId);
 	// return unstable_cache(async () => dataFetcher(params, groupId), cacheKeys, {
 	// 	// 1 day in production, 1 second in development to allow for quick testing
 	// 	revalidate: process.env.VERCEL_ENV === 'production' ? ttl : 1,
@@ -68,7 +69,8 @@ export async function LoadWithData<DataType, PagePropsType, ParamsType>({
 	dataFetcher,
 	getCacheKeys,
 	PageComponent,
-	ttl
+	ttl,
+	viewedGroupId: viewedGroupIdProp
 }: BootstrapPageDataProps<DataType, PagePropsType, ParamsType>) {
 	let params: ParamsType;
 	if (getParams) {
@@ -79,13 +81,14 @@ export async function LoadWithData<DataType, PagePropsType, ParamsType>({
 		params = {} as ParamsType;
 	}
 
-	const groupId = await getGroupCookie();
+	const loggedInGroupId = await getGroupCookie();
+	const viewedGroupId = viewedGroupIdProp ?? loggedInGroupId;
 	const cacheKeys = getCacheKeys(params);
-	const groupScopedCacheKeys = groupId
-		? [String(groupId), ...cacheKeys]
+	const groupScopedCacheKeys = viewedGroupId
+		? [String(viewedGroupId), ...cacheKeys]
 		: cacheKeys;
 
-	if (!groupId) {
+	if (!viewedGroupId) {
 		// TODO this should trigger a proper authorisation flow
 		return <p>Select a group to view data on this site</p>;
 	}
@@ -94,12 +97,14 @@ export async function LoadWithData<DataType, PagePropsType, ParamsType>({
 		dataFetcher,
 		cacheKeys: groupScopedCacheKeys,
 		ttl,
-		groupId
+		viewedGroupId
 	});
 	if (!data) {
 		notFound();
 	}
-	return <PageComponent params={params} data={data} groupId={groupId} />;
+	return (
+		<PageComponent params={params} data={data} viewedGroupId={viewedGroupId} />
+	);
 }
 
 export function BootstrapPageData<

--- a/app/components/layout/__mocks__/BootstrapPageData.tsx
+++ b/app/components/layout/__mocks__/BootstrapPageData.tsx
@@ -54,6 +54,10 @@ export function BootstrapPageData<
 	}
 
 	return (
-		<bootstrapProps.PageComponent params={params} data={data} groupId={1} />
+		<bootstrapProps.PageComponent
+			params={params}
+			data={data}
+			viewedGroupId={1}
+		/>
 	);
 }


### PR DESCRIPTION
## Summary

- Each own-group page default export now accepts an optional `viewedGroupId` prop
- When provided, this is forwarded to `BootstrapPageData`, which uses it instead of the cookie group for data fetching
- Affected pages: home, sessions, species, species/[name], effort, mistakes, retraps

This has no visible behaviour change for own-group users. It sets up the pages for reuse from cross-group route wrappers (next PR) without code duplication.

## Test plan
- [ ] `npm run qa` passes
- [ ] Own-group pages still work normally (viewedGroupId defaults to cookie group)

🤖 Generated with [Claude Code](https://claude.com/claude-code)