### PR TITLE
fix: resolve blocking-route build error and flaky test

### DIFF
--- a/app/components/layout/BootstrapPageData.tsx
+++ b/app/components/layout/BootstrapPageData.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
+import { connection } from 'next/server';
 import { getGroupCookie } from '@/app/actions/group-cookie';
 
 export type DefaultPageParams = Record<string, string>;
@@ -81,6 +82,7 @@ export async function LoadWithData<DataType, PagePropsType, ParamsType>({
 		params = {} as ParamsType;
 	}
 
+	await connection();
 	const loggedInGroupId = await getGroupCookie();
 	const viewedGroupId = viewedGroupIdProp ?? loggedInGroupId;
 	const cacheKeys = getCacheKeys(params);

--- a/app/components/layout/__mocks__/BootstrapPageData.tsx
+++ b/app/components/layout/__mocks__/BootstrapPageData.tsx
@@ -16,6 +16,8 @@ export function BootstrapPageData<
 	const [isLoading, setIsLoading] = useState(true);
 
 	useEffect(() => {
+		let mounted = true;
+
 		async function loadData() {
 			try {
 				let resolvedParams: ParamsType;
@@ -31,18 +33,23 @@ export function BootstrapPageData<
 					resolvedParams = {} as ParamsType;
 				}
 
+				if (!mounted) return;
 				setParams(resolvedParams);
 				const fetchedData = await bootstrapProps.dataFetcher(resolvedParams, 1);
+				if (!mounted) return;
 				setData(fetchedData);
 			} catch (error) {
 				console.error('Error loading data in BootstrapPageData mock:', error);
-				setData(null);
+				if (mounted) setData(null);
 			} finally {
-				setIsLoading(false);
+				if (mounted) setIsLoading(false);
 			}
 		}
 
 		loadData();
+		return () => {
+			mounted = false;
+		};
 	}, [bootstrapProps]);
 
 	if (isLoading) {


### PR DESCRIPTION
## Summary

- Adds `await connection()` to `LoadWithData` in `BootstrapPageData.tsx` before accessing cookies, fixing the Next.js 16 build error: _Route "/bird/[ring]": Uncached data was accessed outside of `<Suspense>`_
- Fixes a flaky test failure (~30% of runs) in the `BootstrapPageData` mock: async state setters (`setIsLoading`, `setData`) were being called after the component unmounted during test teardown, causing unhandled rejections that made the test suite exit with code 1

## Root causes

**Build error**: `cacheComponents: true` in `next.config.ts` enables Next.js 16 Cache Components mode, which requires components accessing request-scoped data (cookies) to establish a dynamic request boundary via `connection()` before doing so. `LoadWithData` was already inside a `<Suspense>` boundary but needed the explicit `connection()` call.

**Flaky test**: The `BootstrapPageData` mock's `useEffect` started an async `loadData()` function but had no cleanup. If the component unmounted while data was still loading, the `finally { setIsLoading(false) }` block would attempt a state update on an unmounted component. Fixed with a `mounted` flag and cleanup function.

Closes no issue (bug fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)