### PR TITLE
test(e2e): replace test.skip with Playwright tag+grep; fix import test

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,4 @@
 npm run lint
 npx tsc --noEmit
 npm run test:nowatch
+npm run test:e2e

--- a/e2e/authenticated/bird.spec.ts
+++ b/e2e/authenticated/bird.spec.ts
@@ -1,24 +1,19 @@
 import { test, expect } from '@playwright/test'
 
-const project = () => test.info().project.name
-
 test.describe('bird search', () => {
-	test('alpha: exact ring match redirects to bird page', async ({ page }) => {
-		test.skip(project() !== 'alpha', 'alpha only')
+	test('alpha: exact ring match redirects to bird page', { tag: '@alpha' }, async ({ page }) => {
 		await page.goto('/bird?q=ARRETRAP')
 		await expect(page).toHaveURL(/\/bird\/ARRETRAP/i)
 	})
 
-	test('beta: partial match shows search results', async ({ page }) => {
-		test.skip(project() !== 'beta', 'beta only')
+	test('beta: partial match shows search results', { tag: '@beta' }, async ({ page }) => {
 		await page.goto('/bird?q=BCHAF')
 		await expect(
 			page.getByRole('heading', { name: 'Search results' })
 		).toBeVisible()
 	})
 
-	test('gamma: no own birds — search yields no results', async ({ page }) => {
-		test.skip(project() !== 'gamma', 'gamma only')
+	test('gamma: no own birds — search yields no results', { tag: '@gamma' }, async ({ page }) => {
 		await page.goto('/bird?q=ARRETRAP')
 		// Gamma cannot see Alpha's birds; fuzzy search returns empty
 		await expect(
@@ -29,15 +24,13 @@ test.describe('bird search', () => {
 })
 
 test.describe('ARRETRAP bird page', () => {
-	test('alpha: shows Robin with multiple encounters', async ({ page }) => {
-		test.skip(project() !== 'alpha', 'alpha only')
+	test('alpha: shows Robin with multiple encounters', { tag: '@alpha' }, async ({ page }) => {
 		await page.goto('/bird/ARRETRAP')
 		await expect(page.getByRole('heading', { name: /Robin.*ARRETRAP/i })).toBeVisible()
 		await expect(page.getByText('9 encounters')).toBeVisible()
 	})
 
-	test('beta: cannot see ARRETRAP (Alpha bird, no reverse share)', async ({ page }) => {
-		test.skip(project() !== 'beta', 'beta only')
+	test('beta: cannot see ARRETRAP (Alpha bird, no reverse share)', { tag: '@beta' }, async ({ page }) => {
 		await page.goto('/bird/ARRETRAP')
 		// Beta can see the bird record (ringing_group_ids includes alphaId which Beta can read)
 		// but encounters from Alpha should NOT be filtered to zero (Beta sees Alpha encounters via sharing)
@@ -46,23 +39,20 @@ test.describe('ARRETRAP bird page', () => {
 })
 
 test.describe('SHARED01 bird page (shared across Alpha and Beta)', () => {
-	test('alpha: sees own encounter only', async ({ page }) => {
-		test.skip(project() !== 'alpha', 'alpha only')
+	test('alpha: sees own encounter only', { tag: '@alpha' }, async ({ page }) => {
 		await page.goto('/bird/SHARED01')
 		await expect(page.getByRole('heading', { name: /Robin.*SHARED01/i })).toBeVisible()
 		await expect(page.getByText('1 encounter')).toBeVisible()
 	})
 
-	test('beta: sees Alpha and Beta encounters', async ({ page }) => {
-		test.skip(project() !== 'beta', 'beta only')
+	test('beta: sees Alpha and Beta encounters', { tag: '@beta' }, async ({ page }) => {
 		await page.goto('/bird/SHARED01')
 		await expect(page.getByRole('heading', { name: /Robin.*SHARED01/i })).toBeVisible()
 		await expect(page.getByText('2 encounters')).toBeVisible()
 		await expect(page.getByText('1 from another group')).toBeVisible()
 	})
 
-	test('gamma: sees only Beta encounter', async ({ page }) => {
-		test.skip(project() !== 'gamma', 'gamma only')
+	test('gamma: sees only Beta encounter', { tag: '@gamma' }, async ({ page }) => {
 		await page.goto('/bird/SHARED01')
 		await expect(page.getByRole('heading', { name: /Robin.*SHARED01/i })).toBeVisible()
 		await expect(page.getByText('1 encounter')).toBeVisible()

--- a/e2e/authenticated/cross-group-pages.spec.ts
+++ b/e2e/authenticated/cross-group-pages.spec.ts
@@ -1,14 +1,9 @@
 import { test, expect } from '@playwright/test'
 import { alphaId } from '../helpers/group-ids'
 
-const project = () => test.info().project.name
 const knownDate = '2024-05-10'
 
-test.beforeEach(() => {
-	test.skip(project() !== 'beta', 'beta only')
-})
-
-test.describe('cross-group pages (beta user viewing alpha data)', () => {
+test.describe('cross-group pages (beta user viewing alpha data)', { tag: '@beta' }, () => {
 	test.describe('/group/[alphaId] (cross-group home)', () => {
 		test('shows Recent Sessions heading', async ({ page }) => {
 			await page.goto(`/group/${alphaId}`)
@@ -92,7 +87,7 @@ test.describe('cross-group pages (beta user viewing alpha data)', () => {
 	})
 })
 
-test.describe('cross-group session pages (beta user viewing alpha data)', () => {
+test.describe('cross-group session pages (beta user viewing alpha data)', { tag: '@beta' }, () => {
 	test.describe(`/group/[alphaId]/session/${knownDate}`, () => {
 		test('shows the session date as heading', async ({ page }) => {
 			await page.goto(`/group/${alphaId}/session/${knownDate}`)

--- a/e2e/authenticated/cross-group.spec.ts
+++ b/e2e/authenticated/cross-group.spec.ts
@@ -1,31 +1,25 @@
 import { test, expect } from '@playwright/test'
 import { alphaId, betaId, gammaId } from '../helpers/group-ids'
 
-const project = () => test.info().project.name
-
 test.describe('/group/[id] home redirect for own group', () => {
-	test('alpha: own group home redirects to /', async ({ page }) => {
-		test.skip(project() !== 'alpha', 'alpha only')
+	test('alpha: own group home redirects to /', { tag: '@alpha' }, async ({ page }) => {
 		await page.goto(`/group/${alphaId}`)
 		await expect(page).toHaveURL('/')
 	})
 
-	test('beta: own group home redirects to /', async ({ page }) => {
-		test.skip(project() !== 'beta', 'beta only')
+	test('beta: own group home redirects to /', { tag: '@beta' }, async ({ page }) => {
 		await page.goto(`/group/${betaId}`)
 		await expect(page).toHaveURL('/')
 	})
 
-	test('gamma: own group home redirects to /', async ({ page }) => {
-		test.skip(project() !== 'gamma', 'gamma only')
+	test('gamma: own group home redirects to /', { tag: '@gamma' }, async ({ page }) => {
 		await page.goto(`/group/${gammaId}`)
 		await expect(page).toHaveURL('/')
 	})
 })
 
 test.describe('/group/[alphaId]/sessions — Alpha shares with Beta', () => {
-	test('beta: sees Alpha sessions (share exists)', async ({ page }) => {
-		test.skip(project() !== 'beta', 'beta only')
+	test('beta: sees Alpha sessions (share exists)', { tag: '@beta' }, async ({ page }) => {
 		await page.goto(`/group/${alphaId}/sessions`)
 		await expect(
 			page.getByRole('heading', { name: 'Session history' })
@@ -34,8 +28,7 @@ test.describe('/group/[alphaId]/sessions — Alpha shares with Beta', () => {
 		await expect(page.getByText('2024')).toBeVisible()
 	})
 
-	test('gamma: sees no Alpha sessions (no transitive share)', async ({ page }) => {
-		test.skip(project() !== 'gamma', 'gamma only')
+	test('gamma: sees no Alpha sessions (no transitive share)', { tag: '@gamma' }, async ({ page }) => {
 		await page.goto(`/group/${alphaId}/sessions`)
 		await expect(
 			page.getByRole('heading', { name: 'Session history' })
@@ -43,8 +36,7 @@ test.describe('/group/[alphaId]/sessions — Alpha shares with Beta', () => {
 		await expect(page.getByText('No session data available.')).toBeVisible()
 	})
 
-	test('alpha: own sessions visible (no redirect on sub-pages)', async ({ page }) => {
-		test.skip(project() !== 'alpha', 'alpha only')
+	test('alpha: own sessions visible (no redirect on sub-pages)', { tag: '@alpha' }, async ({ page }) => {
 		await page.goto(`/group/${alphaId}/sessions`)
 		await expect(
 			page.getByRole('heading', { name: 'Session history' })
@@ -54,8 +46,7 @@ test.describe('/group/[alphaId]/sessions — Alpha shares with Beta', () => {
 })
 
 test.describe('/group/[betaId]/sessions — Beta shares with Gamma', () => {
-	test('gamma: sees Beta sessions (share exists)', async ({ page }) => {
-		test.skip(project() !== 'gamma', 'gamma only')
+	test('gamma: sees Beta sessions (share exists)', { tag: '@gamma' }, async ({ page }) => {
 		await page.goto(`/group/${betaId}/sessions`)
 		await expect(
 			page.getByRole('heading', { name: 'Session history' })
@@ -63,8 +54,7 @@ test.describe('/group/[betaId]/sessions — Beta shares with Gamma', () => {
 		await expect(page.getByText('2023')).toBeVisible()
 	})
 
-	test('alpha: sees no Beta sessions (no reverse share)', async ({ page }) => {
-		test.skip(project() !== 'alpha', 'alpha only')
+	test('alpha: sees no Beta sessions (no reverse share)', { tag: '@alpha' }, async ({ page }) => {
 		await page.goto(`/group/${betaId}/sessions`)
 		await expect(
 			page.getByRole('heading', { name: 'Session history' })
@@ -74,8 +64,7 @@ test.describe('/group/[betaId]/sessions — Beta shares with Gamma', () => {
 })
 
 test.describe('/group/[alphaId] home — cross-group data visibility', () => {
-	test('beta: sees Alpha home data (share exists)', async ({ page }) => {
-		test.skip(project() !== 'beta', 'beta only')
+	test('beta: sees Alpha home data (share exists)', { tag: '@beta' }, async ({ page }) => {
 		await page.goto(`/group/${alphaId}`)
 		await expect(page).not.toHaveURL('/')
 		await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
@@ -83,8 +72,7 @@ test.describe('/group/[alphaId] home — cross-group data visibility', () => {
 		await expect(page.getByRole('link', { name: /10th May/ })).toBeVisible()
 	})
 
-	test('gamma: sees no Alpha data (no share)', async ({ page }) => {
-		test.skip(project() !== 'gamma', 'gamma only')
+	test('gamma: sees no Alpha data (no share)', { tag: '@gamma' }, async ({ page }) => {
 		await page.goto(`/group/${alphaId}`)
 		await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
 		await expect(page.getByRole('link', { name: /10th May/ })).not.toBeVisible()
@@ -92,8 +80,7 @@ test.describe('/group/[alphaId] home — cross-group data visibility', () => {
 })
 
 test.describe('/group/[betaId] home — cross-group data visibility', () => {
-	test('gamma: sees Beta home data (share exists)', async ({ page }) => {
-		test.skip(project() !== 'gamma', 'gamma only')
+	test('gamma: sees Beta home data (share exists)', { tag: '@gamma' }, async ({ page }) => {
 		await page.goto(`/group/${betaId}`)
 		await expect(page).not.toHaveURL('/')
 		await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
@@ -101,8 +88,7 @@ test.describe('/group/[betaId] home — cross-group data visibility', () => {
 		await expect(page.getByRole('link', { name: /1st June/ })).toBeVisible()
 	})
 
-	test('alpha: sees no Beta data (no reverse share)', async ({ page }) => {
-		test.skip(project() !== 'alpha', 'alpha only')
+	test('alpha: sees no Beta data (no reverse share)', { tag: '@alpha' }, async ({ page }) => {
 		await page.goto(`/group/${betaId}`)
 		await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
 		await expect(page.getByRole('link', { name: /1st June/ })).not.toBeVisible()
@@ -110,16 +96,14 @@ test.describe('/group/[betaId] home — cross-group data visibility', () => {
 })
 
 test.describe('/group/[gammaId] home — Gamma has no data', () => {
-	test('alpha: sees empty Gamma home (no share)', async ({ page }) => {
-		test.skip(project() !== 'alpha', 'alpha only')
+	test('alpha: sees empty Gamma home (no share)', { tag: '@alpha' }, async ({ page }) => {
 		await page.goto(`/group/${gammaId}`)
 		await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
 		await expect(page.getByRole('link', { name: /10th May/ })).not.toBeVisible()
 		await expect(page.getByRole('link', { name: /1st June/ })).not.toBeVisible()
 	})
 
-	test('beta: sees empty Gamma home (no share)', async ({ page }) => {
-		test.skip(project() !== 'beta', 'beta only')
+	test('beta: sees empty Gamma home (no share)', { tag: '@beta' }, async ({ page }) => {
 		await page.goto(`/group/${gammaId}`)
 		await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
 		await expect(page.getByRole('link', { name: /1st June/ })).not.toBeVisible()

--- a/e2e/authenticated/effort.spec.ts
+++ b/e2e/authenticated/effort.spec.ts
@@ -1,31 +1,26 @@
 import { test, expect } from '@playwright/test'
 
-const project = () => test.info().project.name
-
-test('shows Effort and Pay-off heading', async ({ page }) => {
+test('shows Effort and Pay-off heading', { tag: '@all' }, async ({ page }) => {
 	await page.goto('/effort')
 	await expect(
 		page.getByRole('heading', { name: 'Effort and Pay-off' })
 	).toBeVisible()
 })
 
-test('alpha: shows yearly data with non-zero encounter counts', async ({ page }) => {
-	test.skip(project() !== 'alpha', 'alpha only')
+test('alpha: shows yearly data with non-zero encounter counts', { tag: '@alpha' }, async ({ page }) => {
 	await page.goto('/effort')
 	await expect(page.getByText('Total ringing effort')).toBeVisible()
 	await expect(page.getByRole('columnheader', { name: '2021' })).toBeVisible()
 	await expect(page.getByRole('columnheader', { name: '2024' })).toBeVisible()
 })
 
-test('beta: shows yearly data with non-zero encounter counts', async ({ page }) => {
-	test.skip(project() !== 'beta', 'beta only')
+test('beta: shows yearly data with non-zero encounter counts', { tag: '@beta' }, async ({ page }) => {
 	await page.goto('/effort')
 	await expect(page.getByText('Total ringing effort')).toBeVisible()
 	await expect(page.getByRole('columnheader', { name: '2023' })).toBeVisible()
 })
 
-test('gamma: shows table with all-zero encounter counts (no own data)', async ({ page }) => {
-	test.skip(project() !== 'gamma', 'gamma only')
+test('gamma: shows table with all-zero encounter counts (no own data)', { tag: '@gamma' }, async ({ page }) => {
 	await page.goto('/effort')
 	// aggregate_stats returns zero-count rows for all years; no Alpha/Beta data leaks
 	// via ringing_group_filter — only encounters where ringing_group_id = gammaId are counted

--- a/e2e/authenticated/home.spec.ts
+++ b/e2e/authenticated/home.spec.ts
@@ -1,33 +1,28 @@
 import { test, expect } from '@playwright/test'
 
-const project = () => test.info().project.name
-
-test('shows Recent Sessions heading', async ({ page }) => {
+test('shows Recent Sessions heading', { tag: '@all' }, async ({ page }) => {
 	await page.goto('/')
 	await expect(page.getByRole('heading', { name: 'Recent Sessions' })).toBeVisible()
 })
 
-test('shows stats accordion', async ({ page }) => {
+test('shows stats accordion', { tag: '@all' }, async ({ page }) => {
 	await page.goto('/')
 	await expect(page.getByText('Busiest sessions:')).toBeVisible()
 })
 
-test('alpha: shows own recent sessions by date', async ({ page }) => {
-	test.skip(project() !== 'alpha', 'alpha only')
+test('alpha: shows own recent sessions by date', { tag: '@alpha' }, async ({ page }) => {
 	await page.goto('/')
 	// Alpha's most recent session is 2024-05-10
 	await expect(page.getByRole('link', { name: /10th May/ })).toBeVisible()
 })
 
-test('beta: shows own recent sessions by date', async ({ page }) => {
-	test.skip(project() !== 'beta', 'beta only')
+test('beta: shows own recent sessions by date', { tag: '@beta' }, async ({ page }) => {
 	await page.goto('/')
 	// Beta's only session is 2023-06-01
 	await expect(page.getByRole('link', { name: /1st June/ })).toBeVisible()
 })
 
-test('gamma: shows no sessions (empty own data)', async ({ page }) => {
-	test.skip(project() !== 'gamma', 'gamma only')
+test('gamma: shows no sessions (empty own data)', { tag: '@gamma' }, async ({ page }) => {
 	await page.goto('/')
 	// Gamma has no sessions; Alpha/Beta dates must not leak
 	await expect(page.getByRole('link', { name: /10th May/ })).not.toBeVisible()

--- a/e2e/authenticated/import.spec.ts
+++ b/e2e/authenticated/import.spec.ts
@@ -12,11 +12,14 @@ function psql(sql: string) {
 
 test.describe.serial('import flow', { tag: '@delta' }, () => {
 	test.beforeAll(async () => {
+		// Disable trigger to avoid NOT NULL proven_age violation when all encounters for a bird are deleted
+		psql(`ALTER TABLE "Birds" DISABLE TRIGGER trg_encounters_refresh_bird_proven_age`)
 		psql(`DELETE FROM "Encounters" WHERE ringing_group_id = ${deltaId}`)
 		psql(`DELETE FROM "Sessions" WHERE ringing_group_id = ${deltaId}`)
 		psql(`DELETE FROM "Locations" WHERE ringing_group_id = ${deltaId}`)
 		psql(`UPDATE "Birds" SET ringing_group_ids = array_remove(ringing_group_ids, ${deltaId}) WHERE ${deltaId} = ANY(ringing_group_ids)`)
 		psql(`DELETE FROM "Birds" WHERE ringing_group_ids = '{}'`)
+		psql(`ALTER TABLE "Birds" ENABLE TRIGGER trg_encounters_refresh_bird_proven_age`)
 	})
 
 	test('uploads delta.csv and shows completion message', async ({ page }) => {

--- a/e2e/authenticated/import.spec.ts
+++ b/e2e/authenticated/import.spec.ts
@@ -1,12 +1,13 @@
 import { test, expect } from '@playwright/test'
-import { execSync } from 'child_process'
+import { spawnSync } from 'child_process'
 import path from 'path'
 import { deltaId } from '../helpers/group-ids'
 
 const LOCAL_DB_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres'
 
 function psql(sql: string) {
-	execSync(`psql "${LOCAL_DB_URL}" -c '${sql}'`, { stdio: 'pipe' })
+	const result = spawnSync('psql', [LOCAL_DB_URL, '-c', sql], { stdio: 'pipe', encoding: 'utf8' })
+	if (result.status !== 0) throw new Error(`psql failed: ${result.stderr}`)
 }
 
 test.describe.serial('import flow', { tag: '@delta' }, () => {

--- a/e2e/authenticated/import.spec.ts
+++ b/e2e/authenticated/import.spec.ts
@@ -28,7 +28,7 @@ test.describe.serial('import flow', { tag: '@delta' }, () => {
 		const fileInput = page.locator('input[type="file"][name="csv"]')
 		await fileInput.setInputFiles(csvPath)
 
-		await page.click('button[type="submit"]')
+		await page.getByRole('button', { name: 'Import' }).click()
 
 		await expect(
 			page.getByText('Import complete: 10 rows imported successfully')

--- a/e2e/authenticated/import.spec.ts
+++ b/e2e/authenticated/import.spec.ts
@@ -6,20 +6,16 @@ import { deltaId } from '../helpers/group-ids'
 const LOCAL_DB_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres'
 
 function psql(sql: string) {
-	execSync(`psql "${LOCAL_DB_URL}" -c "${sql}"`, { stdio: 'pipe' })
+	execSync(`psql "${LOCAL_DB_URL}" -c '${sql}'`, { stdio: 'pipe' })
 }
 
-test.describe.serial('import flow', () => {
+test.describe.serial('import flow', { tag: '@delta' }, () => {
 	test.beforeAll(async () => {
 		psql(`DELETE FROM "Encounters" WHERE ringing_group_id = ${deltaId}`)
 		psql(`DELETE FROM "Sessions" WHERE ringing_group_id = ${deltaId}`)
 		psql(`DELETE FROM "Locations" WHERE ringing_group_id = ${deltaId}`)
 		psql(`UPDATE "Birds" SET ringing_group_ids = array_remove(ringing_group_ids, ${deltaId}) WHERE ${deltaId} = ANY(ringing_group_ids)`)
 		psql(`DELETE FROM "Birds" WHERE ringing_group_ids = '{}'`)
-	})
-
-	test.beforeEach(({}, testInfo) => {
-		test.skip(testInfo.project.name !== 'delta', 'delta only')
 	})
 
 	test('uploads delta.csv and shows completion message', async ({ page }) => {

--- a/e2e/authenticated/import.spec.ts
+++ b/e2e/authenticated/import.spec.ts
@@ -13,13 +13,13 @@ function psql(sql: string) {
 test.describe.serial('import flow', { tag: '@delta' }, () => {
 	test.beforeAll(async () => {
 		// Disable trigger to avoid NOT NULL proven_age violation when all encounters for a bird are deleted
-		psql(`ALTER TABLE "Birds" DISABLE TRIGGER trg_encounters_refresh_bird_proven_age`)
+		psql(`ALTER TABLE "Encounters" DISABLE TRIGGER trigger_encounters_refresh_bird_proven_age`)
 		psql(`DELETE FROM "Encounters" WHERE ringing_group_id = ${deltaId}`)
 		psql(`DELETE FROM "Sessions" WHERE ringing_group_id = ${deltaId}`)
 		psql(`DELETE FROM "Locations" WHERE ringing_group_id = ${deltaId}`)
 		psql(`UPDATE "Birds" SET ringing_group_ids = array_remove(ringing_group_ids, ${deltaId}) WHERE ${deltaId} = ANY(ringing_group_ids)`)
 		psql(`DELETE FROM "Birds" WHERE ringing_group_ids = '{}'`)
-		psql(`ALTER TABLE "Birds" ENABLE TRIGGER trg_encounters_refresh_bird_proven_age`)
+		psql(`ALTER TABLE "Encounters" ENABLE TRIGGER trigger_encounters_refresh_bird_proven_age`)
 	})
 
 	test('uploads delta.csv and shows completion message', async ({ page }) => {

--- a/e2e/authenticated/import.spec.ts
+++ b/e2e/authenticated/import.spec.ts
@@ -44,6 +44,7 @@ test.describe.serial('import flow', { tag: '@delta' }, () => {
 	test('imported session appears on /sessions page', async ({ page }) => {
 		await page.goto('/sessions')
 		await expect(page.getByText('2024')).toBeVisible()
+		await page.getByRole('button', { name: /March/ }).click()
 		await expect(page.getByRole('link', { name: /15th March/ })).toBeVisible()
 	})
 })

--- a/e2e/authenticated/import.spec.ts
+++ b/e2e/authenticated/import.spec.ts
@@ -48,6 +48,6 @@ test.describe.serial('import flow', { tag: '@delta' }, () => {
 		await page.goto('/sessions')
 		await expect(page.getByText('2024')).toBeVisible()
 		await page.getByRole('button', { name: /March/ }).click()
-		await expect(page.getByRole('link', { name: /15th March/ })).toBeVisible()
+		await expect(page.getByRole('link', { name: /15th/ })).toBeVisible()
 	})
 })

--- a/e2e/authenticated/logout.spec.ts
+++ b/e2e/authenticated/logout.spec.ts
@@ -1,10 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-test.beforeEach(({}, testInfo) => {
-	test.skip(testInfo.project.name !== 'alpha', 'alpha only')
-})
-
-test.describe('logout flow', () => {
+test.describe('logout flow', { tag: '@alpha' }, () => {
 	test('login modal becomes visible after logout', async ({ page }) => {
 		await page.goto('/')
 		await page.getByRole('button', { name: 'Toggle user menu' }).click()

--- a/e2e/authenticated/mistakes.spec.ts
+++ b/e2e/authenticated/mistakes.spec.ts
@@ -1,28 +1,23 @@
 import { test, expect } from '@playwright/test'
 
-const project = () => test.info().project.name
-
-test('shows Mistakes heading', async ({ page }) => {
+test('shows Mistakes heading', { tag: '@all' }, async ({ page }) => {
 	await page.goto('/mistakes')
 	await expect(page.getByRole('heading', { name: 'Mistakes' })).toBeVisible()
 })
 
-test('alpha: shows discrepancy rows', async ({ page }) => {
-	test.skip(project() !== 'alpha', 'alpha only')
+test('alpha: shows discrepancy rows', { tag: '@alpha' }, async ({ page }) => {
 	await page.goto('/mistakes')
 	// Multiple rows for ABTITMIS (age + sex discrepancy) — use first()
 	await expect(page.getByRole('link', { name: 'ABTITMIS' }).first()).toBeVisible()
 	await expect(page.getByRole('link', { name: 'ARRETRAP' }).first()).toBeVisible()
 })
 
-test('beta: shows empty mistakes table', async ({ page }) => {
-	test.skip(project() !== 'beta', 'beta only')
+test('beta: shows empty mistakes table', { tag: '@beta' }, async ({ page }) => {
 	await page.goto('/mistakes')
 	await expect(page.getByRole('link', { name: 'ABTITMIS' })).not.toBeVisible()
 })
 
-test('gamma: shows empty mistakes table', async ({ page }) => {
-	test.skip(project() !== 'gamma', 'gamma only')
+test('gamma: shows empty mistakes table', { tag: '@gamma' }, async ({ page }) => {
 	await page.goto('/mistakes')
 	await expect(page.getByRole('link', { name: 'ABTITMIS' })).not.toBeVisible()
 })

--- a/e2e/authenticated/retraps.spec.ts
+++ b/e2e/authenticated/retraps.spec.ts
@@ -1,27 +1,22 @@
 import { test, expect } from '@playwright/test'
 
-const project = () => test.info().project.name
-
-test('shows Notable Birds heading', async ({ page }) => {
+test('shows Notable Birds heading', { tag: '@all' }, async ({ page }) => {
 	await page.goto('/retraps')
 	await expect(page.getByRole('heading', { name: 'Notable Birds' })).toBeVisible()
 })
 
-test('alpha: shows ARRETRAP as notable Robin retrap', async ({ page }) => {
-	test.skip(project() !== 'alpha', 'alpha only')
+test('alpha: shows ARRETRAP as notable Robin retrap', { tag: '@alpha' }, async ({ page }) => {
 	await page.goto('/retraps')
 	await expect(page.getByText('ARRETRAP')).toBeVisible()
 	await expect(page.getByText('Robin')).toBeVisible()
 })
 
-test('beta: shows no notable retraps', async ({ page }) => {
-	test.skip(project() !== 'beta', 'beta only')
+test('beta: shows no notable retraps', { tag: '@beta' }, async ({ page }) => {
 	await page.goto('/retraps')
 	await expect(page.getByText('ARRETRAP')).not.toBeVisible()
 })
 
-test('gamma: shows no notable retraps', async ({ page }) => {
-	test.skip(project() !== 'gamma', 'gamma only')
+test('gamma: shows no notable retraps', { tag: '@gamma' }, async ({ page }) => {
 	await page.goto('/retraps')
 	await expect(page.getByText('ARRETRAP')).not.toBeVisible()
 })

--- a/e2e/authenticated/sessions.spec.ts
+++ b/e2e/authenticated/sessions.spec.ts
@@ -1,28 +1,23 @@
 import { test, expect } from '@playwright/test'
 
-const project = () => test.info().project.name
-
-test('shows Session history heading', async ({ page }) => {
+test('shows Session history heading', { tag: '@all' }, async ({ page }) => {
 	await page.goto('/sessions')
 	await expect(page.getByRole('heading', { name: 'Session history' })).toBeVisible()
 })
 
-test('alpha: shows sessions across multiple years', async ({ page }) => {
-	test.skip(project() !== 'alpha', 'alpha only')
+test('alpha: shows sessions across multiple years', { tag: '@alpha' }, async ({ page }) => {
 	await page.goto('/sessions')
 	await expect(page.getByText('2021')).toBeVisible()
 	await expect(page.getByText('2024')).toBeVisible()
 })
 
-test('beta: shows sessions in a single year', async ({ page }) => {
-	test.skip(project() !== 'beta', 'beta only')
+test('beta: shows sessions in a single year', { tag: '@beta' }, async ({ page }) => {
 	await page.goto('/sessions')
 	await expect(page.getByText('2023')).toBeVisible()
 	await expect(page.getByText('2021')).not.toBeVisible()
 })
 
-test('gamma: shows no session data message', async ({ page }) => {
-	test.skip(project() !== 'gamma', 'gamma only')
+test('gamma: shows no session data message', { tag: '@gamma' }, async ({ page }) => {
 	await page.goto('/sessions')
 	await expect(page.getByText('No session data available.')).toBeVisible()
 })

--- a/e2e/authenticated/single-species.spec.ts
+++ b/e2e/authenticated/single-species.spec.ts
@@ -1,21 +1,17 @@
 import { test, expect } from '@playwright/test'
 
-const project = () => test.info().project.name
-
-test('shows species name as heading', async ({ page }) => {
+test('shows species name as heading', { tag: '@all' }, async ({ page }) => {
 	await page.goto('/species/Robin')
 	await expect(page.getByRole('heading', { name: 'Robin' })).toBeVisible()
 })
 
-test('alpha: shows bird list tab with birds', async ({ page }) => {
-	test.skip(project() !== 'alpha', 'alpha only')
+test('alpha: shows bird list tab with birds', { tag: '@alpha' }, async ({ page }) => {
 	await page.goto('/species/Robin')
 	await expect(page.getByRole('button', { name: 'Bird list' })).toBeVisible()
 	await expect(page.getByTestId('infinite-scroll-loader')).toBeVisible()
 })
 
-test('alpha: loads more birds on scroll past loader', async ({ page }) => {
-	test.skip(project() !== 'alpha', 'alpha only')
+test('alpha: loads more birds on scroll past loader', { tag: '@alpha' }, async ({ page }) => {
 	await page.goto('/species/Robin')
 	const loader = page.getByTestId('infinite-scroll-loader')
 	await expect(loader).toBeVisible()
@@ -23,15 +19,13 @@ test('alpha: loads more birds on scroll past loader', async ({ page }) => {
 	await expect(loader).not.toBeVisible({ timeout: 5000 })
 })
 
-test('beta: shows Robin with limited data', async ({ page }) => {
-	test.skip(project() !== 'beta', 'beta only')
+test('beta: shows Robin with limited data', { tag: '@beta' }, async ({ page }) => {
 	await page.goto('/species/Robin')
 	await expect(page.getByRole('button', { name: 'Bird list' })).toBeVisible()
 	await expect(page.getByTestId('infinite-scroll-loader')).not.toBeVisible()
 })
 
-test('gamma: shows not authorised message', async ({ page }) => {
-	test.skip(project() !== 'gamma', 'gamma only')
+test('gamma: shows not authorised message', { tag: '@gamma' }, async ({ page }) => {
 	await page.goto('/species/Robin')
 	await expect(
 		page.getByText('Not authorised to view any encounter data for this species')

--- a/e2e/authenticated/species.spec.ts
+++ b/e2e/authenticated/species.spec.ts
@@ -1,37 +1,30 @@
 import { test, expect } from '@playwright/test'
 
-const project = () => test.info().project.name
-
-test('alpha: shows full species table', async ({ page }) => {
-	test.skip(project() !== 'alpha', 'alpha only')
+test('alpha: shows full species table', { tag: '@alpha' }, async ({ page }) => {
 	await page.goto('/species')
 	await expect(page.getByRole('link', { name: 'Blue Tit' })).toBeVisible()
 	await expect(page.getByRole('link', { name: 'Robin' })).toBeVisible()
 	await expect(page.getByRole('link', { name: 'Kingfisher' })).toBeVisible()
 })
 
-test('alpha: does not show Beta species', async ({ page }) => {
-	test.skip(project() !== 'alpha', 'alpha only')
+test('alpha: does not show Beta species', { tag: '@alpha' }, async ({ page }) => {
 	await page.goto('/species')
 	await expect(page.getByRole('link', { name: 'Chaffinch' })).not.toBeVisible()
 })
 
-test('beta: shows own sparse species', async ({ page }) => {
-	test.skip(project() !== 'beta', 'beta only')
+test('beta: shows own sparse species', { tag: '@beta' }, async ({ page }) => {
 	await page.goto('/species')
 	await expect(page.getByRole('link', { name: 'Chaffinch' })).toBeVisible()
 	await expect(page.getByRole('link', { name: 'Robin' })).toBeVisible()
 })
 
-test('beta: does not show Alpha-only species', async ({ page }) => {
-	test.skip(project() !== 'beta', 'beta only')
+test('beta: does not show Alpha-only species', { tag: '@beta' }, async ({ page }) => {
 	await page.goto('/species')
 	await expect(page.getByRole('link', { name: 'Blue Tit' })).not.toBeVisible()
 	await expect(page.getByRole('link', { name: 'Kingfisher' })).not.toBeVisible()
 })
 
-test('gamma: shows empty species table', async ({ page }) => {
-	test.skip(project() !== 'gamma', 'gamma only')
+test('gamma: shows empty species table', { tag: '@gamma' }, async ({ page }) => {
 	await page.goto('/species')
 	await expect(page.getByRole('link', { name: 'Robin' })).not.toBeVisible()
 	await expect(page.getByRole('link', { name: 'Chaffinch' })).not.toBeVisible()

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,21 +20,25 @@ export default defineConfig({
 		},
 		{
 			name: 'alpha',
+			grep: /@alpha|@all/,
 			use: { storageState: 'e2e/.auth/alpha.json' },
 			dependencies: ['setup'],
 		},
 		{
 			name: 'beta',
+			grep: /@beta|@all/,
 			use: { storageState: 'e2e/.auth/beta.json' },
 			dependencies: ['setup'],
 		},
 		{
 			name: 'gamma',
+			grep: /@gamma|@all/,
 			use: { storageState: 'e2e/.auth/gamma.json' },
 			dependencies: ['setup'],
 		},
 		{
 			name: 'delta',
+			grep: /@delta|@all/,
 			use: { storageState: 'e2e/.auth/delta.json' },
 			dependencies: ['setup'],
 		},


### PR DESCRIPTION
## Summary

- Replace all `test.skip(project() !== 'X')` runtime guards with Playwright collection-time tag+grep: tests tagged `@alpha`/`@beta`/`@gamma`/`@delta`/`@all`, projects configured with `grep` in `playwright.config.ts`. Skipped tests now vanish from the report entirely.
- Fix several pre-existing bugs in `import.spec.ts` that prevented the import flow from ever actually running:
  - `psql` shell-quoting broke PascalCase table names → switched to `spawnSync` to bypass shell entirely
  - `button[type="submit"]` matched the nav ring-search button instead of the import button → use `getByRole('button', { name: 'Import' })`
  - Sessions accordion is collapsed by default → click March button before asserting session link
  - Session link format on own-group `/sessions` is `"Friday 15th"`, not `"15th March"` → use `/15th/`
  - Deleting all encounters for a delta-only bird triggers `trg_encounters_refresh_bird_proven_age` which sets `proven_age` to NULL, violating NOT NULL → disable the trigger during cleanup
- Add `npm run test:e2e` to the pre-push hook (requires local Supabase running)

## Test plan

- [ ] `npm run test:e2e` — all 98 tests pass, no skipped tests in report
- [ ] `npm run test:e2e -- --project=alpha` — only `@alpha|@all` tests collected
- [ ] `npm run test:e2e -- --project=delta` — import flow runs and passes end-to-end
- [ ] `git push` — pre-push hook runs e2e suite automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)