### PR TITLE
test: unit tests for home, sessions, species list, species detail, and bird-search pages

### DIFF
--- a/app/(routes)/__tests__/page.test.tsx
+++ b/app/(routes)/__tests__/page.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import Page from '../page';
+import recentSessionsSnapshot from '@/test-fixtures/snapshots/fetchRecentSessions.alpha.json';
+
+const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
+	mockGetAuthenticatedSupabaseClient: vi.fn()
+}));
+
+vi.mock('@/lib/group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+vi.mock('@/app/actions/top-performers', () => ({
+	getTopStats: vi.fn().mockResolvedValue([])
+}));
+
+function makeChainClient(data: unknown) {
+	const thenable = {
+		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+			Promise.resolve({ data, error: null }).then(resolve)
+	};
+	const chain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		order: vi.fn().mockReturnThis(),
+		limit: vi.fn().mockReturnThis(),
+		...thenable
+	};
+	return { from: vi.fn().mockReturnValue(chain) };
+}
+
+describe('home page', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	beforeEach(() => {
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+			makeChainClient(recentSessionsSnapshot)
+		);
+	});
+
+	it('renders Recent Sessions heading', async () => {
+		render(await Page());
+		const heading = await screen.findByRole('heading', {
+			name: 'Recent Sessions'
+		});
+		expect(heading).toBeDefined();
+	});
+
+	it('renders stats accordion', async () => {
+		render(await Page());
+		const accordions = await screen.findAllByTestId('stats-accordion-group');
+		expect(accordions.length).toBeGreaterThan(0);
+	});
+
+	it('renders session links from fixture', async () => {
+		render(await Page());
+		const heading = await screen.findByRole('heading', {
+			name: 'Recent Sessions'
+		});
+		const sessionLinks =
+			heading.nextElementSibling?.querySelectorAll('a') ?? [];
+		expect(sessionLinks.length).toBe(recentSessionsSnapshot.length);
+	});
+
+	describe('with no recent sessions', () => {
+		it('renders empty session list', async () => {
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(makeChainClient([]));
+			render(await Page());
+			const heading = await screen.findByRole('heading', {
+				name: 'Recent Sessions'
+			});
+			const sessionLinks =
+				heading.nextElementSibling?.querySelectorAll('a') ?? [];
+			expect(sessionLinks.length).toBe(0);
+		});
+	});
+});

--- a/app/(routes)/bird/__tests__/page.test.tsx
+++ b/app/(routes)/bird/__tests__/page.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import Page from '../page';
+
+const { mockGetAuthenticatedSupabaseClient, mockRedirect } = vi.hoisted(() => ({
+	mockGetAuthenticatedSupabaseClient: vi.fn(),
+	mockRedirect: vi.fn()
+}));
+
+vi.mock('@/lib/group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+vi.mock('next/navigation', () => ({
+	useRouter: () => ({
+		push: vi.fn(),
+		replace: vi.fn(),
+		refresh: vi.fn(),
+		back: vi.fn(),
+		forward: vi.fn(),
+		prefetch: vi.fn()
+	}),
+	usePathname: () => '/',
+	useSearchParams: () => new URLSearchParams(),
+	redirect: mockRedirect
+}));
+
+type FuzzyResult = {
+	ring_no: string;
+	species_name: string;
+	closeness_score: number;
+};
+
+function makeBirdSearchClient({
+	exactMatch,
+	fuzzyResults
+}: {
+	exactMatch: { id: number } | null;
+	fuzzyResults: FuzzyResult[];
+}) {
+	const fromChain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		maybeSingle: vi.fn().mockReturnThis(),
+		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+			Promise.resolve({ data: exactMatch, error: null }).then(resolve)
+	};
+	const rpcThenable = {
+		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+			Promise.resolve({ data: fuzzyResults, error: null }).then(resolve)
+	};
+	return {
+		from: vi.fn().mockReturnValue(fromChain),
+		rpc: vi.fn().mockReturnValue(rpcThenable)
+	};
+}
+
+function renderBirdPage(q: string) {
+	return Page({ searchParams: Promise.resolve({ q }) });
+}
+
+describe('bird search page', () => {
+	afterEach(() => {
+		cleanup();
+		mockRedirect.mockReset();
+	});
+
+	describe('with query param matching no rings', () => {
+		beforeEach(() => {
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+				makeBirdSearchClient({ exactMatch: null, fuzzyResults: [] })
+			);
+		});
+
+		it('renders "No exact match found" message', async () => {
+			render(await renderBirdPage('UNKNOWN'));
+			await screen.findByText(/No exact match found/);
+		});
+
+		it('renders empty results list', async () => {
+			render(await renderBirdPage('UNKNOWN'));
+			await screen.findByText(/No exact match found/);
+			const list = screen.getByRole('list');
+			expect(list.querySelectorAll('li').length).toBe(0);
+		});
+	});
+
+	describe('with query param matching fuzzy results', () => {
+		const fuzzyResults: FuzzyResult[] = [
+			{ ring_no: 'ABC123', species_name: 'Robin', closeness_score: 0.9 },
+			{ ring_no: 'ABC456', species_name: 'Blue Tit', closeness_score: 0.7 }
+		];
+
+		beforeEach(() => {
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+				makeBirdSearchClient({ exactMatch: null, fuzzyResults })
+			);
+		});
+
+		it('renders list of fuzzy match results with ring numbers', async () => {
+			render(await renderBirdPage('ABC'));
+			const list = await screen.findByRole('list');
+			const items = list.querySelectorAll('li');
+			expect(items.length).toBe(fuzzyResults.length);
+			expect(items[0].textContent).toContain('ABC123');
+			expect(items[1].textContent).toContain('ABC456');
+		});
+	});
+
+	describe('with query matching exact ring', () => {
+		beforeEach(() => {
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+				makeBirdSearchClient({
+					exactMatch: { id: 42 },
+					fuzzyResults: []
+				})
+			);
+		});
+
+		it('calls redirect to /bird/[ring]', async () => {
+			render(await renderBirdPage('RING123'));
+			await waitFor(() => {
+				expect(mockRedirect).toHaveBeenCalledWith('/bird/RING123');
+			});
+		});
+	});
+});

