### PR TITLE
test: unauthenticated redirect tests (HTTP, Vitest)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,19 +104,19 @@ Three separate Vitest configs:
 |---|---|---|---|
 | App tests | `vitest.config.ts` | `npm run test:nowatch` | pre-push hook + CI |
 | DB integration tests | `vitest.integration.config.ts` | `npm run test:integration` | pre-push hook (requires local Supabase) |
-| HTTP tests | `vitest.http.config.ts` | `npm run test:http` | manually (requires Next.js dev server) |
+| HTTP tests | `vitest.http.config.ts` | `npm run test:http` | manually (auto-starts Next.js dev server if not running) |
 
 ```sh
 npm test              # watch mode (app tests only)
 npm run test:nowatch  # single run (app tests)
 npm run test:integration  # DB integration tests against local Supabase
-npm run test:http     # HTTP tests against local Next.js dev server (run npm run next:dev first)
+npm run test:http     # HTTP tests — starts dev server automatically if needed
 npm run qa            # lint + type-check + app tests
 ```
 
 The pre-push hook runs app tests and DB integration tests. Local Supabase must be running (`npm run db:start:local`) and seeded (`npm run db:seed:e2e`) for integration tests to pass.
 
-HTTP tests (`http-tests/`) require the Next.js dev server running at `http://localhost:3000` (or `TEST_BASE_URL` env var).
+HTTP tests (`http-tests/`) use `http-tests/global-setup.ts` to start/stop the Next.js dev server automatically. If a server is already running at `http://localhost:3000` (or `TEST_BASE_URL`), it reuses it and does not kill it after the suite.
 
 ### App tests (Vitest + happy-dom)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,21 +98,25 @@ You will need to ask your human to run `op signin` first
 
 ### Test suites
 
-Two separate Vitest configs:
+Three separate Vitest configs:
 
 | Suite | Config | Command | Runs in |
 |---|---|---|---|
 | App tests | `vitest.config.ts` | `npm run test:nowatch` | pre-push hook + CI |
 | DB integration tests | `vitest.integration.config.ts` | `npm run test:integration` | pre-push hook (requires local Supabase) |
+| HTTP tests | `vitest.http.config.ts` | `npm run test:http` | manually (requires Next.js dev server) |
 
 ```sh
 npm test              # watch mode (app tests only)
 npm run test:nowatch  # single run (app tests)
 npm run test:integration  # DB integration tests against local Supabase
+npm run test:http     # HTTP tests against local Next.js dev server (run npm run next:dev first)
 npm run qa            # lint + type-check + app tests
 ```
 
-The pre-push hook runs both suites. Local Supabase must be running (`npm run db:start:local`) and seeded (`npm run db:seed:e2e`) for integration tests to pass.
+The pre-push hook runs app tests and DB integration tests. Local Supabase must be running (`npm run db:start:local`) and seeded (`npm run db:seed:e2e`) for integration tests to pass.
+
+HTTP tests (`http-tests/`) require the Next.js dev server running at `http://localhost:3000` (or `TEST_BASE_URL` env var).
 
 ### App tests (Vitest + happy-dom)
 

