### PR TITLE
feat(#203): restructure nav — Sessions/Species top-level, More dropdown for rest

### DIFF
--- a/app/components/layout/GlobalNav.tsx
+++ b/app/components/layout/GlobalNav.tsx
@@ -13,7 +13,15 @@ const moreLinks = [
 	{ href: '/ring-sequences', label: 'Ring Sequences' }
 ];
 
-export function DesktopNavItems({ classes }: { classes: string }) {
+export function DesktopNavItems({
+	classes,
+	moreExpanded,
+	onMoreClick
+}: {
+	classes: string;
+	moreExpanded: boolean;
+	onMoreClick: () => void;
+}) {
 	return (
 		<ul className={classes}>
 			<li>
@@ -22,23 +30,25 @@ export function DesktopNavItems({ classes }: { classes: string }) {
 			<li>
 				<NoPrefetchLink href="/species">Species</NoPrefetchLink>
 			</li>
-			<li className="dropdown dropdown-hover relative">
-				<button type="button" className="cursor-pointer">
+			<li className="relative">
+				<button type="button" className="cursor-pointer" onClick={onMoreClick}>
 					More
 					<span className="icon-[tabler--chevron-down] size-4 ml-1 inline-block align-middle"></span>
 				</button>
-				<ul className="dropdown-menu absolute left-0 top-full z-50 min-w-max bg-base-100 shadow-md rounded-md p-1 border border-base-content/10">
-					{moreLinks.map(({ href, label }) => (
-						<li key={href}>
-							<NoPrefetchLink
-								href={href}
-								className="block px-4 py-2 hover:bg-base-200 rounded"
-							>
-								{label}
-							</NoPrefetchLink>
-						</li>
-					))}
-				</ul>
+				{moreExpanded && (
+					<ul className="absolute left-0 top-full z-50 min-w-max bg-base-100 shadow-md rounded-md p-1 border border-base-content/10">
+						{moreLinks.map(({ href, label }) => (
+							<li key={href}>
+								<NoPrefetchLink
+									href={href}
+									className="block px-4 py-2 hover:bg-base-200 rounded"
+								>
+									{label}
+								</NoPrefetchLink>
+							</li>
+						))}
+					</ul>
+				)}
 			</li>
 		</ul>
 	);
@@ -123,7 +133,7 @@ function GroupSwitcher({
 		</select>
 	);
 }
-type ExpanderId = 'search' | 'mobileNav' | 'userMenu';
+type ExpanderId = 'search' | 'mobileNav' | 'userMenu' | 'moreMenu';
 type ExpanderAction =
 	| { type: 'toggle'; id: ExpanderId }
 	| { type: 'collapseAll' }
@@ -160,6 +170,7 @@ export default function GlobalNav({
 	const [expanders, expandersDispatch] = useReducer(expanderReducer, {
 		search: false,
 		mobileNav: false,
+		moreMenu: false,
 		userMenu: !selectedGroupId
 	} as Record<ExpanderId, boolean>);
 	const groupsCount = groups.length;
@@ -243,7 +254,13 @@ export default function GlobalNav({
 							<RingSearchForm />
 						</div>
 						<div className="hidden md:flex">
-							<DesktopNavItems classes="menu menu-horizontal gap-2 p-0 text-base" />
+							<DesktopNavItems
+								classes="menu menu-horizontal gap-2 p-0 text-base"
+								moreExpanded={expanders.moreMenu}
+								onMoreClick={() =>
+									expandersDispatch({ type: 'toggle', id: 'moreMenu' })
+								}
+							/>
 						</div>
 						<button
 							type="button"

--- a/app/components/layout/GlobalNav.tsx
+++ b/app/components/layout/GlobalNav.tsx
@@ -6,7 +6,14 @@ import { RingSearchForm } from '@/app/components/shared/RingSearchForm';
 import { useSetRingingGroup } from './RingingGroupProvider';
 import { logout } from '@/app/actions/logout';
 import type { RingingGroupRow } from '@/app/models/db';
-export function NavItems({ classes }: { classes: string }) {
+const moreLinks = [
+	{ href: '/mistakes', label: 'Mistakes' },
+	{ href: '/retraps', label: 'Retraps' },
+	{ href: '/effort', label: 'Effort' },
+	{ href: '/ring-sequences', label: 'Ring Sequences' }
+];
+
+export function DesktopNavItems({ classes }: { classes: string }) {
 	return (
 		<ul className={classes}>
 			<li>
@@ -15,15 +22,42 @@ export function NavItems({ classes }: { classes: string }) {
 			<li>
 				<NoPrefetchLink href="/species">Species</NoPrefetchLink>
 			</li>
+			<li className="dropdown dropdown-hover relative">
+				<button type="button" className="cursor-pointer">
+					More
+					<span className="icon-[tabler--chevron-down] size-4 ml-1 inline-block align-middle"></span>
+				</button>
+				<ul className="dropdown-menu absolute left-0 top-full z-50 min-w-max bg-base-100 shadow-md rounded-md p-1 border border-base-content/10">
+					{moreLinks.map(({ href, label }) => (
+						<li key={href}>
+							<NoPrefetchLink
+								href={href}
+								className="block px-4 py-2 hover:bg-base-200 rounded"
+							>
+								{label}
+							</NoPrefetchLink>
+						</li>
+					))}
+				</ul>
+			</li>
+		</ul>
+	);
+}
+
+export function MobileNavItems({ classes }: { classes: string }) {
+	return (
+		<ul className={classes}>
 			<li>
-				<NoPrefetchLink href="/mistakes">Mistakes</NoPrefetchLink>
+				<NoPrefetchLink href="/sessions">Sessions</NoPrefetchLink>
 			</li>
 			<li>
-				<NoPrefetchLink href="/retraps">Retraps</NoPrefetchLink>
+				<NoPrefetchLink href="/species">Species</NoPrefetchLink>
 			</li>
-			<li>
-				<NoPrefetchLink href="/effort">Effort</NoPrefetchLink>
-			</li>
+			{moreLinks.map(({ href, label }) => (
+				<li key={href}>
+					<NoPrefetchLink href={href}>{label}</NoPrefetchLink>
+				</li>
+			))}
 		</ul>
 	);
 }
@@ -209,7 +243,7 @@ export default function GlobalNav({
 							<RingSearchForm />
 						</div>
 						<div className="hidden md:flex">
-							<NavItems classes="menu menu-horizontal gap-2 p-0 text-base" />
+							<DesktopNavItems classes="menu menu-horizontal gap-2 p-0 text-base" />
 						</div>
 						<button
 							type="button"
@@ -225,7 +259,7 @@ export default function GlobalNav({
 					</div>
 				</div>
 				<Expander id="mobile-nav" isExpanded={expanders.mobileNav}>
-					<NavItems classes="p-4 text-right *:p-2 *:mt-1 *:mb-1 *:hover:bg-base-200 *:rounded" />
+					<MobileNavItems classes="p-4 text-right *:p-2 *:mt-1 *:mb-1 *:hover:bg-base-200 *:rounded" />
 				</Expander>
 				<Expander id="ring-search-form-wrapper" isExpanded={expanders.search}>
 					<div className="p-4 pt-0">

--- a/app/components/layout/__tests__/GlobalNav.test.tsx
+++ b/app/components/layout/__tests__/GlobalNav.test.tsx
@@ -1,49 +1,51 @@
-import { describe, it, expect, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { DesktopNavItems, MobileNavItems } from '../GlobalNav';
+
+const noOp = () => {};
 
 describe('DesktopNavItems', () => {
 	afterEach(cleanup);
 
 	it('renders Sessions link at top level', () => {
-		render(<DesktopNavItems classes="" />);
+		render(<DesktopNavItems classes="" moreExpanded={false} onMoreClick={noOp} />);
 		expect(screen.getByRole('link', { name: 'Sessions' })).toBeDefined();
 	});
 
 	it('renders Species link at top level', () => {
-		render(<DesktopNavItems classes="" />);
+		render(<DesktopNavItems classes="" moreExpanded={false} onMoreClick={noOp} />);
 		expect(screen.getByRole('link', { name: 'Species' })).toBeDefined();
 	});
 
 	it('renders a More button', () => {
-		render(<DesktopNavItems classes="" />);
+		render(<DesktopNavItems classes="" moreExpanded={false} onMoreClick={noOp} />);
 		expect(screen.getByRole('button', { name: /more/i })).toBeDefined();
 	});
 
-	it('More dropdown contains Mistakes link', () => {
-		render(<DesktopNavItems classes="" />);
+	it('More dropdown shows when moreExpanded is true', () => {
+		render(<DesktopNavItems classes="" moreExpanded={true} onMoreClick={noOp} />);
 		expect(screen.getByRole('link', { name: 'Mistakes' })).toBeDefined();
-	});
-
-	it('More dropdown contains Retraps link', () => {
-		render(<DesktopNavItems classes="" />);
 		expect(screen.getByRole('link', { name: 'Retraps' })).toBeDefined();
-	});
-
-	it('More dropdown contains Effort link', () => {
-		render(<DesktopNavItems classes="" />);
 		expect(screen.getByRole('link', { name: 'Effort' })).toBeDefined();
-	});
-
-	it('More dropdown contains Ring Sequences link', () => {
-		render(<DesktopNavItems classes="" />);
 		expect(screen.getByRole('link', { name: 'Ring Sequences' })).toBeDefined();
 	});
 
+	it('More dropdown is hidden when moreExpanded is false', () => {
+		render(<DesktopNavItems classes="" moreExpanded={false} onMoreClick={noOp} />);
+		expect(screen.queryByRole('link', { name: 'Mistakes' })).toBeNull();
+	});
+
 	it('Ring Sequences link points to /ring-sequences', () => {
-		render(<DesktopNavItems classes="" />);
+		render(<DesktopNavItems classes="" moreExpanded={true} onMoreClick={noOp} />);
 		const link = screen.getByRole('link', { name: 'Ring Sequences' });
 		expect(link.getAttribute('href')).toBe('/ring-sequences');
+	});
+
+	it('calls onMoreClick when More button is clicked', () => {
+		const onMoreClick = vi.fn();
+		render(<DesktopNavItems classes="" moreExpanded={false} onMoreClick={onMoreClick} />);
+		fireEvent.click(screen.getByRole('button', { name: /more/i }));
+		expect(onMoreClick).toHaveBeenCalledOnce();
 	});
 });
 

--- a/app/components/layout/__tests__/GlobalNav.test.tsx
+++ b/app/components/layout/__tests__/GlobalNav.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { DesktopNavItems, MobileNavItems } from '../GlobalNav';
+
+describe('DesktopNavItems', () => {
+	afterEach(cleanup);
+
+	it('renders Sessions link at top level', () => {
+		render(<DesktopNavItems classes="" />);
+		expect(screen.getByRole('link', { name: 'Sessions' })).toBeDefined();
+	});
+
+	it('renders Species link at top level', () => {
+		render(<DesktopNavItems classes="" />);
+		expect(screen.getByRole('link', { name: 'Species' })).toBeDefined();
+	});
+
+	it('renders a More button', () => {
+		render(<DesktopNavItems classes="" />);
+		expect(screen.getByRole('button', { name: /more/i })).toBeDefined();
+	});
+
+	it('More dropdown contains Mistakes link', () => {
+		render(<DesktopNavItems classes="" />);
+		expect(screen.getByRole('link', { name: 'Mistakes' })).toBeDefined();
+	});
+
+	it('More dropdown contains Retraps link', () => {
+		render(<DesktopNavItems classes="" />);
+		expect(screen.getByRole('link', { name: 'Retraps' })).toBeDefined();
+	});
+
+	it('More dropdown contains Effort link', () => {
+		render(<DesktopNavItems classes="" />);
+		expect(screen.getByRole('link', { name: 'Effort' })).toBeDefined();
+	});
+
+	it('More dropdown contains Ring Sequences link', () => {
+		render(<DesktopNavItems classes="" />);
+		expect(screen.getByRole('link', { name: 'Ring Sequences' })).toBeDefined();
+	});
+
+	it('Ring Sequences link points to /ring-sequences', () => {
+		render(<DesktopNavItems classes="" />);
+		const link = screen.getByRole('link', { name: 'Ring Sequences' });
+		expect(link.getAttribute('href')).toBe('/ring-sequences');
+	});
+});
+
+describe('MobileNavItems', () => {
+	afterEach(cleanup);
+
+	it('renders all 6 links in a flat list', () => {
+		render(<MobileNavItems classes="" />);
+		const links = screen.getAllByRole('link');
+		expect(links).toHaveLength(6);
+	});
+
+	it('includes Sessions link', () => {
+		render(<MobileNavItems classes="" />);
+		expect(screen.getByRole('link', { name: 'Sessions' })).toBeDefined();
+	});
+
+	it('includes Species link', () => {
+		render(<MobileNavItems classes="" />);
+		expect(screen.getByRole('link', { name: 'Species' })).toBeDefined();
+	});
+
+	it('includes Ring Sequences link', () => {
+		render(<MobileNavItems classes="" />);
+		expect(screen.getByRole('link', { name: 'Ring Sequences' })).toBeDefined();
+	});
+});

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -47,6 +47,7 @@ async function warmupServer() {
 		'/mistakes',
 		'/retraps',
 		'/effort',
+		'/ring-sequences',
 		'/bird/ARRETRAP',
 		'/species/Robin',
 	]


### PR DESCRIPTION
## Summary

- Sessions and Species remain as top-level nav links on desktop
- Mistakes, Retraps, Effort, and Ring Sequences moved into a click-based "More" dropdown on desktop
- Mobile hamburger expander shows all 6 links as a flat list
- Used existing `expanderReducer` for the More dropdown state (click-based, not CSS hover) to avoid hover-triggered overlays interfering with other interactions
- Adds `/ring-sequences` to e2e server warmup routes

## Test plan

- [x] `npm run test:nowatch` — 159 tests pass (includes `GlobalNav` nav structure tests)
- [x] `npm run qa` — lint + types clean
- [x] `npm run test:e2e` — 98/98 pass (including logout tests that failed with CSS-hover approach)

Closes #203