--- a/app/(routes)/sessions/__tests__/page.test.tsx
+++ b/app/(routes)/sessions/__tests__/page.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import Page from '../page';
+import alphaSessionsSnapshot from '@/test-fixtures/snapshots/fetchAllSessions.alpha.json';
+import betaSessionsSnapshot from '@/test-fixtures/snapshots/fetchAllSessions.beta.json';
+
+const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
+	mockGetAuthenticatedSupabaseClient: vi.fn()
+}));
+
+vi.mock('@/lib/group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+function makeChainClient(data: unknown) {
+	const thenable = {
+		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+			Promise.resolve({ data, error: null }).then(resolve)
+	};
+	const chain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		order: vi.fn().mockReturnThis(),
+		...thenable
+	};
+	return { from: vi.fn().mockReturnValue(chain) };
+}
+
+describe('sessions page', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders "Session history" heading', async () => {
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+			makeChainClient(alphaSessionsSnapshot)
+		);
+		render(await Page());
+		const heading = await screen.findByRole('heading', { level: 1 });
+		expect(heading.textContent).toBe('Session history');
+	});
+
+	describe('with multi-year data (alpha fixture)', () => {
+		beforeEach(() => {
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+				makeChainClient(alphaSessionsSnapshot)
+			);
+		});
+
+		it('renders sessions grouped by year', async () => {
+			render(await Page());
+			const yearHeadings = await screen.findAllByRole('heading', { level: 2 });
+			expect(yearHeadings.length).toBeGreaterThan(1);
+			yearHeadings.forEach((h) => expect(h.textContent).toMatch(/^\d{4}$/));
+		});
+
+		it('renders sessions grouped by month within year', async () => {
+			render(await Page());
+			await screen.findAllByRole('heading', { level: 2 });
+			const monthButtons = screen
+				.getAllByRole('button')
+				.filter((btn) => /[a-z]+: \d+ sessions/i.test(btn.textContent ?? ''));
+			expect(monthButtons.length).toBeGreaterThan(0);
+		});
+	});
+
+	describe('with single-year data (beta fixture)', () => {
+		beforeEach(() => {
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+				makeChainClient(betaSessionsSnapshot)
+			);
+		});
+
+		it('renders sessions for a single year only', async () => {
+			render(await Page());
+			const yearHeadings = await screen.findAllByRole('heading', { level: 2 });
+			expect(yearHeadings).toHaveLength(1);
+		});
+	});
+
+	describe('with no sessions', () => {
+		it('renders "No session data available." message', async () => {
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(makeChainClient([]));
+			render(await Page());
+			await screen.findByText('No session data available.');
+		});
+	});
+});