--- a/http-tests/global-setup.ts
+++ b/http-tests/global-setup.ts
@@ -1,0 +1,37 @@
+import { spawn } from 'child_process'
+import type { ChildProcess } from 'child_process'
+
+const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000'
+
+async function isServerRunning(): Promise<boolean> {
+  try {
+    await fetch(BASE_URL)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function waitForServer(timeoutMs = 120_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (await isServerRunning()) return
+    await new Promise((r) => setTimeout(r, 1000))
+  }
+  throw new Error(`Server at ${BASE_URL} did not start within ${timeoutMs}ms`)
+}
+
+let serverProcess: ChildProcess | null = null
+
+export async function setup() {
+  if (await isServerRunning()) return
+  serverProcess = spawn('npm', ['run', 'next:dev'], {
+    stdio: 'inherit',
+    detached: false,
+  })
+  await waitForServer()
+}
+
+export async function teardown() {
+  serverProcess?.kill()
+}

--- a/http-tests/unauthenticated-redirects.test.ts
+++ b/http-tests/unauthenticated-redirects.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from 'vitest'
+
+const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000'
+
+const LOGIN_MODAL_TEXT = 'Login to your group'
+
+const ownGroupRoutes = [
+  '/',
+  '/bird',
+  '/bird/A123456',
+  '/species',
+  '/species/Blue%20Tit',
+  '/effort',
+  '/mistakes',
+  '/retraps',
+  '/sessions',
+]
+
+const crossGroupRoutes = [
+  '/group/1',
+  '/group/1/species',
+  '/group/1/species/Blue%20Tit',
+  '/group/1/effort',
+  '/group/1/mistakes',
+  '/group/1/retraps',
+  '/group/1/sessions',
+  '/group/1/session/2024-01-01',
+  '/group/1/session/2024-01-01/site/1',
+]
+
+describe('own-group routes (unauthenticated)', () => {
+  test.each(ownGroupRoutes)('%s shows login modal', async (route) => {
+    const response = await fetch(BASE_URL + route)
+    expect(response.status).toBe(200)
+    const body = await response.text()
+    expect(body).toContain(LOGIN_MODAL_TEXT)
+  })
+})
+
+describe('cross-group routes (unauthenticated)', () => {
+  test.each(crossGroupRoutes)('%s redirects', async (route) => {
+    const response = await fetch(BASE_URL + route, { redirect: 'manual' })
+    expect(response.status).toBeGreaterThanOrEqual(300)
+    expect(response.status).toBeLessThan(400)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"test": "dotenvx run -f .env.dev -- vitest",
 		"test:nowatch": "dotenvx run -f .env.dev -- vitest run",
 		"test:integration": "dotenvx run -f .env.dev -- vitest run --config vitest.integration.config.ts",
-		"test:http": "dotenvx run -f .env.dev -- vitest run --config vitest.http.config.ts",
+		"test:http": "vitest run --config vitest.http.config.ts",
 		"qa": "npm run lint && npm run type:check && npm run test:nowatch",
 		"prepare": "husky"
 	},

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"test": "dotenvx run -f .env.dev -- vitest",
 		"test:nowatch": "dotenvx run -f .env.dev -- vitest run",
 		"test:integration": "dotenvx run -f .env.dev -- vitest run --config vitest.integration.config.ts",
+		"test:http": "dotenvx run -f .env.dev -- vitest run --config vitest.http.config.ts",
 		"qa": "npm run lint && npm run type:check && npm run test:nowatch",
 		"prepare": "husky"
 	},

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
   test: {
     setupFiles: ['./vitest.setup.tsx'],
     environment: 'happy-dom',
-    exclude: ['**/node_modules/**', 'supabase/__tests__/**'],
+    exclude: ['**/node_modules/**', 'supabase/__tests__/**', 'http-tests/**'],
   },
 })

--- a/vitest.http.config.ts
+++ b/vitest.http.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     include: ['http-tests/**/*.test.ts'],
     environment: 'node',
+    globalSetup: ['./http-tests/global-setup.ts'],
   },
 })

--- a/vitest.http.config.ts
+++ b/vitest.http.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+import tsconfigPaths from 'vite-tsconfig-paths'
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    include: ['http-tests/**/*.test.ts'],
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary

- Adds `http-tests/unauthenticated-redirects.test.ts` covering all 18 URL patterns
- Own-group routes (`/`, `/species`, etc.): assert login modal shown (200 with "Login to your group")
- Cross-group routes (`/group/[id]/...`): assert 3xx redirect
- New `vitest.http.config.ts` with `npm run test:http` script; excluded from main suite (requires Next.js dev server at `http://localhost:3000` or `TEST_BASE_URL`)
- CLAUDE.md updated to document the third test suite

## Test plan

- [ ] Start dev server: `npm run next:dev`
- [ ] Run `npm run test:http` — all 18 tests pass
- [ ] Run `npm run qa` — still passes (HTTP tests excluded from main suite)

Closes #260
🤖 Generated with [Claude Code](https://claude.com/claude-code)