### PR TITLE
Add GroupDataSharing table and extend RLS for cross-group reads

### DIFF
--- a/supabase/schema/schemas/public/tables/"Birds".sql
+++ b/supabase/schema/schemas/public/tables/"Birds".sql
@@ -11,30 +11,40 @@ CREATE INDEX idx_birds_ringing_group_ids ON public."Birds" USING gin (ringing_gr
 
 CREATE INDEX idx_birds_species_id ON public."Birds" (species_id);
 
+-- SELECT: grants access if any of:
+-- 1. The logged-in group is one of the groups that has ringed this bird (its id is in ringing_group_ids)
+-- 2. The bird has no ringing group yet (empty array, e.g. freshly imported) and the user is authenticated
+-- 3. A group that has ringed this bird has granted read access to the logged-in group via GroupDataSharing
 CREATE POLICY group_birds_access ON public."Birds" FOR
 SELECT
 	USING (
 		(
 			(
-				(
-					(
-						(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
-					)
-				)::bigint = ANY (ringing_group_ids)
-			)
+				(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
+			)::bigint = ANY (ringing_group_ids)
 			OR (
 				(ringing_group_ids = '{}'::BIGINT[])
 				AND (
 					(
-						(
-							(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
-						)
+						(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
 					)::bigint IS NOT NULL
 				)
+			)
+			OR EXISTS (
+				SELECT
+					1
+				FROM
+					public."GroupDataSharing" gds
+					JOIN unnest(ringing_group_ids) gid ON gid = gds.granter_group_id
+				WHERE
+					gds.recipient_group_id = (
+						(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
+					)::bigint
 			)
 		)
 	);
 
+-- INSERT: allows any authenticated group to insert birds (group ownership is tracked via ringing_group_ids, set by triggers)
 CREATE POLICY group_birds_insert ON public."Birds" FOR INSERT
 WITH
 	CHECK (
@@ -47,6 +57,7 @@ WITH
 		)
 	);
 
+-- UPDATE: allows any authenticated group to update birds (shared birds can be updated by any group that has encountered them)
 CREATE POLICY group_birds_update ON public."Birds"
 FOR UPDATE
 	USING (

--- a/supabase/schema/schemas/public/tables/"Encounters".sql
+++ b/supabase/schema/schemas/public/tables/"Encounters".sql
@@ -51,18 +51,28 @@ AFTER
 UPDATE OF ringing_group_id ON public."Encounters" FOR EACH ROW
 EXECUTE FUNCTION public.trg_update_bird_ringing_group_id ();
 
+-- SELECT: grants access if the encounter belongs to the logged-in group, or if the encounter's group
+-- has granted read access to the logged-in group via GroupDataSharing
 CREATE POLICY group_encounters_access ON public."Encounters" FOR
 SELECT
 	USING (
-		(
-			ringing_group_id = (
-				(
+		ringing_group_id = (
+			(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
+		)::bigint
+		OR EXISTS (
+			SELECT
+				1
+			FROM
+				public."GroupDataSharing"
+			WHERE
+				granter_group_id = ringing_group_id
+				AND recipient_group_id = (
 					(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
-				)
-			)::bigint
+				)::bigint
 		)
 	);
 
+-- INSERT: only the owning group can insert encounters
 CREATE POLICY group_encounters_insert ON public."Encounters" FOR INSERT
 WITH
 	CHECK (
@@ -75,6 +85,7 @@ WITH
 		)
 	);
 
+-- UPDATE: only the owning group can update encounters
 CREATE POLICY group_encounters_update ON public."Encounters"
 FOR UPDATE
 	USING (

--- a/supabase/schema/schemas/public/tables/"GroupDataSharing".sql
+++ b/supabase/schema/schemas/public/tables/"GroupDataSharing".sql
@@ -1,0 +1,41 @@
+CREATE SEQUENCE public."GroupDataSharing_id_seq";
+
+CREATE TABLE public."GroupDataSharing" (
+	id bigint DEFAULT nextval('public."GroupDataSharing_id_seq"'::regclass) NOT NULL,
+	granter_group_id bigint NOT NULL,
+	recipient_group_id bigint NOT NULL,
+	created_at timestamptz NOT NULL DEFAULT NOW(),
+	CONSTRAINT no_self_share CHECK (granter_group_id <> recipient_group_id),
+	CONSTRAINT unique_share UNIQUE (granter_group_id, recipient_group_id)
+);
+
+COMMENT ON TABLE public."GroupDataSharing" IS 'granter_group_id shares their data with recipient_group_id';
+
+-- Grants SELECT only to the recipient group for rows that grant them access.
+-- Each group can only see sharing grants directed at them; grantors cannot see their own grants.
+CREATE POLICY group_data_sharing_select ON public."GroupDataSharing" FOR
+SELECT
+	USING (
+		recipient_group_id = (
+			(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
+		)::bigint
+	);
+
+ALTER SEQUENCE public."GroupDataSharing_id_seq" OWNED BY public."GroupDataSharing".id;
+
+ALTER TABLE public."GroupDataSharing" ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public."GroupDataSharing"
+ADD CONSTRAINT "GroupDataSharing_pkey" PRIMARY KEY (id);
+
+ALTER TABLE public."GroupDataSharing"
+ADD CONSTRAINT group_data_sharing_granter_group_id_fkey FOREIGN KEY (granter_group_id) REFERENCES public."RingingGroups" (id) ON DELETE CASCADE;
+
+ALTER TABLE public."GroupDataSharing"
+ADD CONSTRAINT group_data_sharing_recipient_group_id_fkey FOREIGN KEY (recipient_group_id) REFERENCES public."RingingGroups" (id) ON DELETE CASCADE;
+
+GRANT ALL ON public."GroupDataSharing" TO anon;
+
+GRANT ALL ON public."GroupDataSharing" TO authenticated;
+
+GRANT ALL ON public."GroupDataSharing" TO service_role;

--- a/supabase/schema/schemas/public/tables/"Locations".sql
+++ b/supabase/schema/schemas/public/tables/"Locations".sql
@@ -6,18 +6,28 @@ CREATE TABLE public."Locations" (
 
 CREATE INDEX idx_locations_ringing_group_id ON public."Locations" (ringing_group_id);
 
+-- SELECT: grants access if the location belongs to the logged-in group, or if the location's group
+-- has granted read access to the logged-in group via GroupDataSharing
 CREATE POLICY group_locations_access ON public."Locations" FOR
 SELECT
 	USING (
-		(
-			ringing_group_id = (
-				(
+		ringing_group_id = (
+			(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
+		)::bigint
+		OR EXISTS (
+			SELECT
+				1
+			FROM
+				public."GroupDataSharing"
+			WHERE
+				granter_group_id = ringing_group_id
+				AND recipient_group_id = (
 					(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
-				)
-			)::bigint
+				)::bigint
 		)
 	);
 
+-- INSERT: only the owning group can insert locations
 CREATE POLICY group_locations_insert ON public."Locations" FOR INSERT
 WITH
 	CHECK (
@@ -30,6 +40,7 @@ WITH
 		)
 	);
 
+-- UPDATE: only the owning group can update locations
 CREATE POLICY group_locations_update ON public."Locations"
 FOR UPDATE
 	USING (

--- a/supabase/schema/schemas/public/tables/"Sessions".sql
+++ b/supabase/schema/schemas/public/tables/"Sessions".sql
@@ -14,18 +14,28 @@ OR
 UPDATE OF location_id ON public."Sessions" FOR EACH ROW
 EXECUTE FUNCTION public.trg_set_session_generated_fields ();
 
+-- SELECT: grants access if the session belongs to the logged-in group, or if the session's group
+-- has granted read access to the logged-in group via GroupDataSharing
 CREATE POLICY group_sessions_access ON public."Sessions" FOR
 SELECT
 	USING (
-		(
-			ringing_group_id = (
-				(
+		ringing_group_id = (
+			(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
+		)::bigint
+		OR EXISTS (
+			SELECT
+				1
+			FROM
+				public."GroupDataSharing"
+			WHERE
+				granter_group_id = ringing_group_id
+				AND recipient_group_id = (
 					(auth.jwt () -> 'app_metadata'::text) ->> 'ringing_group_id'::text
-				)
-			)::bigint
+				)::bigint
 		)
 	);
 
+-- INSERT: only the owning group can insert sessions
 CREATE POLICY group_sessions_insert ON public."Sessions" FOR INSERT
 WITH
 	CHECK (
@@ -38,6 +48,7 @@ WITH
 		)
 	);
 
+-- UPDATE: only the owning group can update sessions
 CREATE POLICY group_sessions_update ON public."Sessions"
 FOR UPDATE
 	USING (

--- a/types/supabase.types.ts
+++ b/types/supabase.types.ts
@@ -132,6 +132,42 @@ export type Database = {
           },
         ]
       }
+      GroupDataSharing: {
+        Row: {
+          created_at: string
+          granter_group_id: number
+          id: number
+          recipient_group_id: number
+        }
+        Insert: {
+          created_at?: string
+          granter_group_id: number
+          id?: number
+          recipient_group_id: number
+        }
+        Update: {
+          created_at?: string
+          granter_group_id?: number
+          id?: number
+          recipient_group_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "group_data_sharing_granter_group_id_fkey"
+            columns: ["granter_group_id"]
+            isOneToOne: false
+            referencedRelation: "RingingGroups"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "group_data_sharing_recipient_group_id_fkey"
+            columns: ["recipient_group_id"]
+            isOneToOne: false
+            referencedRelation: "RingingGroups"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       Locations: {
         Row: {
           id: number


### PR DESCRIPTION
## Summary

- Creates `GroupDataSharing` table (`from_group_id` → `to_group_id`): non-commutative, non-transitive, no self-share, RLS so each group sees only rows where they are the recipient
- Extends SELECT policies on `Sessions`, `Encounters`, `Locations`, and `Birds` to allow reads where a `GroupDataSharing` row grants access from the viewed group to the logged-in group
- The JWT always carries the **logged-in** group's ID — no JWT switching. RLS handles the cross-group access transparently

**After merging:** run `npm run db:schema:apply` then `npm run db:types` to apply the migration and regenerate TypeScript types.

## Test plan
- [ ] Apply schema locally: `npm run db:schema:apply`
- [ ] Regenerate types: `npm run db:types`
- [ ] `npm run qa` passes after type regeneration
- [ ] Insert a `GroupDataSharing` row and verify the recipient group can query the other group's Sessions/Encounters/Birds via the authenticated client
- [ ] Verify the donor group cannot query the recipient's data (non-commutative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)