--- a/app/(routes)/species/[speciesName]/__tests__/page.test.tsx
+++ b/app/(routes)/species/[speciesName]/__tests__/page.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import Page from '../page';
+import spPageSnapshot from '@/test-fixtures/snapshots/fetchSpPageData.alpha.robin.json';
+import type { FullFatPageData } from '../page';
+
+const {
+	mockGetAuthenticatedSupabaseClient,
+	mockGetTopPeriodsByMetric,
+	mockFetchPageOfBirds
+} = vi.hoisted(() => ({
+	mockGetAuthenticatedSupabaseClient: vi.fn(),
+	mockGetTopPeriodsByMetric: vi.fn(),
+	mockFetchPageOfBirds: vi.fn()
+}));
+
+vi.mock('@/lib/group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+vi.mock('@/app/actions/top-performers', () => ({
+	getTopPeriodsByMetric: mockGetTopPeriodsByMetric
+}));
+
+vi.mock('@/app/actions/sp-data', () => ({
+	fetchPageOfBirds: mockFetchPageOfBirds
+}));
+
+vi.mock('@/app/components/SpIndividualsTab', () => ({
+	SpIndividualsTab: () => <div data-testid="sp-individuals-tab" />
+}));
+
+vi.mock('@/app/components/SpNotableRetrapsTab', () => ({
+	SpNotableRetrapsTab: () => <div data-testid="sp-notable-retraps-tab" />
+}));
+
+vi.mock('@/app/components/SpStatsHistoryTab', () => ({
+	SpStatsHistoryTab: () => <div data-testid="sp-stats-history-tab" />
+}));
+
+vi.mock('@/app/components/SpWeightWingTab', () => ({
+	SpWeightWingTab: () => <div data-testid="sp-weight-wing-tab" />
+}));
+
+const { topSessions, birds, speciesStats } =
+	spPageSnapshot as unknown as FullFatPageData;
+
+function makeSpeciesClient() {
+	const fromChain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		single: vi.fn().mockReturnThis(),
+		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+			Promise.resolve({
+				data: { id: spPageSnapshot.speciesId },
+				error: null
+			}).then(resolve)
+	};
+	const rpcThenable = {
+		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+			Promise.resolve({ data: [speciesStats], error: null }).then(resolve)
+	};
+	return {
+		from: vi.fn().mockReturnValue(fromChain),
+		rpc: vi.fn().mockReturnValue(rpcThenable)
+	};
+}
+
+function renderSpeciesPage(speciesName = 'Robin') {
+	return Page({
+		params: Promise.resolve({ speciesName })
+	});
+}
+
+describe('species detail page', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe('with full data (Robin fixture)', () => {
+		beforeEach(() => {
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(makeSpeciesClient());
+			mockGetTopPeriodsByMetric.mockResolvedValue(topSessions);
+			mockFetchPageOfBirds.mockResolvedValue(birds);
+		});
+
+		it('renders all 4 tab buttons: Bird list, Retraps, Stats history, Size plot', async () => {
+			render(await renderSpeciesPage());
+			await screen.findByTestId('sp-individuals-tab');
+			expect(screen.getByRole('button', { name: 'Bird list' })).toBeDefined();
+			expect(screen.getByRole('button', { name: 'Retraps' })).toBeDefined();
+			expect(
+				screen.getByRole('button', { name: 'Stats history' })
+			).toBeDefined();
+			expect(screen.getByRole('button', { name: 'Size plot' })).toBeDefined();
+		});
+
+		describe('bird-list tab (default active)', () => {
+			it('renders SpIndividualsTab', async () => {
+				render(await renderSpeciesPage());
+				await screen.findByTestId('sp-individuals-tab');
+			});
+		});
+
+		describe('retraps tab (click to activate)', () => {
+			it('renders SpNotableRetrapsTab after clicking Retraps button', async () => {
+				render(await renderSpeciesPage());
+				await screen.findByTestId('sp-individuals-tab');
+				fireEvent.click(screen.getByRole('button', { name: 'Retraps' }));
+				await screen.findByTestId('sp-notable-retraps-tab');
+			});
+		});
+
+		describe('stats-history tab (click to activate)', () => {
+			it('renders SpStatsHistoryTab after clicking Stats history button', async () => {
+				render(await renderSpeciesPage());
+				await screen.findByTestId('sp-individuals-tab');
+				fireEvent.click(screen.getByRole('button', { name: 'Stats history' }));
+				await screen.findByTestId('sp-stats-history-tab');
+			});
+		});
+
+		describe('size-plot tab (click to activate)', () => {
+			it('renders SpWeightWingTab after clicking Size plot button', async () => {
+				render(await renderSpeciesPage());
+				await screen.findByTestId('sp-individuals-tab');
+				fireEvent.click(screen.getByRole('button', { name: 'Size plot' }));
+				await screen.findByTestId('sp-weight-wing-tab');
+			});
+		});
+	});
+
+	describe('not authorised state (data has speciesId only, no birds)', () => {
+		beforeEach(() => {
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(makeSpeciesClient());
+			mockGetTopPeriodsByMetric.mockResolvedValue([]);
+			mockFetchPageOfBirds.mockResolvedValue([]);
+		});
+
+		it('renders "Not authorised to view any encounter data for this species" message', async () => {
+			render(await renderSpeciesPage());
+			await screen.findByText(
+				'Not authorised to view any encounter data for this species'
+			);
+		});
+
+		it('does not render tab buttons', async () => {
+			render(await renderSpeciesPage());
+			await screen.findByText(
+				'Not authorised to view any encounter data for this species'
+			);
+			expect(screen.queryByRole('button', { name: 'Bird list' })).toBeNull();
+		});
+
+		it('does not render SpStats', async () => {
+			render(await renderSpeciesPage());
+			await screen.findByText(
+				'Not authorised to view any encounter data for this species'
+			);
+			expect(screen.queryByTestId('headline-stats')).toBeNull();
+		});
+	});
+});

