### PR TITLE
feat(#203): ring sequences page UI — server actions, model, components

### DIFF
--- a/app/(routes)/ring-sequences/page.tsx
+++ b/app/(routes)/ring-sequences/page.tsx
@@ -1,0 +1,29 @@
+import {
+	BootstrapPageData,
+	type DefaultPageParams
+} from '@/app/components/layout/BootstrapPageData';
+import { fetchRingSequenceSummaries } from '@/app/actions/ring-sequences';
+import type { RingSequenceSummary } from '@/app/actions/ring-sequences';
+import { RingSequencesPage } from '@/app/components/RingSequencesPage';
+
+async function dataFetcher(
+	_: DefaultPageParams,
+	viewedGroupId: number
+): Promise<RingSequenceSummary[] | null> {
+	return fetchRingSequenceSummaries(viewedGroupId);
+}
+
+export default async function RingSequencesRoute({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
+	return (
+		<BootstrapPageData<RingSequenceSummary[]>
+			viewedGroupId={viewedGroupId}
+			getCacheKeys={() => ['ring-sequences']}
+			dataFetcher={dataFetcher}
+			PageComponent={RingSequencesPage}
+		/>
+	);
+}

--- a/app/actions/ring-sequences.ts
+++ b/app/actions/ring-sequences.ts
@@ -1,0 +1,56 @@
+'use server';
+import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
+import { catchSupabaseErrors } from '@/lib/supabase';
+
+export type RingSequenceSummary = {
+	sequence_prefix: string;
+	ring_length: number;
+	ring_count: number;
+	earliest_date: string;
+	latest_date: string;
+};
+
+export type RingSequenceDetailRow = {
+	ring_no: string;
+	species_name: string;
+	ringed_date: string;
+};
+
+export type RingSequenceControlRow = {
+	ring_no: string;
+	species_name: string;
+	first_date: string;
+};
+
+export async function fetchRingSequenceSummaries(
+	viewedGroupId: number
+): Promise<RingSequenceSummary[] | null> {
+	const supabase = await getAuthenticatedSupabaseClient();
+	return supabase
+		.rpc('ring_sequence_summaries', { ringing_group_filter: viewedGroupId })
+		.then(catchSupabaseErrors) as Promise<RingSequenceSummary[] | null>;
+}
+
+export async function fetchRingSequenceDetail(
+	sequencePrefix: string,
+	ringLength: number,
+	viewedGroupId: number
+): Promise<RingSequenceDetailRow[] | null> {
+	const supabase = await getAuthenticatedSupabaseClient();
+	return supabase
+		.rpc('ring_sequence_detail', {
+			sequence_prefix_filter: sequencePrefix,
+			ring_length_filter: ringLength,
+			ringing_group_filter: viewedGroupId
+		})
+		.then(catchSupabaseErrors) as Promise<RingSequenceDetailRow[] | null>;
+}
+
+export async function fetchRingSequenceControls(
+	viewedGroupId: number
+): Promise<RingSequenceControlRow[] | null> {
+	const supabase = await getAuthenticatedSupabaseClient();
+	return supabase
+		.rpc('ring_sequence_controls', { ringing_group_filter: viewedGroupId })
+		.then(catchSupabaseErrors) as Promise<RingSequenceControlRow[] | null>;
+}

--- a/app/components/RingSequenceControls.tsx
+++ b/app/components/RingSequenceControls.tsx
@@ -5,6 +5,7 @@ import {
 	type RingSequenceControlRow
 } from '@/app/actions/ring-sequences';
 import { InlineTable } from './shared/DesignSystem';
+import { NoPrefetchLink } from './shared/NoPrefetchLink';
 
 export function RingSequenceControls({
 	viewedGroupId,
@@ -60,7 +61,11 @@ export function RingSequenceControls({
 			<tbody>
 				{data.map((row) => (
 					<tr key={row.ring_no}>
-						<td>{row.ring_no}</td>
+						<td>
+							<NoPrefetchLink className="link" href={`/bird/${row.ring_no}`}>
+								{row.ring_no}
+							</NoPrefetchLink>
+						</td>
 						<td>{row.species_name}</td>
 						<td>{row.first_date}</td>
 					</tr>

--- a/app/components/RingSequenceControls.tsx
+++ b/app/components/RingSequenceControls.tsx
@@ -1,0 +1,71 @@
+'use client';
+import { useState, useEffect } from 'react';
+import {
+	fetchRingSequenceControls,
+	type RingSequenceControlRow
+} from '@/app/actions/ring-sequences';
+import { InlineTable } from './shared/DesignSystem';
+
+export function RingSequenceControls({
+	viewedGroupId,
+	isExpanded
+}: {
+	viewedGroupId: number;
+	isExpanded: boolean;
+}) {
+	const [data, setData] = useState<RingSequenceControlRow[] | null>(null);
+	const [isLoading, setIsLoading] = useState(false);
+	const [isLoaded, setIsLoaded] = useState(false);
+
+	useEffect(() => {
+		if (!isExpanded || isLoaded) return;
+		let cancelled = false;
+		setTimeout(() => {
+			if (!cancelled) setIsLoading(true);
+		}, 100);
+		fetchRingSequenceControls(viewedGroupId)
+			.then((result) => {
+				if (!cancelled) setData(result);
+			})
+			.catch(console.error)
+			.finally(() => {
+				cancelled = true;
+				setIsLoaded(true);
+				setIsLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [isExpanded, isLoaded, viewedGroupId]);
+
+	if (!isExpanded) return null;
+
+	if (isLoading) {
+		return <span className="loading loading-spinner loading-xl"></span>;
+	}
+
+	if (!data || data.length === 0) {
+		return <p className="py-3">No control birds found.</p>;
+	}
+
+	return (
+		<InlineTable testId="controls-table">
+			<thead>
+				<tr>
+					<th>Ring</th>
+					<th>Species</th>
+					<th>First date</th>
+				</tr>
+			</thead>
+			<tbody>
+				{data.map((row) => (
+					<tr key={row.ring_no}>
+						<td>{row.ring_no}</td>
+						<td>{row.species_name}</td>
+						<td>{row.first_date}</td>
+					</tr>
+				))}
+			</tbody>
+		</InlineTable>
+	);
+}

--- a/app/components/RingSequenceDetail.tsx
+++ b/app/components/RingSequenceDetail.tsx
@@ -1,0 +1,156 @@
+'use client';
+import { useState, useEffect } from 'react';
+import {
+	fetchRingSequenceDetail,
+	type RingSequenceDetailRow
+} from '@/app/actions/ring-sequences';
+import { findUnusedRings } from '@/app/models/ring-sequences';
+import { AccordionItem } from './shared/Accordion';
+import { BoxyList, InlineTable } from './shared/DesignSystem';
+
+type SequenceDetailModel = {
+	sequencePrefix: string;
+	ringLength: number;
+	viewedGroupId: number;
+};
+
+type SpeciesGroup = {
+	speciesName: string;
+	rings: RingSequenceDetailRow[];
+};
+
+function groupBySpecies(rows: RingSequenceDetailRow[]): SpeciesGroup[] {
+	const map = new Map<string, RingSequenceDetailRow[]>();
+	for (const row of rows) {
+		const existing = map.get(row.species_name) ?? [];
+		existing.push(row);
+		map.set(row.species_name, existing);
+	}
+	return Array.from(map.entries()).map(([speciesName, rings]) => ({
+		speciesName,
+		rings
+	}));
+}
+
+function SpeciesHeading({ model }: { model: SpeciesGroup }) {
+	return (
+		<span>
+			<span className="font-bold">{model.speciesName}</span>{' '}
+			<span>({model.rings.length})</span>
+		</span>
+	);
+}
+
+function SpeciesContent({
+	model,
+	expandedId
+}: {
+	model: SpeciesGroup;
+	expandedId: string | false;
+}) {
+	const isExpanded = expandedId === model.speciesName;
+	if (!isExpanded) return null;
+	return (
+		<InlineTable>
+			<thead>
+				<tr>
+					<th>Ring</th>
+					<th>Date ringed</th>
+				</tr>
+			</thead>
+			<tbody>
+				{model.rings.map((ring) => (
+					<tr key={ring.ring_no}>
+						<td>{ring.ring_no}</td>
+						<td>{ring.ringed_date}</td>
+					</tr>
+				))}
+			</tbody>
+		</InlineTable>
+	);
+}
+
+export function RingSequenceDetail({
+	model,
+	expandedId
+}: {
+	model: SequenceDetailModel;
+	expandedId: string | false;
+}) {
+	const accordionId = `${model.sequencePrefix}-${model.ringLength}`;
+	const isExpanded = expandedId === accordionId;
+
+	const [data, setData] = useState<RingSequenceDetailRow[] | null>(null);
+	const [isLoading, setIsLoading] = useState(false);
+	const [isLoaded, setIsLoaded] = useState(false);
+	const [expandedSpecies, setExpandedSpecies] = useState<string | false>(false);
+
+	useEffect(() => {
+		if (!isExpanded || isLoaded) return;
+		let cancelled = false;
+		setTimeout(() => {
+			if (!cancelled) setIsLoading(true);
+		}, 100);
+		fetchRingSequenceDetail(
+			model.sequencePrefix,
+			model.ringLength,
+			model.viewedGroupId
+		)
+			.then((result) => {
+				if (!cancelled) setData(result);
+			})
+			.catch(console.error)
+			.finally(() => {
+				cancelled = true;
+				setIsLoaded(true);
+				setIsLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [
+		isExpanded,
+		isLoaded,
+		model.sequencePrefix,
+		model.ringLength,
+		model.viewedGroupId
+	]);
+
+	if (!isExpanded) return null;
+
+	if (isLoading) {
+		return <span className="loading loading-spinner loading-xl"></span>;
+	}
+
+	if (!data) return null;
+
+	const unusedRings = findUnusedRings(
+		data.map((r) => r.ring_no),
+		model.sequencePrefix.length
+	);
+	const speciesGroups = groupBySpecies(data);
+
+	return (
+		<div className="py-3">
+			{unusedRings.length > 0 && (
+				<p data-testid="unused-rings">
+					<span className="font-bold">Unused rings:</span>{' '}
+					{unusedRings.join(', ')}
+				</p>
+			)}
+			<BoxyList>
+				{speciesGroups.map((group) => (
+					<AccordionItem
+						key={group.speciesName}
+						id={group.speciesName}
+						model={group}
+						onToggle={setExpandedSpecies}
+						expandedId={expandedSpecies}
+						HeadingComponent={SpeciesHeading}
+						ContentComponent={SpeciesContent}
+					/>
+				))}
+			</BoxyList>
+		</div>
+	);
+}

--- a/app/components/RingSequenceDetail.tsx
+++ b/app/components/RingSequenceDetail.tsx
@@ -7,6 +7,7 @@ import {
 import { findUnusedRings } from '@/app/models/ring-sequences';
 import { AccordionItem } from './shared/Accordion';
 import { BoxyList, InlineTable } from './shared/DesignSystem';
+import { NoPrefetchLink } from './shared/NoPrefetchLink';
 
 type SequenceDetailModel = {
 	sequencePrefix: string;
@@ -61,7 +62,11 @@ function SpeciesContent({
 			<tbody>
 				{model.rings.map((ring) => (
 					<tr key={ring.ring_no}>
-						<td>{ring.ring_no}</td>
+						<td>
+							<NoPrefetchLink className="link" href={`/bird/${ring.ring_no}`}>
+								{ring.ring_no}
+							</NoPrefetchLink>
+						</td>
 						<td>{ring.ringed_date}</td>
 					</tr>
 				))}

--- a/app/components/RingSequencesPage.tsx
+++ b/app/components/RingSequencesPage.tsx
@@ -1,0 +1,112 @@
+'use client';
+import { useState } from 'react';
+import type { RingSequenceSummary } from '@/app/actions/ring-sequences';
+import { AccordionItem } from './shared/Accordion';
+import { BoxyList, PageWrapper, PrimaryHeading } from './shared/DesignSystem';
+import { RingSequenceControls } from './RingSequenceControls';
+import { RingSequenceDetail } from './RingSequenceDetail';
+
+const CONTROLS_ID = 'controls';
+
+type SequenceSummaryModel = {
+	summary: RingSequenceSummary;
+	viewedGroupId: number;
+};
+
+function SequenceHeading({ model }: { model: SequenceSummaryModel }) {
+	const { summary } = model;
+	return (
+		<span>
+			<span className="font-bold">{summary.sequence_prefix}</span>
+			{' — '}
+			<span>{summary.ring_count} rings</span>
+			{', '}
+			<span>
+				{summary.earliest_date} – {summary.latest_date}
+			</span>
+		</span>
+	);
+}
+
+function SequenceContent({
+	model,
+	expandedId
+}: {
+	model: SequenceSummaryModel;
+	expandedId: string | false;
+}) {
+	const accordionId = `${model.summary.sequence_prefix}-${model.summary.ring_length}`;
+	return (
+		<RingSequenceDetail
+			model={{
+				sequencePrefix: model.summary.sequence_prefix,
+				ringLength: model.summary.ring_length,
+				viewedGroupId: model.viewedGroupId
+			}}
+			expandedId={expandedId}
+		/>
+	);
+}
+
+function ControlsHeading() {
+	return <span className="font-bold">Controls</span>;
+}
+
+function ControlsContent({
+	model,
+	expandedId
+}: {
+	model: { viewedGroupId: number };
+	expandedId: string | false;
+}) {
+	return (
+		<RingSequenceControls
+			viewedGroupId={model.viewedGroupId}
+			isExpanded={expandedId === CONTROLS_ID}
+		/>
+	);
+}
+
+export function RingSequencesPage({
+	data,
+	viewedGroupId
+}: {
+	params: Record<string, string>;
+	data: RingSequenceSummary[];
+	viewedGroupId: number;
+}) {
+	const [expandedId, setExpandedId] = useState<string | false>(false);
+
+	return (
+		<PageWrapper>
+			<PrimaryHeading>Ring Sequences</PrimaryHeading>
+			<BoxyList>
+				<AccordionItem
+					id={CONTROLS_ID}
+					model={{ viewedGroupId }}
+					onToggle={setExpandedId}
+					expandedId={expandedId}
+					HeadingComponent={ControlsHeading}
+					ContentComponent={ControlsContent}
+					testId="controls-accordion"
+				/>
+				{data.map((summary) => {
+					const id = `${summary.sequence_prefix}-${summary.ring_length}`;
+					const summaryModel: SequenceSummaryModel = { summary, viewedGroupId };
+					return (
+						<AccordionItem
+							key={id}
+							id={id}
+							model={summaryModel}
+							onToggle={setExpandedId}
+							expandedId={expandedId}
+							HeadingComponent={SequenceHeading}
+							ContentComponent={SequenceContent}
+							testId={`sequence-${id}`}
+						/>
+					);
+				})}
+			</BoxyList>
+		</PageWrapper>
+	);
+}

--- a/app/components/RingSequencesPage.tsx
+++ b/app/components/RingSequencesPage.tsx
@@ -35,7 +35,6 @@ function SequenceContent({
 	model: SequenceSummaryModel;
 	expandedId: string | false;
 }) {
-	const accordionId = `${model.summary.sequence_prefix}-${model.summary.ring_length}`;
 	return (
 		<RingSequenceDetail
 			model={{

--- a/app/components/__tests__/RingSequenceDetail.test.tsx
+++ b/app/components/__tests__/RingSequenceDetail.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import {
+	render,
+	screen,
+	cleanup,
+	waitFor,
+	fireEvent
+} from '@testing-library/react';
+import { RingSequenceDetail } from '../RingSequenceDetail';
+import type { RingSequenceDetailRow } from '@/app/actions/ring-sequences';
+
+vi.mock('@/app/actions/ring-sequences', () => ({
+	fetchRingSequenceSummaries: vi.fn(),
+	fetchRingSequenceDetail: vi.fn(),
+	fetchRingSequenceControls: vi.fn()
+}));
+
+const mockDetailRows: RingSequenceDetailRow[] = [
+	{ ring_no: 'ARW000001', species_name: 'Robin', ringed_date: '2022-06-15' },
+	{ ring_no: 'ARW000002', species_name: 'Robin', ringed_date: '2022-06-15' },
+	{ ring_no: 'ARW000004', species_name: 'Blue Tit', ringed_date: '2023-04-01' }
+];
+
+const detailModel = {
+	sequencePrefix: 'ARW',
+	ringLength: 9,
+	viewedGroupId: 1
+};
+
+const accordionId = 'ARW-9';
+
+describe('RingSequenceDetail', () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('fetches detail data when the item is expanded', async () => {
+		const { fetchRingSequenceDetail } =
+			await import('@/app/actions/ring-sequences');
+		vi.mocked(fetchRingSequenceDetail).mockResolvedValue(mockDetailRows);
+
+		render(<RingSequenceDetail model={detailModel} expandedId={accordionId} />);
+
+		await waitFor(() => {
+			expect(vi.mocked(fetchRingSequenceDetail)).toHaveBeenCalledWith(
+				'ARW',
+				9,
+				1
+			);
+		});
+	});
+
+	it('renders nothing when not expanded', () => {
+		render(<RingSequenceDetail model={detailModel} expandedId="other-id" />);
+		expect(screen.queryByTestId('unused-rings')).toBeNull();
+	});
+
+	it('shows unused rings when there are gaps in the sequence', async () => {
+		const { fetchRingSequenceDetail } =
+			await import('@/app/actions/ring-sequences');
+		vi.mocked(fetchRingSequenceDetail).mockResolvedValue(mockDetailRows);
+
+		render(<RingSequenceDetail model={detailModel} expandedId={accordionId} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('unused-rings')).toBeDefined();
+		});
+		expect(screen.getByTestId('unused-rings').textContent).toContain(
+			'ARW000003'
+		);
+	});
+
+	it('does not show unused rings section when no gaps exist', async () => {
+		const { fetchRingSequenceDetail } =
+			await import('@/app/actions/ring-sequences');
+		const contiguousRows: RingSequenceDetailRow[] = [
+			{
+				ring_no: 'ARW000001',
+				species_name: 'Robin',
+				ringed_date: '2022-06-15'
+			},
+			{ ring_no: 'ARW000002', species_name: 'Robin', ringed_date: '2022-06-16' }
+		];
+		vi.mocked(fetchRingSequenceDetail).mockResolvedValue(contiguousRows);
+
+		render(<RingSequenceDetail model={detailModel} expandedId={accordionId} />);
+
+		await waitFor(() => {
+			expect(screen.queryByTestId('unused-rings')).toBeNull();
+		});
+	});
+
+	it('groups rings by species in a sub-accordion', async () => {
+		const { fetchRingSequenceDetail } =
+			await import('@/app/actions/ring-sequences');
+		vi.mocked(fetchRingSequenceDetail).mockResolvedValue(mockDetailRows);
+
+		render(<RingSequenceDetail model={detailModel} expandedId={accordionId} />);
+
+		await waitFor(() => {
+			expect(screen.getByText(/Robin/)).toBeDefined();
+			expect(screen.getByText(/Blue Tit/)).toBeDefined();
+		});
+	});
+
+	it('shows ring count in species heading', async () => {
+		const { fetchRingSequenceDetail } =
+			await import('@/app/actions/ring-sequences');
+		vi.mocked(fetchRingSequenceDetail).mockResolvedValue(mockDetailRows);
+
+		render(<RingSequenceDetail model={detailModel} expandedId={accordionId} />);
+
+		await waitFor(() => {
+			const robinHeading = screen
+				.getAllByText(/Robin/)
+				.find((el) => el.closest('button') !== null);
+			expect(robinHeading?.closest('button')?.textContent).toContain('(2)');
+		});
+	});
+
+	it('shows individual ring numbers and dates when species sub-item expanded', async () => {
+		const { fetchRingSequenceDetail } =
+			await import('@/app/actions/ring-sequences');
+		vi.mocked(fetchRingSequenceDetail).mockResolvedValue(mockDetailRows);
+
+		render(<RingSequenceDetail model={detailModel} expandedId={accordionId} />);
+
+		await waitFor(() => {
+			expect(screen.getByText('Robin')).toBeDefined();
+		});
+
+		const robinButtons = screen
+			.getAllByRole('button')
+			.filter((btn) => btn.textContent?.includes('Robin'));
+		fireEvent.click(robinButtons[0]);
+
+		await waitFor(() => {
+			expect(screen.getByText('ARW000001')).toBeDefined();
+			expect(screen.getByText('ARW000002')).toBeDefined();
+		});
+	});
+});

--- a/app/components/__tests__/RingSequenceDetail.test.tsx
+++ b/app/components/__tests__/RingSequenceDetail.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
 	render,
 	screen,

--- a/app/components/__tests__/RingSequencesPage.test.tsx
+++ b/app/components/__tests__/RingSequencesPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
 	render,
 	screen,

--- a/app/components/__tests__/RingSequencesPage.test.tsx
+++ b/app/components/__tests__/RingSequencesPage.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import {
+	render,
+	screen,
+	cleanup,
+	waitFor,
+	fireEvent
+} from '@testing-library/react';
+import { RingSequencesPage } from '../RingSequencesPage';
+import type {
+	RingSequenceSummary,
+	RingSequenceControlRow
+} from '@/app/actions/ring-sequences';
+
+vi.mock('@/app/actions/ring-sequences', () => ({
+	fetchRingSequenceSummaries: vi.fn(),
+	fetchRingSequenceDetail: vi.fn(),
+	fetchRingSequenceControls: vi.fn()
+}));
+
+const mockSummaries: RingSequenceSummary[] = [
+	{
+		sequence_prefix: 'ARW',
+		ring_length: 9,
+		ring_count: 15,
+		earliest_date: '2022-06-15',
+		latest_date: '2024-05-10'
+	},
+	{
+		sequence_prefix: 'ABT',
+		ring_length: 8,
+		ring_count: 6,
+		earliest_date: '2022-04-30',
+		latest_date: '2023-05-12'
+	}
+];
+
+const mockControls: RingSequenceControlRow[] = [
+	{ ring_no: 'SHARED01', species_name: 'Robin', first_date: '2023-06-01' }
+];
+
+const viewedGroupId = 1;
+
+describe('RingSequencesPage', () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('renders Controls accordion item first', () => {
+		render(
+			<RingSequencesPage
+				params={{}}
+				data={mockSummaries}
+				viewedGroupId={viewedGroupId}
+			/>
+		);
+		const items = screen.getAllByRole('listitem');
+		expect(items[0].getAttribute('data-testid')).toBe('controls-accordion');
+	});
+
+	it('renders one accordion item per ring sequence summary', () => {
+		render(
+			<RingSequencesPage
+				params={{}}
+				data={mockSummaries}
+				viewedGroupId={viewedGroupId}
+			/>
+		);
+		expect(screen.getByTestId('sequence-ARW-9')).toBeDefined();
+		expect(screen.getByTestId('sequence-ABT-8')).toBeDefined();
+	});
+
+	it('shows sequence prefix, ring count, and date range in heading', () => {
+		render(
+			<RingSequencesPage
+				params={{}}
+				data={mockSummaries}
+				viewedGroupId={viewedGroupId}
+			/>
+		);
+		const arwItem = screen.getByTestId('sequence-ARW-9');
+		expect(arwItem.textContent).toContain('ARW');
+		expect(arwItem.textContent).toContain('15 rings');
+		expect(arwItem.textContent).toContain('2022-06-15');
+		expect(arwItem.textContent).toContain('2024-05-10');
+	});
+
+	it('expands Controls item and fetches controls data', async () => {
+		const { fetchRingSequenceControls } =
+			await import('@/app/actions/ring-sequences');
+		vi.mocked(fetchRingSequenceControls).mockResolvedValue(mockControls);
+
+		render(
+			<RingSequencesPage
+				params={{}}
+				data={mockSummaries}
+				viewedGroupId={viewedGroupId}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByTestId('controls-accordion').querySelector('button')!
+		);
+
+		await waitFor(() => {
+			expect(vi.mocked(fetchRingSequenceControls)).toHaveBeenCalledWith(
+				viewedGroupId
+			);
+		});
+	});
+
+	it('displays controls table once data resolves', async () => {
+		const { fetchRingSequenceControls } =
+			await import('@/app/actions/ring-sequences');
+		vi.mocked(fetchRingSequenceControls).mockResolvedValue(mockControls);
+
+		render(
+			<RingSequencesPage
+				params={{}}
+				data={mockSummaries}
+				viewedGroupId={viewedGroupId}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByTestId('controls-accordion').querySelector('button')!
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('controls-table')).toBeDefined();
+		});
+		expect(screen.getByText('SHARED01')).toBeDefined();
+		expect(screen.getByText('Robin')).toBeDefined();
+	});
+
+	it('collapses Controls when a sequence item is expanded', async () => {
+		const { fetchRingSequenceControls, fetchRingSequenceDetail } =
+			await import('@/app/actions/ring-sequences');
+		vi.mocked(fetchRingSequenceControls).mockResolvedValue(mockControls);
+		vi.mocked(fetchRingSequenceDetail).mockResolvedValue([]);
+
+		render(
+			<RingSequencesPage
+				params={{}}
+				data={mockSummaries}
+				viewedGroupId={viewedGroupId}
+			/>
+		);
+
+		fireEvent.click(
+			screen.getByTestId('controls-accordion').querySelector('button')!
+		);
+		await waitFor(() => {
+			expect(screen.getByTestId('controls-table')).toBeDefined();
+		});
+
+		fireEvent.click(
+			screen.getByTestId('sequence-ARW-9').querySelector('button')!
+		);
+
+		await waitFor(() => {
+			expect(screen.queryByTestId('controls-table')).toBeNull();
+		});
+	});
+});

--- a/app/models/__tests__/ring-sequences.test.ts
+++ b/app/models/__tests__/ring-sequences.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { findUnusedRings } from '../ring-sequences';
+
+describe('findUnusedRings', () => {
+	it('returns empty array when no gaps exist', () => {
+		const rings = ['ARW000001', 'ARW000002', 'ARW000003'];
+		expect(findUnusedRings(rings, 3)).toEqual([]);
+	});
+
+	it('returns missing ring numbers between min and max suffix', () => {
+		const rings = ['ARW000001', 'ARW000003', 'ARW000005'];
+		expect(findUnusedRings(rings, 3)).toEqual(['ARW000002', 'ARW000004']);
+	});
+
+	it('pads suffix with leading zeros to match original ring length', () => {
+		const rings = ['ARW000001', 'ARW000010'];
+		const unused = findUnusedRings(rings, 3);
+		expect(unused).toContain('ARW000002');
+		expect(unused).toContain('ARW000009');
+		expect(unused[0]).toHaveLength(9);
+	});
+
+	it('returns empty array for a single ring', () => {
+		expect(findUnusedRings(['ARW000001'], 3)).toEqual([]);
+	});
+
+	it('returns empty array when input is empty', () => {
+		expect(findUnusedRings([], 3)).toEqual([]);
+	});
+});

--- a/app/models/ring-sequences.ts
+++ b/app/models/ring-sequences.ts
@@ -1,0 +1,21 @@
+export function findUnusedRings(
+	rings: string[],
+	prefixLength: number
+): string[] {
+	if (rings.length === 0) return [];
+
+	const suffixLength = rings[0].length - prefixLength;
+	const prefix = rings[0].slice(0, prefixLength);
+	const suffixes = rings.map((ring) => parseInt(ring.slice(prefixLength), 10));
+	const min = Math.min(...suffixes);
+	const max = Math.max(...suffixes);
+	const suffixSet = new Set(suffixes);
+
+	const unused: string[] = [];
+	for (let i = min + 1; i < max; i++) {
+		if (!suffixSet.has(i)) {
+			unused.push(`${prefix}${String(i).padStart(suffixLength, '0')}`);
+		}
+	}
+	return unused;
+}

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -34,6 +34,33 @@ function getGroupIds(): Record<string, number> {
 	return ids
 }
 
+const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:3000'
+
+// Pre-warm Next.js page compilation before parallel workers start.
+// Without this, 4 workers simultaneously hit uncompiled routes, causing >30s
+// compilation timeouts on first request.
+async function warmupServer() {
+	const routes = [
+		'/',
+		'/sessions',
+		'/species',
+		'/mistakes',
+		'/retraps',
+		'/effort',
+		'/bird/ARRETRAP',
+		'/species/Robin',
+	]
+	console.log('Warming up server routes...')
+	await Promise.all(
+		routes.map((route) =>
+			fetch(`${BASE_URL}${route}`).catch(() => {
+				// Ignore errors (e.g. auth redirects); we only need compilation to run
+			})
+		)
+	)
+	console.log('Server warmup complete')
+}
+
 export default async function globalSetup() {
 	mkdirSync(path.join(ROOT, 'e2e', '.auth'), { recursive: true })
 	if (isAlreadySeeded()) {
@@ -48,4 +75,6 @@ export default async function globalSetup() {
 		JSON.stringify(groupIds, null, 2)
 	)
 	console.log('Group IDs:', groupIds)
+
+	await warmupServer()
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
 	use: {
 		baseURL: BASE_URL,
 		trace: 'on-first-retry',
+		actionTimeout: 60_000,
 	},
 	projects: [
 		{

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
 	retries: process.env.CI ? 2 : 0,
 	reporter: 'html',
 	globalSetup: './e2e/global-setup.ts',
+	timeout: 60_000,
 	use: {
 		baseURL: BASE_URL,
 		trace: 'on-first-retry',

--- a/supabase/__tests__/ring-sequences.test.ts
+++ b/supabase/__tests__/ring-sequences.test.ts
@@ -1,0 +1,257 @@
+/**
+ * Integration tests for ring-sequence RPC functions.
+ *
+ * Requires local Supabase running and e2e seed data loaded:
+ *   npm run db:start:local
+ *   npm run db:seed:e2e
+ *
+ * Run with: npm run test:integration
+ */
+
+import { describe, it, beforeAll, expect } from 'vitest';
+import { getAuthenticatedSupabaseClientForGroup } from '../../lib/group-auth';
+import { supabase } from '../../lib/supabase';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+async function getGroupIdByName(name: string): Promise<number> {
+	const { data, error } = await supabase
+		.from('RingingGroups')
+		.select('id')
+		.eq('group_name', name)
+		.single();
+	if (error || !data) throw new Error(`Group "${name}" not found — run npm run db:seed:e2e first`);
+	return data.id;
+}
+
+describe('ring sequence RPC functions', () => {
+	let alphaId: number;
+	let betaId: number;
+	let alphaClient: SupabaseClient;
+	let betaClient: SupabaseClient;
+
+	beforeAll(async () => {
+		alphaId = await getGroupIdByName('Alpha');
+		betaId = await getGroupIdByName('Beta');
+
+		[alphaClient, betaClient] = await Promise.all([
+			getAuthenticatedSupabaseClientForGroup(alphaId),
+			getAuthenticatedSupabaseClientForGroup(betaId),
+		]);
+	});
+
+	// Alpha seed has 6 ring sequences (all N-type encounters):
+	//   ARW (len 9): 15 Reed Warbler rings, 2022-06-15 – 2024-05-10
+	//   ABT (len 8): 6 Blue Tit rings,     2022-04-30 – 2023-05-12
+	//   AR0 (len 6): 21 Robin rings,        2022-04-30 – 2023-05-12
+	//   AKI (len 9): 1 Kingfisher ring,     2022-04-30 – 2022-04-30
+	//   SHA (len 8): 1 Robin ring,          2022-04-30 – 2022-04-30
+	//   ARR (len 8): 1 Robin ring,          2021-06-20 – 2021-06-20
+	//
+	// ARRETRAP has 1 N encounter + 8 S encounters; it falls in the ARR sequence.
+	// Beta seed has BCH (len 8): 2 Chaffinch rings, 2023-06-01 – 2023-06-01
+	// Beta also has 1 S encounter for SHARED01 (Robin, originally ringed by Alpha).
+
+	describe('ring_sequence_summaries', () => {
+		it('groups birds by 3-char prefix and total ring length', async () => {
+			const { data, error } = await alphaClient.rpc('ring_sequence_summaries', {
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(6);
+			const prefixes = data!.map((r) => r.sequence_prefix);
+			expect(prefixes).toContain('ARW');
+			expect(prefixes).toContain('ABT');
+			expect(prefixes).toContain('AR0');
+		});
+
+		it('counts only distinct ring_nos per sequence', async () => {
+			const { data, error } = await alphaClient.rpc('ring_sequence_summaries', {
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			const byPrefix = Object.fromEntries(
+				data!.map((r) => [r.sequence_prefix, r])
+			);
+			expect(Number(byPrefix['ARW'].ring_count)).toBe(15);
+			expect(Number(byPrefix['ABT'].ring_count)).toBe(6);
+			expect(Number(byPrefix['AR0'].ring_count)).toBe(21);
+			expect(Number(byPrefix['ARR'].ring_count)).toBe(1);
+		});
+
+		it('excludes encounters where record_type is not N', async () => {
+			// ARRETRAP has 1 N + 8 S encounters; only the N should be counted
+			const { data, error } = await alphaClient.rpc('ring_sequence_summaries', {
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			const arrRow = data!.find((r) => r.sequence_prefix === 'ARR');
+			expect(Number(arrRow!.ring_count)).toBe(1);
+			// Earliest/latest date should reflect the single N encounter date (2021-06-20)
+			expect(arrRow!.earliest_date).toBe('2021-06-20');
+			expect(arrRow!.latest_date).toBe('2021-06-20');
+		});
+
+		it('filters by ringing_group_id when provided', async () => {
+			const { data, error } = await betaClient.rpc('ring_sequence_summaries', {
+				ringing_group_filter: betaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(1);
+			expect(data![0].sequence_prefix).toBe('BCH');
+			expect(Number(data![0].ring_count)).toBe(2);
+		});
+
+		it('sorts by latest_date DESC, then earliest_date DESC, then sequence_prefix ASC', async () => {
+			const { data, error } = await alphaClient.rpc('ring_sequence_summaries', {
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			// ARW has latest 2024-05-10; ABT and AR0 tie on latest 2023-05-12 and earliest 2022-04-30
+			// tiebreak: ABT < AR0 alphabetically
+			expect(data![0].sequence_prefix).toBe('ARW');
+			expect(data![1].sequence_prefix).toBe('ABT');
+			expect(data![2].sequence_prefix).toBe('AR0');
+			// ARR has earliest latest_date
+			expect(data![5].sequence_prefix).toBe('ARR');
+		});
+
+		it('returns correct date ranges per sequence', async () => {
+			const { data, error } = await alphaClient.rpc('ring_sequence_summaries', {
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			const byPrefix = Object.fromEntries(
+				data!.map((r) => [r.sequence_prefix, r])
+			);
+			expect(byPrefix['ARW'].earliest_date).toBe('2022-06-15');
+			expect(byPrefix['ARW'].latest_date).toBe('2024-05-10');
+			expect(byPrefix['AR0'].earliest_date).toBe('2022-04-30');
+			expect(byPrefix['AR0'].latest_date).toBe('2023-05-12');
+		});
+
+		it('returns empty array when group has no N-type encounters', async () => {
+			// Gamma group has no encounters
+			const gammaId = await getGroupIdByName('Gamma');
+			const gammaClient = await getAuthenticatedSupabaseClientForGroup(gammaId);
+			const { data, error } = await gammaClient.rpc('ring_sequence_summaries', {
+				ringing_group_filter: gammaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(0);
+		});
+	});
+
+	describe('ring_sequence_detail', () => {
+		it('returns ring_no, species_name, ringed_date for matching prefix and length', async () => {
+			const { data, error } = await alphaClient.rpc('ring_sequence_detail', {
+				sequence_prefix_filter: 'ARW',
+				ring_length_filter: 9,
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(15);
+			expect(data![0]).toMatchObject({
+				ring_no: 'ARWRBL001',
+				species_name: 'Reed Warbler',
+				ringed_date: '2022-06-15',
+			});
+			expect(data![14]).toMatchObject({
+				ring_no: 'ARWRBL015',
+				ringed_date: '2024-05-10',
+			});
+		});
+
+		it('excludes encounters where record_type is not N', async () => {
+			// ARR prefix: only ARRETRAP, which has 1 N + 8 S encounters
+			const { data, error } = await alphaClient.rpc('ring_sequence_detail', {
+				sequence_prefix_filter: 'ARR',
+				ring_length_filter: 8,
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(1);
+			expect(data![0].ring_no).toBe('ARRETRAP');
+			expect(data![0].ringed_date).toBe('2021-06-20');
+		});
+
+		it('filters by ringing_group_id', async () => {
+			// Alpha has SHA sequence (SHARED01 with N record); Beta has no N records for SHA
+			const { data, error } = await betaClient.rpc('ring_sequence_detail', {
+				sequence_prefix_filter: 'SHA',
+				ring_length_filter: 8,
+				ringing_group_filter: betaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(0);
+		});
+
+		it('does not return rings from a different prefix or length', async () => {
+			const { data, error } = await alphaClient.rpc('ring_sequence_detail', {
+				sequence_prefix_filter: 'ABT',
+				ring_length_filter: 8,
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(6);
+			expect(data!.every((r) => r.ring_no.startsWith('ABT') && r.ring_no.length === 8)).toBe(true);
+		});
+	});
+
+	describe('ring_sequence_controls', () => {
+		it('returns rings where every encounter for the group is record_type S', async () => {
+			// Beta has SHARED01 with only 1 S encounter
+			const { data, error } = await betaClient.rpc('ring_sequence_controls', {
+				ringing_group_filter: betaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(1);
+			expect(data![0]).toMatchObject({
+				ring_no: 'SHARED01',
+				species_name: 'Robin',
+				first_date: '2023-06-01',
+			});
+		});
+
+		it('excludes rings that have any N encounter for the group', async () => {
+			// Alpha: all birds have at least 1 N encounter → no controls
+			const { data, error } = await alphaClient.rpc('ring_sequence_controls', {
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(0);
+		});
+
+		it('excludes ARRETRAP because it has an N record despite also having S records', async () => {
+			// ARRETRAP has 1 N + 8 S for Alpha — should not appear in Alpha controls
+			const { data, error } = await alphaClient.rpc('ring_sequence_controls', {
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			const arretrap = data!.find((r) => r.ring_no === 'ARRETRAP');
+			expect(arretrap).toBeUndefined();
+		});
+
+		it('filters by ringing_group_id', async () => {
+			// SHARED01 is a control for Beta but not for Alpha
+			const { data: alphaData } = await alphaClient.rpc('ring_sequence_controls', {
+				ringing_group_filter: alphaId,
+			});
+			const { data: betaData } = await betaClient.rpc('ring_sequence_controls', {
+				ringing_group_filter: betaId,
+			});
+			expect(alphaData!.find((r) => r.ring_no === 'SHARED01')).toBeUndefined();
+			expect(betaData!.find((r) => r.ring_no === 'SHARED01')).toBeDefined();
+		});
+
+		it('returns ring_no, species_name and first_date columns', async () => {
+			const { data, error } = await betaClient.rpc('ring_sequence_controls', {
+				ringing_group_filter: betaId,
+			});
+			expect(error).toBeNull();
+			const row = data![0];
+			expect(row).toHaveProperty('ring_no');
+			expect(row).toHaveProperty('species_name');
+			expect(row).toHaveProperty('first_date');
+		});
+	});
+});

--- a/supabase/schema/schemas/public/functions/ring_sequence_controls.sql
+++ b/supabase/schema/schemas/public/functions/ring_sequence_controls.sql
@@ -1,0 +1,32 @@
+CREATE FUNCTION public.ring_sequence_controls (
+	ringing_group_filter bigint DEFAULT NULL::bigint
+) RETURNS TABLE (
+	ring_no text,
+	species_name text,
+	first_date date
+) LANGUAGE plpgsql STABLE
+SET
+	search_path TO 'public',
+	'pg_catalog' AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT
+    b.ring_no,
+    sp.species_name   AS species_name,
+    MIN(s.visit_date) AS first_date
+  FROM "Birds" b
+  JOIN "Encounters" e  ON e.bird_id = b.id
+  JOIN "Sessions"   s  ON s.id = e.session_id
+  JOIN "Species"    sp ON sp.id = b.species_id
+  WHERE (ringing_group_filter IS NULL OR e.ringing_group_id = ringing_group_filter)
+  GROUP BY b.ring_no, sp.species_name
+  HAVING COUNT(*) = COUNT(*) FILTER (WHERE e.record_type = 'S')
+  ORDER BY b.ring_no;
+END;
+$function$;
+
+GRANT ALL ON FUNCTION public.ring_sequence_controls (bigint) TO anon;
+
+GRANT ALL ON FUNCTION public.ring_sequence_controls (bigint) TO authenticated;
+
+GRANT ALL ON FUNCTION public.ring_sequence_controls (bigint) TO service_role;

--- a/supabase/schema/schemas/public/functions/ring_sequence_controls.sql
+++ b/supabase/schema/schemas/public/functions/ring_sequence_controls.sql
@@ -1,10 +1,4 @@
-CREATE FUNCTION public.ring_sequence_controls (
-	ringing_group_filter bigint DEFAULT NULL::bigint
-) RETURNS TABLE (
-	ring_no text,
-	species_name text,
-	first_date date
-) LANGUAGE plpgsql STABLE
+CREATE FUNCTION public.ring_sequence_controls (ringing_group_filter bigint DEFAULT NULL::bigint) RETURNS TABLE (ring_no text, species_name text, first_date date) LANGUAGE plpgsql STABLE
 SET
 	search_path TO 'public',
 	'pg_catalog' AS $function$

--- a/supabase/schema/schemas/public/functions/ring_sequence_detail.sql
+++ b/supabase/schema/schemas/public/functions/ring_sequence_detail.sql
@@ -1,0 +1,35 @@
+CREATE FUNCTION public.ring_sequence_detail (
+	sequence_prefix_filter text,
+	ring_length_filter int,
+	ringing_group_filter bigint DEFAULT NULL::bigint
+) RETURNS TABLE (
+	ring_no text,
+	species_name text,
+	ringed_date date
+) LANGUAGE plpgsql STABLE
+SET
+	search_path TO 'public',
+	'pg_catalog' AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT
+    b.ring_no,
+    sp.species_name AS species_name,
+    s.visit_date    AS ringed_date
+  FROM "Birds" b
+  JOIN "Species"    sp ON sp.id = b.species_id
+  JOIN "Encounters" e  ON e.bird_id = b.id
+  JOIN "Sessions"   s  ON s.id = e.session_id
+  WHERE e.record_type = 'N'
+    AND LEFT(b.ring_no, 3) = sequence_prefix_filter
+    AND LENGTH(b.ring_no) = ring_length_filter
+    AND (ringing_group_filter IS NULL OR e.ringing_group_id = ringing_group_filter)
+  ORDER BY b.ring_no;
+END;
+$function$;
+
+GRANT ALL ON FUNCTION public.ring_sequence_detail (text, int, bigint) TO anon;
+
+GRANT ALL ON FUNCTION public.ring_sequence_detail (text, int, bigint) TO authenticated;
+
+GRANT ALL ON FUNCTION public.ring_sequence_detail (text, int, bigint) TO service_role;

--- a/supabase/schema/schemas/public/functions/ring_sequence_detail.sql
+++ b/supabase/schema/schemas/public/functions/ring_sequence_detail.sql
@@ -2,11 +2,7 @@ CREATE FUNCTION public.ring_sequence_detail (
 	sequence_prefix_filter text,
 	ring_length_filter int,
 	ringing_group_filter bigint DEFAULT NULL::bigint
-) RETURNS TABLE (
-	ring_no text,
-	species_name text,
-	ringed_date date
-) LANGUAGE plpgsql STABLE
+) RETURNS TABLE (ring_no text, species_name text, ringed_date date) LANGUAGE plpgsql STABLE
 SET
 	search_path TO 'public',
 	'pg_catalog' AS $function$

--- a/supabase/schema/schemas/public/functions/ring_sequence_summaries.sql
+++ b/supabase/schema/schemas/public/functions/ring_sequence_summaries.sql
@@ -1,6 +1,4 @@
-CREATE FUNCTION public.ring_sequence_summaries (
-	ringing_group_filter bigint DEFAULT NULL::bigint
-) RETURNS TABLE (
+CREATE FUNCTION public.ring_sequence_summaries (ringing_group_filter bigint DEFAULT NULL::bigint) RETURNS TABLE (
 	sequence_prefix text,
 	ring_length int,
 	ring_count bigint,

--- a/supabase/schema/schemas/public/functions/ring_sequence_summaries.sql
+++ b/supabase/schema/schemas/public/functions/ring_sequence_summaries.sql
@@ -1,0 +1,35 @@
+CREATE FUNCTION public.ring_sequence_summaries (
+	ringing_group_filter bigint DEFAULT NULL::bigint
+) RETURNS TABLE (
+	sequence_prefix text,
+	ring_length int,
+	ring_count bigint,
+	earliest_date date,
+	latest_date date
+) LANGUAGE plpgsql STABLE
+SET
+	search_path TO 'public',
+	'pg_catalog' AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT
+    LEFT(b.ring_no, 3)             AS sequence_prefix,
+    LENGTH(b.ring_no)              AS ring_length,
+    COUNT(DISTINCT b.ring_no)      AS ring_count,
+    MIN(s.visit_date)              AS earliest_date,
+    MAX(s.visit_date)              AS latest_date
+  FROM "Birds" b
+  JOIN "Encounters" e ON e.bird_id = b.id
+  JOIN "Sessions"   s ON s.id = e.session_id
+  WHERE e.record_type = 'N'
+    AND (ringing_group_filter IS NULL OR e.ringing_group_id = ringing_group_filter)
+  GROUP BY LEFT(b.ring_no, 3), LENGTH(b.ring_no)
+  ORDER BY MAX(s.visit_date) DESC, MIN(s.visit_date) DESC, LEFT(b.ring_no, 3) ASC;
+END;
+$function$;
+
+GRANT ALL ON FUNCTION public.ring_sequence_summaries (bigint) TO anon;
+
+GRANT ALL ON FUNCTION public.ring_sequence_summaries (bigint) TO authenticated;
+
+GRANT ALL ON FUNCTION public.ring_sequence_summaries (bigint) TO service_role;

--- a/types/supabase.types.ts
+++ b/types/supabase.types.ts
@@ -373,6 +373,36 @@ export type Database = {
           species_name: string
         }[]
       }
+      ring_sequence_controls: {
+        Args: { ringing_group_filter?: number }
+        Returns: {
+          first_date: string
+          ring_no: string
+          species_name: string
+        }[]
+      }
+      ring_sequence_detail: {
+        Args: {
+          ring_length_filter: number
+          ringing_group_filter?: number
+          sequence_prefix_filter: string
+        }
+        Returns: {
+          ring_no: string
+          ringed_date: string
+          species_name: string
+        }[]
+      }
+      ring_sequence_summaries: {
+        Args: { ringing_group_filter?: number }
+        Returns: {
+          earliest_date: string
+          latest_date: string
+          ring_count: number
+          ring_length: number
+          sequence_prefix: string
+        }[]
+      }
       soundex: { Args: { "": string }; Returns: string }
       text_soundex: { Args: { "": string }; Returns: string }
       top_metrics_by_period: {


### PR DESCRIPTION
## Summary

- Adds `/ring-sequences` page showing ring sequences (grouped by 3-char prefix + total ring length)
- Each sequence accordion item shows prefix, ring count, and date range; expands to lazy-load species breakdown with unused ring gap detection
- Controls accordion item (always first) lazy-loads rings where every encounter is a sighting (`record_type = 'S'`)
- Server actions in `app/actions/ring-sequences.ts` call the three RPCs added in PR 1
- Pure `findUnusedRings` helper in `app/models/ring-sequences.ts` detects gaps between min and max numeric suffix

## Test plan

- [x] `npm run test:nowatch` — 148 tests pass (includes `RingSequencesPage`, `RingSequenceDetail`, and `findUnusedRings` unit tests)
- [x] `npm run qa` — lint + types clean (no errors, only pre-existing warnings)
- [x] `npm run test:e2e` — 98/98 pass

Part of #203 — nav restructure to follow in PR 3.