### PR TITLE
test: E2E tests for authenticated routes (tests/9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ supabase/migrations
 e2e/.auth/
 playwright-report/
 test-results/
+e2e/group-ids.json

--- a/app/components/SessionHistoryCalendar.tsx
+++ b/app/components/SessionHistoryCalendar.tsx
@@ -115,7 +115,7 @@ export function SessionHistoryCalendar({
 	viewedGroupId: number;
 }) {
 	const calendar = groupByYear(sessions || []).map(groupByMonth);
-	const thisYearString = getYearString(calendar[0]);
+	const thisYearString = calendar[0] ? getYearString(calendar[0]) : false;
 	const [expandedYear, setExpandedYear] = useState<string | false>(
 		thisYearString
 	);
@@ -123,6 +123,10 @@ export function SessionHistoryCalendar({
 	useEffect(() => {
 		setExpandedYear(thisYearString);
 	}, [thisYearString]);
+
+	if (calendar.length === 0) {
+		return null;
+	}
 
 	return (
 		<ol>

--- a/app/components/SessionHistoryCalendar.tsx
+++ b/app/components/SessionHistoryCalendar.tsx
@@ -125,7 +125,7 @@ export function SessionHistoryCalendar({
 	}, [thisYearString]);
 
 	if (calendar.length === 0) {
-		return null;
+		return <p>No session data available.</p>;
 	}
 
 	return (

--- a/e2e/authenticated/bird.spec.ts
+++ b/e2e/authenticated/bird.spec.ts
@@ -1,0 +1,71 @@
+import { test, expect } from '@playwright/test'
+
+const project = () => test.info().project.name
+
+test.describe('bird search', () => {
+	test('alpha: exact ring match redirects to bird page', async ({ page }) => {
+		test.skip(project() !== 'alpha', 'alpha only')
+		await page.goto('/bird?q=ARRETRAP')
+		await expect(page).toHaveURL(/\/bird\/ARRETRAP/i)
+	})
+
+	test('beta: partial match shows search results', async ({ page }) => {
+		test.skip(project() !== 'beta', 'beta only')
+		await page.goto('/bird?q=BCHAF')
+		await expect(
+			page.getByRole('heading', { name: 'Search results' })
+		).toBeVisible()
+	})
+
+	test('gamma: no own birds — search yields no results', async ({ page }) => {
+		test.skip(project() !== 'gamma', 'gamma only')
+		await page.goto('/bird?q=ARRETRAP')
+		// Gamma cannot see Alpha's birds; fuzzy search returns empty
+		await expect(
+			page.getByRole('heading', { name: 'Search results' })
+		).toBeVisible()
+		await expect(page.getByRole('link', { name: /ARRETRAP/i })).not.toBeVisible()
+	})
+})
+
+test.describe('ARRETRAP bird page', () => {
+	test('alpha: shows Robin with multiple encounters', async ({ page }) => {
+		test.skip(project() !== 'alpha', 'alpha only')
+		await page.goto('/bird/ARRETRAP')
+		await expect(page.getByRole('heading', { name: /Robin.*ARRETRAP/i })).toBeVisible()
+		await expect(page.getByText('9 encounters')).toBeVisible()
+	})
+
+	test('beta: cannot see ARRETRAP (Alpha bird, no reverse share)', async ({ page }) => {
+		test.skip(project() !== 'beta', 'beta only')
+		await page.goto('/bird/ARRETRAP')
+		// Beta can see the bird record (ringing_group_ids includes alphaId which Beta can read)
+		// but encounters from Alpha should NOT be filtered to zero (Beta sees Alpha encounters via sharing)
+		await expect(page.getByRole('heading', { name: /Robin.*ARRETRAP/i })).toBeVisible()
+	})
+})
+
+test.describe('SHARED01 bird page (shared across Alpha and Beta)', () => {
+	test('alpha: sees own encounter only', async ({ page }) => {
+		test.skip(project() !== 'alpha', 'alpha only')
+		await page.goto('/bird/SHARED01')
+		await expect(page.getByRole('heading', { name: /Robin.*SHARED01/i })).toBeVisible()
+		await expect(page.getByText('1 encounter')).toBeVisible()
+	})
+
+	test('beta: sees Alpha and Beta encounters', async ({ page }) => {
+		test.skip(project() !== 'beta', 'beta only')
+		await page.goto('/bird/SHARED01')
+		await expect(page.getByRole('heading', { name: /Robin.*SHARED01/i })).toBeVisible()
+		await expect(page.getByText('2 encounters')).toBeVisible()
+		await expect(page.getByText('1 from another group')).toBeVisible()
+	})
+
+	test('gamma: sees only Beta encounter', async ({ page }) => {
+		test.skip(project() !== 'gamma', 'gamma only')
+		await page.goto('/bird/SHARED01')
+		await expect(page.getByRole('heading', { name: /Robin.*SHARED01/i })).toBeVisible()
+		await expect(page.getByText('1 encounter')).toBeVisible()
+		await expect(page.getByText('1 from another group')).toBeVisible()
+	})
+})

--- a/e2e/authenticated/cross-group.spec.ts
+++ b/e2e/authenticated/cross-group.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from '@playwright/test'
+import { alphaId, betaId, gammaId } from '../helpers/group-ids'
+
+const project = () => test.info().project.name
+
+test.describe('/group/[id] home redirect for own group', () => {
+	test('alpha: own group home redirects to /', async ({ page }) => {
+		test.skip(project() !== 'alpha', 'alpha only')
+		await page.goto(`/group/${alphaId}`)
+		await expect(page).toHaveURL('/')
+	})
+
+	test('beta: own group home redirects to /', async ({ page }) => {
+		test.skip(project() !== 'beta', 'beta only')
+		await page.goto(`/group/${betaId}`)
+		await expect(page).toHaveURL('/')
+	})
+
+	test('gamma: own group home redirects to /', async ({ page }) => {
+		test.skip(project() !== 'gamma', 'gamma only')
+		await page.goto(`/group/${gammaId}`)
+		await expect(page).toHaveURL('/')
+	})
+})
+
+test.describe('/group/[alphaId]/sessions — Alpha shares with Beta', () => {
+	test('beta: sees Alpha sessions (share exists)', async ({ page }) => {
+		test.skip(project() !== 'beta', 'beta only')
+		await page.goto(`/group/${alphaId}/sessions`)
+		await expect(
+			page.getByRole('heading', { name: 'Session history' })
+		).toBeVisible()
+		await expect(page.getByText('2021')).toBeVisible()
+		await expect(page.getByText('2024')).toBeVisible()
+	})
+
+	test('gamma: sees no Alpha sessions (no transitive share)', async ({ page }) => {
+		test.skip(project() !== 'gamma', 'gamma only')
+		await page.goto(`/group/${alphaId}/sessions`)
+		await expect(
+			page.getByRole('heading', { name: 'Session history' })
+		).toBeVisible()
+		await expect(page.getByText('2021')).not.toBeVisible()
+		await expect(page.getByText('2024')).not.toBeVisible()
+	})
+
+	test('alpha: own sessions visible (no redirect on sub-pages)', async ({ page }) => {
+		test.skip(project() !== 'alpha', 'alpha only')
+		await page.goto(`/group/${alphaId}/sessions`)
+		await expect(
+			page.getByRole('heading', { name: 'Session history' })
+		).toBeVisible()
+		await expect(page.getByText('2021')).toBeVisible()
+	})
+})
+
+test.describe('/group/[betaId]/sessions — Beta shares with Gamma', () => {
+	test('gamma: sees Beta sessions (share exists)', async ({ page }) => {
+		test.skip(project() !== 'gamma', 'gamma only')
+		await page.goto(`/group/${betaId}/sessions`)
+		await expect(
+			page.getByRole('heading', { name: 'Session history' })
+		).toBeVisible()
+		await expect(page.getByText('2023')).toBeVisible()
+	})
+
+	test('alpha: sees no Beta sessions (no reverse share)', async ({ page }) => {
+		test.skip(project() !== 'alpha', 'alpha only')
+		await page.goto(`/group/${betaId}/sessions`)
+		await expect(
+			page.getByRole('heading', { name: 'Session history' })
+		).toBeVisible()
+		await expect(page.getByText('2023')).not.toBeVisible()
+	})
+})
+
+test.describe('/group/[alphaId] home — cross-group data visibility', () => {
+	test('beta: sees Alpha home data (share exists)', async ({ page }) => {
+		test.skip(project() !== 'beta', 'beta only')
+		await page.goto(`/group/${alphaId}`)
+		await expect(page).not.toHaveURL('/')
+		await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
+		// Alpha's most recent session is 2024-05-10
+		await expect(page.getByRole('link', { name: /10th May/ })).toBeVisible()
+	})
+
+	test('gamma: sees no Alpha data (no share)', async ({ page }) => {
+		test.skip(project() !== 'gamma', 'gamma only')
+		await page.goto(`/group/${alphaId}`)
+		await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
+		await expect(page.getByRole('link', { name: /10th May/ })).not.toBeVisible()
+	})
+})
+
+test.describe('/group/[betaId] home — cross-group data visibility', () => {
+	test('gamma: sees Beta home data (share exists)', async ({ page }) => {
+		test.skip(project() !== 'gamma', 'gamma only')
+		await page.goto(`/group/${betaId}`)
+		await expect(page).not.toHaveURL('/')
+		await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
+		// Beta's session is 2023-06-01
+		await expect(page.getByRole('link', { name: /1st June/ })).toBeVisible()
+	})
+
+	test('alpha: sees no Beta data (no reverse share)', async ({ page }) => {
+		test.skip(project() !== 'alpha', 'alpha only')
+		await page.goto(`/group/${betaId}`)
+		await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
+		await expect(page.getByRole('link', { name: /1st June/ })).not.toBeVisible()
+	})
+})
+
+test.describe('/group/[gammaId] home — Gamma has no data', () => {
+	test('alpha: sees empty Gamma home (no share)', async ({ page }) => {
+		test.skip(project() !== 'alpha', 'alpha only')
+		await page.goto(`/group/${gammaId}`)
+		await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
+		await expect(page.getByRole('link', { name: /10th May/ })).not.toBeVisible()
+		await expect(page.getByRole('link', { name: /1st June/ })).not.toBeVisible()
+	})
+
+	test('beta: sees empty Gamma home (no share)', async ({ page }) => {
+		test.skip(project() !== 'beta', 'beta only')
+		await page.goto(`/group/${gammaId}`)
+		await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
+		await expect(page.getByRole('link', { name: /1st June/ })).not.toBeVisible()
+	})
+})

--- a/e2e/authenticated/cross-group.spec.ts
+++ b/e2e/authenticated/cross-group.spec.ts
@@ -40,8 +40,7 @@ test.describe('/group/[alphaId]/sessions — Alpha shares with Beta', () => {
 		await expect(
 			page.getByRole('heading', { name: 'Session history' })
 		).toBeVisible()
-		await expect(page.getByText('2021')).not.toBeVisible()
-		await expect(page.getByText('2024')).not.toBeVisible()
+		await expect(page.getByText('No session data available.')).toBeVisible()
 	})
 
 	test('alpha: own sessions visible (no redirect on sub-pages)', async ({ page }) => {
@@ -70,7 +69,7 @@ test.describe('/group/[betaId]/sessions — Beta shares with Gamma', () => {
 		await expect(
 			page.getByRole('heading', { name: 'Session history' })
 		).toBeVisible()
-		await expect(page.getByText('2023')).not.toBeVisible()
+		await expect(page.getByText('No session data available.')).toBeVisible()
 	})
 })
 

--- a/e2e/authenticated/effort.spec.ts
+++ b/e2e/authenticated/effort.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test'
+
+const project = () => test.info().project.name
+
+test('shows Effort and Pay-off heading', async ({ page }) => {
+	await page.goto('/effort')
+	await expect(
+		page.getByRole('heading', { name: 'Effort and Pay-off' })
+	).toBeVisible()
+})
+
+test('alpha: shows yearly data with non-zero encounter counts', async ({ page }) => {
+	test.skip(project() !== 'alpha', 'alpha only')
+	await page.goto('/effort')
+	await expect(page.getByText('Total ringing effort')).toBeVisible()
+	await expect(page.getByRole('columnheader', { name: '2021' })).toBeVisible()
+	await expect(page.getByRole('columnheader', { name: '2024' })).toBeVisible()
+})
+
+test('beta: shows yearly data with non-zero encounter counts', async ({ page }) => {
+	test.skip(project() !== 'beta', 'beta only')
+	await page.goto('/effort')
+	await expect(page.getByText('Total ringing effort')).toBeVisible()
+	await expect(page.getByRole('columnheader', { name: '2023' })).toBeVisible()
+})
+
+test('gamma: shows table with all-zero encounter counts (no own data)', async ({ page }) => {
+	test.skip(project() !== 'gamma', 'gamma only')
+	await page.goto('/effort')
+	// aggregate_stats returns zero-count rows for all years; no Alpha/Beta data leaks
+	// via ringing_group_filter — only encounters where ringing_group_id = gammaId are counted
+	await expect(page.getByRole('rowheader', { name: 'Encounter count' })).toBeVisible()
+	const encounterRow = page.getByRole('row', { name: /^Encounter count/ })
+	// All year columns must show 0
+	const cells = encounterRow.getByRole('cell')
+	const count = await cells.count()
+	for (let i = 0; i < count; i++) {
+		await expect(cells.nth(i)).toHaveText('0')
+	}
+})

--- a/e2e/authenticated/home.spec.ts
+++ b/e2e/authenticated/home.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test'
+
+const project = () => test.info().project.name
+
+test('shows Recent Sessions heading', async ({ page }) => {
+	await page.goto('/')
+	await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
+})
+
+test('shows stats accordion', async ({ page }) => {
+	await page.goto('/')
+	await expect(page.getByText('Busiest sessions:')).toBeVisible()
+})
+
+test('alpha: shows own recent sessions by date', async ({ page }) => {
+	test.skip(project() !== 'alpha', 'alpha only')
+	await page.goto('/')
+	// Alpha's most recent session is 2024-05-10
+	await expect(page.getByRole('link', { name: /10th May/ })).toBeVisible()
+})
+
+test('beta: shows own recent sessions by date', async ({ page }) => {
+	test.skip(project() !== 'beta', 'beta only')
+	await page.goto('/')
+	// Beta's only session is 2023-06-01
+	await expect(page.getByRole('link', { name: /1st June/ })).toBeVisible()
+})
+
+test('gamma: shows no sessions (empty own data)', async ({ page }) => {
+	test.skip(project() !== 'gamma', 'gamma only')
+	await page.goto('/')
+	// Gamma has no sessions; Alpha/Beta dates must not leak
+	await expect(page.getByRole('link', { name: /10th May/ })).not.toBeVisible()
+	await expect(page.getByRole('link', { name: /1st June/ })).not.toBeVisible()
+})

--- a/e2e/authenticated/mistakes.spec.ts
+++ b/e2e/authenticated/mistakes.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test'
+
+const project = () => test.info().project.name
+
+test('shows Mistakes heading', async ({ page }) => {
+	await page.goto('/mistakes')
+	await expect(page.getByRole('heading', { name: 'Mistakes' })).toBeVisible()
+})
+
+test('alpha: shows discrepancy rows', async ({ page }) => {
+	test.skip(project() !== 'alpha', 'alpha only')
+	await page.goto('/mistakes')
+	// Multiple rows for ABTITMIS (age + sex discrepancy) — use first()
+	await expect(page.getByRole('link', { name: 'ABTITMIS' }).first()).toBeVisible()
+	await expect(page.getByRole('link', { name: 'ARRETRAP' }).first()).toBeVisible()
+})
+
+test('beta: shows empty mistakes table', async ({ page }) => {
+	test.skip(project() !== 'beta', 'beta only')
+	await page.goto('/mistakes')
+	await expect(page.getByRole('link', { name: 'ABTITMIS' })).not.toBeVisible()
+})
+
+test('gamma: shows empty mistakes table', async ({ page }) => {
+	test.skip(project() !== 'gamma', 'gamma only')
+	await page.goto('/mistakes')
+	await expect(page.getByRole('link', { name: 'ABTITMIS' })).not.toBeVisible()
+})

--- a/e2e/authenticated/retraps.spec.ts
+++ b/e2e/authenticated/retraps.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+
+const project = () => test.info().project.name
+
+test('shows Notable Birds heading', async ({ page }) => {
+	await page.goto('/retraps')
+	await expect(page.getByRole('heading', { name: 'Notable Birds' })).toBeVisible()
+})
+
+test('alpha: shows ARRETRAP as notable Robin retrap', async ({ page }) => {
+	test.skip(project() !== 'alpha', 'alpha only')
+	await page.goto('/retraps')
+	await expect(page.getByText('ARRETRAP')).toBeVisible()
+	await expect(page.getByText('Robin')).toBeVisible()
+})
+
+test('beta: shows no notable retraps', async ({ page }) => {
+	test.skip(project() !== 'beta', 'beta only')
+	await page.goto('/retraps')
+	await expect(page.getByText('ARRETRAP')).not.toBeVisible()
+})
+
+test('gamma: shows no notable retraps', async ({ page }) => {
+	test.skip(project() !== 'gamma', 'gamma only')
+	await page.goto('/retraps')
+	await expect(page.getByText('ARRETRAP')).not.toBeVisible()
+})

--- a/e2e/authenticated/sessions.spec.ts
+++ b/e2e/authenticated/sessions.spec.ts
@@ -21,8 +21,8 @@ test('beta: shows sessions in a single year', async ({ page }) => {
 	await expect(page.getByText('2021')).not.toBeVisible()
 })
 
-test('gamma: shows no sessions', async ({ page }) => {
+test('gamma: shows no session data message', async ({ page }) => {
 	test.skip(project() !== 'gamma', 'gamma only')
 	await page.goto('/sessions')
-	await expect(page.getByText('2023')).not.toBeVisible()
+	await expect(page.getByText('No session data available.')).toBeVisible()
 })

--- a/e2e/authenticated/sessions.spec.ts
+++ b/e2e/authenticated/sessions.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test'
+
+const project = () => test.info().project.name
+
+test('shows Session history heading', async ({ page }) => {
+	await page.goto('/sessions')
+	await expect(page.getByRole('heading', { name: 'Session history' })).toBeVisible()
+})
+
+test('alpha: shows sessions across multiple years', async ({ page }) => {
+	test.skip(project() !== 'alpha', 'alpha only')
+	await page.goto('/sessions')
+	await expect(page.getByText('2021')).toBeVisible()
+	await expect(page.getByText('2024')).toBeVisible()
+})
+
+test('beta: shows sessions in a single year', async ({ page }) => {
+	test.skip(project() !== 'beta', 'beta only')
+	await page.goto('/sessions')
+	await expect(page.getByText('2023')).toBeVisible()
+	await expect(page.getByText('2021')).not.toBeVisible()
+})
+
+test('gamma: shows no sessions', async ({ page }) => {
+	test.skip(project() !== 'gamma', 'gamma only')
+	await page.goto('/sessions')
+	await expect(page.getByText('2023')).not.toBeVisible()
+})

--- a/e2e/authenticated/single-species.spec.ts
+++ b/e2e/authenticated/single-species.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test'
+
+const project = () => test.info().project.name
+
+test('shows species name as heading', async ({ page }) => {
+	await page.goto('/species/Robin')
+	await expect(page.getByRole('heading', { name: 'Robin' })).toBeVisible()
+})
+
+test('alpha: shows bird list tab with birds', async ({ page }) => {
+	test.skip(project() !== 'alpha', 'alpha only')
+	await page.goto('/species/Robin')
+	await expect(page.getByRole('button', { name: 'Bird list' })).toBeVisible()
+	await expect(page.getByTestId('infinite-scroll-loader')).toBeVisible()
+})
+
+test('alpha: loads more birds on scroll past loader', async ({ page }) => {
+	test.skip(project() !== 'alpha', 'alpha only')
+	await page.goto('/species/Robin')
+	const loader = page.getByTestId('infinite-scroll-loader')
+	await expect(loader).toBeVisible()
+	await loader.scrollIntoViewIfNeeded()
+	await expect(loader).not.toBeVisible({ timeout: 5000 })
+})
+
+test('beta: shows Robin with limited data', async ({ page }) => {
+	test.skip(project() !== 'beta', 'beta only')
+	await page.goto('/species/Robin')
+	await expect(page.getByRole('button', { name: 'Bird list' })).toBeVisible()
+	await expect(page.getByTestId('infinite-scroll-loader')).not.toBeVisible()
+})
+
+test('gamma: shows not authorised message', async ({ page }) => {
+	test.skip(project() !== 'gamma', 'gamma only')
+	await page.goto('/species/Robin')
+	await expect(
+		page.getByText('Not authorised to view any encounter data for this species')
+	).toBeVisible()
+})

--- a/e2e/authenticated/species.spec.ts
+++ b/e2e/authenticated/species.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test'
+
+const project = () => test.info().project.name
+
+test('alpha: shows full species table', async ({ page }) => {
+	test.skip(project() !== 'alpha', 'alpha only')
+	await page.goto('/species')
+	await expect(page.getByRole('link', { name: 'Blue Tit' })).toBeVisible()
+	await expect(page.getByRole('link', { name: 'Robin' })).toBeVisible()
+	await expect(page.getByRole('link', { name: 'Kingfisher' })).toBeVisible()
+})
+
+test('alpha: does not show Beta species', async ({ page }) => {
+	test.skip(project() !== 'alpha', 'alpha only')
+	await page.goto('/species')
+	await expect(page.getByRole('link', { name: 'Chaffinch' })).not.toBeVisible()
+})
+
+test('beta: shows own sparse species', async ({ page }) => {
+	test.skip(project() !== 'beta', 'beta only')
+	await page.goto('/species')
+	await expect(page.getByRole('link', { name: 'Chaffinch' })).toBeVisible()
+	await expect(page.getByRole('link', { name: 'Robin' })).toBeVisible()
+})
+
+test('beta: does not show Alpha-only species', async ({ page }) => {
+	test.skip(project() !== 'beta', 'beta only')
+	await page.goto('/species')
+	await expect(page.getByRole('link', { name: 'Blue Tit' })).not.toBeVisible()
+	await expect(page.getByRole('link', { name: 'Kingfisher' })).not.toBeVisible()
+})
+
+test('gamma: shows empty species table', async ({ page }) => {
+	test.skip(project() !== 'gamma', 'gamma only')
+	await page.goto('/species')
+	await expect(page.getByRole('link', { name: 'Robin' })).not.toBeVisible()
+	await expect(page.getByRole('link', { name: 'Chaffinch' })).not.toBeVisible()
+})

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process'
-import { mkdirSync } from 'fs'
+import { mkdirSync, writeFileSync } from 'fs'
 import path from 'path'
 
 const ROOT = process.cwd()
@@ -17,11 +17,35 @@ function isAlreadySeeded(): boolean {
 	}
 }
 
+function getGroupIds(): Record<string, number> {
+	const result = execSync(
+		`psql "${LOCAL_DB_URL}" -t -A -F , -c "SELECT lower(group_name), id FROM \\"RingingGroups\\" WHERE group_name IN ('Alpha', 'Beta', 'Gamma') ORDER BY group_name"`,
+		{ encoding: 'utf8' }
+	)
+	const ids: Record<string, number> = {}
+	for (const line of result.trim().split('\n')) {
+		const trimmed = line.trim()
+		if (!trimmed) continue
+		const commaIdx = trimmed.indexOf(',')
+		const name = trimmed.slice(0, commaIdx)
+		const id = Number(trimmed.slice(commaIdx + 1))
+		ids[name] = id
+	}
+	return ids
+}
+
 export default async function globalSetup() {
 	mkdirSync(path.join(ROOT, 'e2e', '.auth'), { recursive: true })
 	if (isAlreadySeeded()) {
 		console.log('DB already seeded, skipping seed step')
-		return
+	} else {
+		execSync('npm run db:seed:e2e', { stdio: 'inherit', cwd: ROOT })
 	}
-	execSync('npm run db:seed:e2e', { stdio: 'inherit', cwd: ROOT })
+
+	const groupIds = getGroupIds()
+	writeFileSync(
+		path.join(ROOT, 'e2e', 'group-ids.json'),
+		JSON.stringify(groupIds, null, 2)
+	)
+	console.log('Group IDs:', groupIds)
 }

--- a/e2e/helpers/group-ids.ts
+++ b/e2e/helpers/group-ids.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from 'fs'
+import path from 'path'
+
+const filePath = path.resolve(process.cwd(), 'e2e', 'group-ids.json')
+const groupIds = JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, number>
+
+export const alphaId = groupIds.alpha
+export const betaId = groupIds.beta
+export const gammaId = groupIds.gamma

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
   test: {
     setupFiles: ['./vitest.setup.tsx'],
     environment: 'happy-dom',
-    exclude: ['**/node_modules/**', 'supabase/__tests__/**', 'http-tests/**'],
+    exclude: ['**/node_modules/**', 'supabase/__tests__/**', 'http-tests/**', 'e2e/**'],
   },
 })


### PR DESCRIPTION
## Summary

- Adds 9 Playwright E2E spec files covering all authenticated routes across Alpha, Beta, and Gamma contexts
- Tests the full auth matrix: own-group data, cross-group sharing (Alpha→Beta, Beta→Gamma), blocked access (no transitive share, no reverse share)
- Updates `global-setup.ts` to persist group IDs to `e2e/group-ids.json` for use in cross-group URL construction
- Fixes a crash in `SessionHistoryCalendar` when sessions array is empty (exposed by Gamma's empty-data state)
- Excludes `e2e/` from Vitest discovery to prevent Playwright test files being picked up by the unit test runner

## Test plan

- [x] `npm run test:e2e` passes locally: 70 passed, 92 skipped (context-specific tests run in one project only)
- [x] `npm run qa` passes: 22 test files, 99 unit tests all green
- [x] Auth matrix verified: Alpha sees own rich data, Beta sees own sparse data + Alpha via share, Gamma sees Beta via share but not Alpha (no transitive share)
- [x] Cross-group redirect: own group `/group/[id]` redirects to `/`
- [x] Data isolation: no Alpha/Beta session dates leak into wrong group context

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)