--- a/app/(routes)/species/__tests__/page.test.tsx
+++ b/app/(routes)/species/__tests__/page.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import Page from '../page';
+import alphaSpeciesSnapshot from '@/test-fixtures/snapshots/fetchSpeciesData.alpha.json';
+import betaSpeciesSnapshot from '@/test-fixtures/snapshots/fetchSpeciesData.beta.json';
+import gammaSpeciesSnapshot from '@/test-fixtures/snapshots/fetchSpeciesData.gamma.json';
+
+const { mockGetAuthenticatedSupabaseClient, mockFetchSpeciesData } = vi.hoisted(
+	() => ({
+		mockGetAuthenticatedSupabaseClient: vi.fn(),
+		mockFetchSpeciesData: vi.fn()
+	})
+);
+
+vi.mock('@/lib/group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+vi.mock('@/app/actions/spp-data', () => ({
+	fetchSpeciesData: mockFetchSpeciesData
+}));
+
+function makeYearsClient(years: number[]) {
+	const dates = years.map((y) => ({ visit_date: `${y}-06-01` }));
+	const thenable = {
+		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+			Promise.resolve({ data: dates, error: null }).then(resolve)
+	};
+	const chain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		order: vi.fn().mockReturnThis(),
+		...thenable
+	};
+	return { from: vi.fn().mockReturnValue(chain) };
+}
+
+describe('species list page', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe('with full data (alpha fixture)', () => {
+		beforeEach(() => {
+			mockFetchSpeciesData.mockResolvedValue(alphaSpeciesSnapshot as unknown[]);
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+				makeYearsClient([2023, 2022])
+			);
+		});
+
+		it('renders species rows in table', async () => {
+			render(await Page());
+			const table = await screen.findByRole('table');
+			const rows = table.querySelectorAll('tbody tr');
+			expect(rows.length).toBe(alphaSpeciesSnapshot.length);
+		});
+
+		it('renders year filter options matching fetched years', async () => {
+			render(await Page());
+			const yearSelect = await screen.findByLabelText('Year');
+			const options = yearSelect.querySelectorAll('option');
+			expect(options[1].value).toBe('2023');
+			expect(options[2].value).toBe('2022');
+		});
+	});
+
+	describe('with sparse data (beta fixture)', () => {
+		beforeEach(() => {
+			mockFetchSpeciesData.mockResolvedValue(betaSpeciesSnapshot as unknown[]);
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+				makeYearsClient([2023])
+			);
+		});
+
+		it('renders fewer species rows', async () => {
+			render(await Page());
+			const table = await screen.findByRole('table');
+			const rows = table.querySelectorAll('tbody tr');
+			expect(rows.length).toBe(betaSpeciesSnapshot.length);
+			expect(rows.length).toBeLessThan(alphaSpeciesSnapshot.length);
+		});
+	});
+
+	describe('with no data (gamma fixture)', () => {
+		beforeEach(() => {
+			mockFetchSpeciesData.mockResolvedValue(gammaSpeciesSnapshot as unknown[]);
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(makeYearsClient([]));
+		});
+
+		it('renders empty table', async () => {
+			render(await Page());
+			const table = await screen.findByRole('table');
+			const rows = table.querySelectorAll('tbody tr');
+			expect(rows.length).toBe(0);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Adds mock-based unit tests for 5 page components using snapshot fixtures (no Supabase required)
- `app/(routes)/__tests__/page.test.tsx` — home page (Recent Sessions heading, stats accordion, session links, empty state)
- `app/(routes)/sessions/__tests__/page.test.tsx` — sessions page (heading, multi-year grouping, single-year, empty state)
- `app/(routes)/species/__tests__/page.test.tsx` — species list (table rows, year filter options, sparse/empty states)
- `app/(routes)/species/[speciesName]/__tests__/page.test.tsx` — species detail tabs (all 4 tabs, click-to-activate, not-authorised state)
- `app/(routes)/bird/__tests__/page.test.tsx` — bird search (no match, fuzzy results, exact match redirect)

All tests mock `@/lib/group-auth` and relevant actions; no Supabase or running server needed.

## Test plan

- [x] `npm run qa` passes (27 test files, 124 tests, no type errors)
- [x] All new tests use snapshot fixtures from `test-fixtures/snapshots/`
- [x] Tab interaction tests use `fireEvent.click` to verify tab switching

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)