### PR TITLE
Migrate session URL and make bird detail show all accessible encounters

### DIFF
--- a/app/(routes)/bird/[ring]/page.tsx
+++ b/app/(routes)/bird/[ring]/page.tsx
@@ -19,7 +19,7 @@ import { EncountersTimeline } from '@/app/components/EncountersTimeline';
 type PageParams = { ring: string };
 type PageProps = { params: Promise<PageParams> };
 
-async function fetchBirdData({ ring }: PageParams, groupId: number) {
+async function fetchBirdData({ ring }: PageParams, _viewedGroupId: number) {
 	const supabase = await getAuthenticatedSupabaseClient();
 	const bird = (await supabase
 		.from('Birds')
@@ -62,7 +62,6 @@ async function fetchBirdData({ ring }: PageParams, groupId: number) {
 	`
 		)
 		.eq('bird_id', bird.id)
-		.eq('ringing_group_id', groupId)
 		.then(catchSupabaseErrors)) as EncounterOfBird[];
 
 	return { ...bird, encounters } as StandaloneBird;
@@ -70,12 +69,19 @@ async function fetchBirdData({ ring }: PageParams, groupId: number) {
 
 function BirdSummary({
 	params: { ring },
-	data: bird
+	data: bird,
+	viewedGroupId: loggedInGroupId
 }: {
 	params: PageParams;
 	data: StandaloneBird;
+	viewedGroupId: number;
 }) {
 	const enrichedBird = bird.encounters.length ? enrichBird(bird) : null;
+	const sharedEncounterCount = enrichedBird
+		? enrichedBird.encounters.filter(
+				(e) => e.ringing_group_id !== loggedInGroupId
+			).length
+		: 0;
 	return (
 		<PageWrapper>
 			<PrimaryHeading>
@@ -91,13 +97,18 @@ function BirdSummary({
 				<>
 					<BadgeList
 						testId="bird-stats"
-						items={[
-							`${enrichedBird.encounters.length} encounters`,
-							`First: ${formatDate(enrichedBird.firstEncounterDate, 'dd MMMM yyyy')}`,
-							`Last: ${formatDate(enrichedBird.lastEncounterDate, 'dd MMMM yyyy')}`,
-							`Sex: ${enrichedBird.sex}${enrichedBird.sexCertainty < 0.5 ? `?` : ''}`,
-							`Proven Age: ${enrichedBird.proven_age}`
-						]}
+						items={
+							[
+								`${enrichedBird.encounters.length} encounters`,
+								sharedEncounterCount > 0
+									? `${sharedEncounterCount} from another group`
+									: null,
+								`First: ${formatDate(enrichedBird.firstEncounterDate, 'dd MMMM yyyy')}`,
+								`Last: ${formatDate(enrichedBird.lastEncounterDate, 'dd MMMM yyyy')}`,
+								`Sex: ${enrichedBird.sex}${enrichedBird.sexCertainty < 0.5 ? `?` : ''}`,
+								`Proven Age: ${enrichedBird.proven_age}`
+							].filter(Boolean) as string[]
+						}
 					/>
 					<div className="m-2">
 						<EncountersTimeline encounters={enrichedBird.encounters} />

--- a/app/(routes)/bird/page.tsx
+++ b/app/(routes)/bird/page.tsx
@@ -19,7 +19,7 @@ type SearchResult = {
 type SearchParams = { q: string };
 type PageProps = { searchParams: Promise<SearchParams> };
 
-async function searchByRing({ q }: SearchParams) {
+async function searchByRing({ q }: SearchParams, _viewedGroupId: number) {
 	const supabase = await getAuthenticatedSupabaseClient();
 	const uppercaseQuery = q.toUpperCase();
 	const exactMatch = await supabase


### PR DESCRIPTION
## Summary

- Session detail URL migrated from `/session/group/[id]/[date]` to `/group/[id]/session/[date]` and `/group/[id]/session/[date]/site/[locationId]` (no redirect — old URLs simply 404)
- Internal links in `SessionHistoryCalendar` and `StatOutput` updated to the new URL scheme
- Session test updated to use the new URL params shape
- Bird detail (`/bird/[ring]`) now shows encounters from all RLS-accessible groups, not just the logged-in group's encounters
- A badge is added to the bird detail page showing how many encounters are from another group (when > 0)
- The old catch-all session route (`app/(routes)/session/[...params]/`) is deleted

## Test plan
- [ ] `npm run qa` passes
- [ ] Session links from the calendar navigate correctly
- [ ] Bird detail shows all encounters; badge appears when encounters from another group exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)