### PR TITLE
test: logout unit + E2E tests (#279)

### DIFF
--- a/app/actions/__tests__/logout.test.ts
+++ b/app/actions/__tests__/logout.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { logout } from '../logout';
+import { deleteGroupCookie } from '../group-cookie';
+import { redirect } from 'next/navigation';
+
+describe('logout', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('calls deleteGroupCookie', async () => {
+		await logout();
+		expect(vi.mocked(deleteGroupCookie)).toHaveBeenCalledOnce();
+	});
+
+	it('redirects to /', async () => {
+		await logout();
+		expect(vi.mocked(redirect)).toHaveBeenCalledWith('/');
+	});
+});

--- a/e2e/authenticated/logout.spec.ts
+++ b/e2e/authenticated/logout.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-test.beforeEach(({ page }, testInfo) => {
+test.beforeEach(({}, testInfo) => {
 	test.skip(testInfo.project.name !== 'alpha', 'alpha only')
 })
 

--- a/e2e/authenticated/logout.spec.ts
+++ b/e2e/authenticated/logout.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test'
+
+test.beforeEach(({ page }, testInfo) => {
+	test.skip(testInfo.project.name !== 'alpha', 'alpha only')
+})
+
+test.describe('logout flow', () => {
+	test('login modal becomes visible after logout', async ({ page }) => {
+		await page.goto('/')
+		await page.getByRole('button', { name: 'Toggle user menu' }).click()
+		await page.getByRole('button', { name: 'Log out' }).click()
+		await expect(page.getByRole('heading', { name: 'Login to your group' })).toBeVisible()
+	})
+
+	test('navigating to a protected page shows login modal', async ({ page }) => {
+		await page.goto('/')
+		await page.getByRole('button', { name: 'Toggle user menu' }).click()
+		await page.getByRole('button', { name: 'Log out' }).click()
+		await expect(page.getByRole('heading', { name: 'Login to your group' })).toBeVisible()
+		await page.goto('/sessions')
+		await expect(page.getByRole('heading', { name: 'Login to your group' })).toBeVisible()
+	})
+})

--- a/vitest.setup.tsx
+++ b/vitest.setup.tsx
@@ -27,6 +27,7 @@ vi.mock('./app/actions/group-cookie', async () => {
   return {
     getGroupCookie: vi.fn().mockResolvedValue(1),
     setGroupCookie: vi.fn().mockResolvedValue(undefined),
+    deleteGroupCookie: vi.fn().mockResolvedValue(undefined),
     getGroupJwt: vi.fn().mockImplementation(() => generateGroupJwt(1)),
   };
 });
@@ -51,4 +52,5 @@ vi.mock('next/navigation', () => ({
   }),
   usePathname: () => '/',
   useSearchParams: () => new URLSearchParams(),
+  redirect: vi.fn(),
 }));


### PR DESCRIPTION
## Summary

- Unit tests for `app/actions/logout.ts` verifying `deleteGroupCookie` is called and redirect goes to `/`
- E2E smoke test (alpha project only) confirming login modal appears after logout and persists when navigating to a protected page
- Added `deleteGroupCookie` and `redirect` to global vitest mocks in `vitest.setup.tsx`

## Test plan

- [x] `npm run test:nowatch` — 126 tests pass
- [x] `npx playwright test --project=alpha e2e/authenticated/logout.spec.ts` — 2 E2E tests pass
- [x] `npm run qa` — 0 errors, 9 pre-existing warnings

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)