### PR TITLE
Update GlobalNav and root layout for cross-group navigation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,10 +24,17 @@ A leaderboard/statistics dashboard for bird ringing data. Bird ringing groups (o
 
 There are no per-person logins. Authentication is group-scoped:
 
-1. The selected group is stored in a `selected_group_id` HTTP-only cookie.
+1. The logged-in group is stored in a `selected_group_id` HTTP-only cookie.
 2. Server actions call `getAuthenticatedSupabaseClient()` (`lib/group-auth.ts`), which reads the cookie and returns a Supabase client carrying a **custom JWT** embedding `app_metadata.ringing_group_id`.
-3. All RLS policies on the database read `ringing_group_id` from this JWT — so the database itself enforces data isolation.
+3. RLS policies on the database read `ringing_group_id` from this JWT — so the database itself enforces data isolation.
 4. Clients are cached in an LRU cache (100 entries, 5-minute TTL) to avoid re-signing JWTs on every request.
+
+### Cross-group data sharing
+
+Groups can grant other groups read access to their data via the `GroupDataSharing` table (`from_group_id` → `to_group_id`). The relationship is non-commutative and non-transitive. The JWT always carries the **logged-in** group's ID; RLS policies allow reading shared data via a `GroupDataSharing` EXISTS check, without switching the JWT.
+
+`loggedInGroupId` = group from the cookie (always the authenticated user's group).
+`viewedGroupId` = group whose data is currently being displayed (may differ when browsing another group's pages).
 
 **Important:** Multi-tenancy via RLS is only partially implemented. See [issue #149](https://github.com/wheresrhys/totf/issues/149) for current status. Do not assume that all tables are fully isolated — verify before adding features that rely on group isolation.
 
@@ -43,6 +50,7 @@ Tables (PascalCase in Postgres, matching generated TypeScript types in `types/su
 | `Sessions` | A ringing session (date + location) |
 | `Encounters` | One bird captured once in one session, with measurements |
 | `Locations` | Ringing sites, owned by a group |
+| `GroupDataSharing` | Non-commutative read-access grants between groups (`from_group_id` shares data with `to_group_id`) |
 
 Key design notes:
 - `Birds.ringing_group_ids` is a Postgres array column (GIN-indexed) — a bird belongs to one or more groups.
@@ -71,6 +79,16 @@ The authoritative schema lives in `supabase/schema/` as declarative SQL files, o
 - Errors from Supabase calls are handled via `catchSupabaseErrors()`.
 - RPC calls go through `.rpc('function_name', args)` on the Supabase client.
 - TypeScript types for DB rows come from `app/models/db.ts`, which re-exports from the auto-generated types.
+
+## Route structure
+
+- Own-group pages: `/`, `/sessions`, `/species`, `/species/[name]`, `/effort`, `/mistakes`, `/retraps`
+- Cross-group pages: `/group/[id]/`, `/group/[id]/sessions`, `/group/[id]/species`, etc.
+- Session detail: `/group/[id]/session/[date]` and `/group/[id]/session/[date]/site/[locationId]`
+- Bird detail: `/bird/[ring]` — always global, no group prefix
+- Import: own-group only, no cross-group variant
+
+Cross-group pages live in `app/group/[id]/`. Thin page wrappers import own-group page components and pass `viewedGroupId` extracted from URL params. `app/group/[id]/layout.tsx` enforces authorization (checks `GroupDataSharing` row exists).
 
 ## Code conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Tables (PascalCase in Postgres, matching generated TypeScript types in `types/su
 | `Sessions` | A ringing session (date + location) |
 | `Encounters` | One bird captured once in one session, with measurements |
 | `Locations` | Ringing sites, owned by a group |
-| `GroupDataSharing` | Non-commutative read-access grants between groups (`from_group_id` shares data with `to_group_id`) |
+| `GroupDataSharing` | Non-commutative read-access grants between groups (`granter_group_id` shares data with `recipient_group_id`) |
 
 Key design notes:
 - `Birds.ringing_group_ids` is a Postgres array column (GIN-indexed) — a bird belongs to one or more groups.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ There are no per-person logins. Authentication is group-scoped:
 
 ### Cross-group data sharing
 
-Groups can grant other groups read access to their data via the `GroupDataSharing` table (`from_group_id` → `to_group_id`). The relationship is non-commutative and non-transitive. The JWT always carries the **logged-in** group's ID; RLS policies allow reading shared data via a `GroupDataSharing` EXISTS check, without switching the JWT.
+Groups can grant other groups read access to their data via the `GroupDataSharing` table (`granter_group_id` → `recipient_group_id`). The relationship is non-commutative and non-transitive. The JWT always carries the **logged-in** group's ID; RLS policies allow reading shared data via a `GroupDataSharing` EXISTS check, without switching the JWT.
 
 `loggedInGroupId` = group from the cookie (always the authenticated user's group).
 `viewedGroupId` = group whose data is currently being displayed (may differ when browsing another group's pages).

--- a/app/components/layout/GlobalNav.tsx
+++ b/app/components/layout/GlobalNav.tsx
@@ -6,23 +6,30 @@ import { RingSearchForm } from '@/app/components/shared/RingSearchForm';
 import { useSetRingingGroup } from './RingingGroupProvider';
 import { logout } from '@/app/actions/logout';
 import type { RingingGroupRow } from '@/app/models/db';
-export function NavItems({ classes }: { classes: string }) {
+
+export function NavItems({
+	classes,
+	basePath = ''
+}: {
+	classes: string;
+	basePath?: string;
+}) {
 	return (
 		<ul className={classes}>
 			<li>
-				<NoPrefetchLink href="/sessions">Sessions</NoPrefetchLink>
+				<NoPrefetchLink href={`${basePath}/sessions`}>Sessions</NoPrefetchLink>
 			</li>
 			<li>
-				<NoPrefetchLink href="/species">Species</NoPrefetchLink>
+				<NoPrefetchLink href={`${basePath}/species`}>Species</NoPrefetchLink>
 			</li>
 			<li>
-				<NoPrefetchLink href="/mistakes">Mistakes</NoPrefetchLink>
+				<NoPrefetchLink href={`${basePath}/mistakes`}>Mistakes</NoPrefetchLink>
 			</li>
 			<li>
-				<NoPrefetchLink href="/retraps">Retraps</NoPrefetchLink>
+				<NoPrefetchLink href={`${basePath}/retraps`}>Retraps</NoPrefetchLink>
 			</li>
 			<li>
-				<NoPrefetchLink href="/effort">Effort</NoPrefetchLink>
+				<NoPrefetchLink href={`${basePath}/effort`}>Effort</NoPrefetchLink>
 			</li>
 		</ul>
 	);
@@ -49,20 +56,27 @@ function Expander({
 
 function GroupSwitcher({
 	groups,
-	selectedGroupId,
+	loggedInGroupId,
+	selectedValue,
 	onChange
 }: {
 	groups: RingingGroupRow[];
-	selectedGroupId: number | null;
+	loggedInGroupId: number | null;
+	selectedValue: number | null;
 	onChange: () => void;
 }) {
 	const router = useRouter();
 	const setRingingGroup = useSetRingingGroup();
+
 	async function handleChange(e: React.ChangeEvent<HTMLSelectElement>) {
 		const groupId = parseInt(e.target.value, 10);
-		await setRingingGroup(groupId);
 		onChange();
-		router.refresh();
+		if (groupId === loggedInGroupId) {
+			await setRingingGroup(groupId);
+			router.push('/');
+		} else {
+			router.push(`/group/${groupId}`);
+		}
 	}
 
 	if (groups.length === 1) {
@@ -72,11 +86,11 @@ function GroupSwitcher({
 	return (
 		<select
 			className="select select-bordered md:w-1/3"
-			value={selectedGroupId ?? ''}
+			value={selectedValue ?? ''}
 			onChange={handleChange}
 			aria-label="Select ringing group"
 		>
-			{selectedGroupId === null && (
+			{selectedValue === null && (
 				<option value="" disabled>
 					Select group
 				</option>
@@ -115,10 +129,10 @@ function expanderReducer(
 
 export default function GlobalNav({
 	groups,
-	selectedGroupId
+	loggedInGroupId
 }: {
 	groups: RingingGroupRow[];
-	selectedGroupId: number | null;
+	loggedInGroupId: number | null;
 }) {
 	const pathname = usePathname();
 	const router = useRouter();
@@ -126,31 +140,36 @@ export default function GlobalNav({
 	const [expanders, expandersDispatch] = useReducer(expanderReducer, {
 		search: false,
 		mobileNav: false,
-		userMenu: !selectedGroupId
+		userMenu: !loggedInGroupId
 	} as Record<ExpanderId, boolean>);
 	const groupsCount = groups.length;
 	const firstGroupId = groups[0].id;
 	const searchInputRef = useRef<HTMLInputElement>(null);
-	const selectedGroup = groups.find(
-		(group) => group.id === selectedGroupId
-	) as RingingGroupRow;
+
+	const crossGroupMatch = pathname.match(/^\/group\/(\d+)/);
+	const viewedGroupId = crossGroupMatch ? Number(crossGroupMatch[1]) : null;
+	const basePath = viewedGroupId ? `/group/${viewedGroupId}` : '';
+	const displayGroupId = viewedGroupId ?? loggedInGroupId;
+	const displayGroup = groups.find((g) => g.id === displayGroupId) as
+		| RingingGroupRow
+		| undefined;
 
 	// Reset expandable UI state when route changes
 	useEffect(() => {
 		expandersDispatch({
 			type: 'set',
 			id: 'userMenu',
-			value: !selectedGroupId
+			value: !loggedInGroupId
 		});
-	}, [pathname, selectedGroupId]);
+	}, [pathname, loggedInGroupId]);
 
 	useEffect(() => {
-		if (groupsCount === 1 && selectedGroupId !== firstGroupId) {
+		if (groupsCount === 1 && loggedInGroupId !== firstGroupId) {
 			setRingingGroup(firstGroupId).then(() => {
 				router.refresh();
 			});
 		}
-	}, [groupsCount, firstGroupId, selectedGroupId, router, setRingingGroup]);
+	}, [groupsCount, firstGroupId, loggedInGroupId, router, setRingingGroup]);
 
 	useEffect(() => {
 		if (expanders.search) {
@@ -163,14 +182,14 @@ export default function GlobalNav({
 				<div className="w-full flex px-6 py-4">
 					<NoPrefetchLink
 						className="link text-base-content link-neutral text-xl font-bold no-underline flex items-center gap-2 text-nowrap"
-						href="/"
+						href={basePath || '/'}
 					>
 						<span className="mr-2 icon-[fluent-emoji-flat--blackbird] size-8 flex-shrink-0 flex-grow-0"></span>
 						<span className="flex items-center gap-x-2 flex-wrap">
 							<span>Top of the Flocks</span>
-							{selectedGroupId ? (
+							{displayGroup ? (
 								<span className="text-sm font-medium">
-									{selectedGroup.group_name}
+									{displayGroup.group_name}
 								</span>
 							) : null}
 						</span>
@@ -209,7 +228,10 @@ export default function GlobalNav({
 							<RingSearchForm />
 						</div>
 						<div className="hidden md:flex">
-							<NavItems classes="menu menu-horizontal gap-2 p-0 text-base" />
+							<NavItems
+								classes="menu menu-horizontal gap-2 p-0 text-base"
+								basePath={basePath}
+							/>
 						</div>
 						<button
 							type="button"
@@ -225,7 +247,10 @@ export default function GlobalNav({
 					</div>
 				</div>
 				<Expander id="mobile-nav" isExpanded={expanders.mobileNav}>
-					<NavItems classes="p-4 text-right *:p-2 *:mt-1 *:mb-1 *:hover:bg-base-200 *:rounded" />
+					<NavItems
+						classes="p-4 text-right *:p-2 *:mt-1 *:mb-1 *:hover:bg-base-200 *:rounded"
+						basePath={basePath}
+					/>
 				</Expander>
 				<Expander id="ring-search-form-wrapper" isExpanded={expanders.search}>
 					<div className="p-4 pt-0">
@@ -241,7 +266,8 @@ export default function GlobalNav({
 						{groups.length > 1 && (
 							<GroupSwitcher
 								groups={groups}
-								selectedGroupId={selectedGroupId}
+								loggedInGroupId={loggedInGroupId}
+								selectedValue={viewedGroupId ?? loggedInGroupId}
 								onChange={() => expandersDispatch({ type: 'collapseAll' })}
 							/>
 						)}

--- a/app/group/[groupId]/layout.tsx
+++ b/app/group/[groupId]/layout.tsx
@@ -1,18 +1,33 @@
-import { redirect } from 'next/navigation';
+import { notFound, redirect } from 'next/navigation';
 import { getGroupCookie } from '@/app/actions/group-cookie';
+import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 
 export default async function CrossGroupLayout({
-	children
+	children,
+	params
 }: {
 	children: React.ReactNode;
 	params: Promise<{ groupId: string }>;
 }) {
+	const { groupId } = await params;
+	const viewedGroupId = Number(groupId);
 	const loggedInGroupId = await getGroupCookie();
 
 	if (!loggedInGroupId) {
 		redirect('/');
 	}
 
-	// Cross-group access control (GroupDataSharing check) added in PR #250
+	const supabase = await getAuthenticatedSupabaseClient();
+	const { data } = await supabase
+		.from('GroupDataSharing')
+		.select('id')
+		.eq('granter_group_id', viewedGroupId)
+		.eq('recipient_group_id', loggedInGroupId)
+		.maybeSingle();
+
+	if (!data) {
+		notFound();
+	}
+
 	return children;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import GlobalNav from './components/layout/GlobalNav';
 import LoadFlyonUI from './components/layout/LoadFlyonUI';
 import { Suspense } from 'react';
 import { supabase, catchSupabaseErrors } from '@/lib/supabase';
+import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { RingingGroupProvider } from './components/layout/RingingGroupProvider';
 import { getGroupCookie } from './actions/group-cookie';
 import { LoginModal } from './components/layout/LoginModal';
@@ -21,22 +22,40 @@ async function fetchRingingGroups(): Promise<RingingGroupRow[]> {
 		.then(catchSupabaseErrors) as Promise<RingingGroupRow[]>;
 }
 
+async function fetchAccessibleGroups(
+	allGroups: RingingGroupRow[]
+): Promise<RingingGroupRow[]> {
+	const authenticatedClient = await getAuthenticatedSupabaseClient();
+	const sharingRows = (await authenticatedClient
+		.from('GroupDataSharing')
+		.select('granter_group_id')
+		.then(catchSupabaseErrors)) as { granter_group_id: number }[];
+
+	if (!sharingRows || sharingRows.length === 0) return [];
+	const accessibleIds = new Set(sharingRows.map((r) => r.granter_group_id));
+	return allGroups.filter((g) => accessibleIds.has(g.id));
+}
+
 async function AuthorisedView({ children }: { children: React.ReactNode }) {
-	const [initialGroupId, groups] = await Promise.all([
+	const [loggedInGroupId, allGroups] = await Promise.all([
 		getGroupCookie(),
 		fetchRingingGroups()
 	]);
 
-	if (!initialGroupId) {
-		return <LoginModal groups={groups} />;
+	if (!loggedInGroupId) {
+		return <LoginModal groups={allGroups} />;
 	}
 
-	const selectedGroup = groups.find((g) => g.id === initialGroupId)!;
+	const ownGroup = allGroups.find((g) => g.id === loggedInGroupId)!;
+	const accessibleGroups = await fetchAccessibleGroups(allGroups);
 
 	return (
 		<Suspense>
-			<RingingGroupProvider initialGroupId={initialGroupId}>
-				<GlobalNav groups={[selectedGroup]} selectedGroupId={initialGroupId} />
+			<RingingGroupProvider initialGroupId={loggedInGroupId}>
+				<GlobalNav
+					groups={[ownGroup, ...accessibleGroups]}
+					loggedInGroupId={loggedInGroupId}
+				/>
 				{children}
 			</RingingGroupProvider>
 		</Suspense>


### PR DESCRIPTION
## Summary

- Root layout (`app/layout.tsx`) now fetches `GroupDataSharing` rows after login and passes own group + all accessible groups to `GlobalNav`
- `GlobalNav` detects cross-group mode from the current pathname (`/group/[id]/...`) and:
  - Prefixes all nav links with `/group/[id]` so they navigate within the viewed group's pages
  - Shows the viewed group's name in the header instead of the logged-in group's name
  - Points the header home link to `/group/[id]` instead of `/`
  - In the group picker: selecting own group navigates to `/` and updates the cookie; selecting another group navigates to `/group/[id]` without changing the cookie
- `GroupSwitcher` is hidden when there is only one group available (own group with no sharing relationships)

## Test plan
- [ ] `npm run qa` passes
- [ ] With a `GroupDataSharing` row in the DB, verify the accessible group appears in the picker
- [ ] Select another group — verify you land on `/group/[id]/` with that group's data and nav links
- [ ] Navigate through sessions, species, effort, mistakes, retraps — verify they all stay within `/group/[id]/`
- [ ] Select own group from picker — verify redirect to `/` and data reverts to own group
- [ ] With no sharing rows, verify the group picker is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)