### PR TITLE
feat(#203): group ring sequences by ring size category

### DIFF
--- a/app/components/RingSequencesPage.tsx
+++ b/app/components/RingSequencesPage.tsx
@@ -1,8 +1,17 @@
 'use client';
 import { useState } from 'react';
 import type { RingSequenceSummary } from '@/app/actions/ring-sequences';
+import {
+	groupSummariesByRingSize,
+	type RingSizeGroup
+} from '@/app/models/ring-sequences';
 import { AccordionItem } from './shared/Accordion';
-import { BoxyList, PageWrapper, PrimaryHeading } from './shared/DesignSystem';
+import {
+	BoxyList,
+	PageWrapper,
+	PrimaryHeading,
+	SecondaryHeading
+} from './shared/DesignSystem';
 import { RingSequenceControls } from './RingSequenceControls';
 import { RingSequenceDetail } from './RingSequenceDetail';
 
@@ -66,6 +75,44 @@ function ControlsContent({
 	);
 }
 
+function RingSizeSection({
+	group,
+	viewedGroupId,
+	expandedId,
+	onToggle
+}: {
+	group: RingSizeGroup;
+	viewedGroupId: number;
+	expandedId: string | false;
+	onToggle: (id: string | false) => void;
+}) {
+	return (
+		<li data-testid={`ring-size-${group.name}`}>
+			<SecondaryHeading>
+				{group.name} — {group.totalRingCount} rings
+			</SecondaryHeading>
+			<ul className="divide-base-content/25 divide-y">
+				{group.summaries.map((summary) => {
+					const id = `${summary.sequence_prefix}-${summary.ring_length}`;
+					const summaryModel: SequenceSummaryModel = { summary, viewedGroupId };
+					return (
+						<AccordionItem
+							key={id}
+							id={id}
+							model={summaryModel}
+							onToggle={onToggle}
+							expandedId={expandedId}
+							HeadingComponent={SequenceHeading}
+							ContentComponent={SequenceContent}
+							testId={`sequence-${id}`}
+						/>
+					);
+				})}
+			</ul>
+		</li>
+	);
+}
+
 export function RingSequencesPage({
 	data,
 	viewedGroupId
@@ -75,6 +122,7 @@ export function RingSequencesPage({
 	viewedGroupId: number;
 }) {
 	const [expandedId, setExpandedId] = useState<string | false>(false);
+	const ringSizeGroups = groupSummariesByRingSize(data);
 
 	return (
 		<PageWrapper>
@@ -89,22 +137,15 @@ export function RingSequencesPage({
 					ContentComponent={ControlsContent}
 					testId="controls-accordion"
 				/>
-				{data.map((summary) => {
-					const id = `${summary.sequence_prefix}-${summary.ring_length}`;
-					const summaryModel: SequenceSummaryModel = { summary, viewedGroupId };
-					return (
-						<AccordionItem
-							key={id}
-							id={id}
-							model={summaryModel}
-							onToggle={setExpandedId}
-							expandedId={expandedId}
-							HeadingComponent={SequenceHeading}
-							ContentComponent={SequenceContent}
-							testId={`sequence-${id}`}
-						/>
-					);
-				})}
+				{ringSizeGroups.map((group) => (
+					<RingSizeSection
+						key={group.name}
+						group={group}
+						viewedGroupId={viewedGroupId}
+						expandedId={expandedId}
+						onToggle={setExpandedId}
+					/>
+				))}
 			</BoxyList>
 		</PageWrapper>
 	);

--- a/app/components/__tests__/RingSequencesPage.test.tsx
+++ b/app/components/__tests__/RingSequencesPage.test.tsx
@@ -18,20 +18,35 @@ vi.mock('@/app/actions/ring-sequences', () => ({
 	fetchRingSequenceControls: vi.fn()
 }));
 
+// AA (3-alpha, length 6), A (3-alpha, length 7), Large (3-alpha, length 9)
 const mockSummaries: RingSequenceSummary[] = [
 	{
 		sequence_prefix: 'ARW',
-		ring_length: 9,
+		ring_length: 6,
+		ring_count: 10,
+		earliest_date: '2022-06-15',
+		latest_date: '2024-05-10'
+	},
+	{
+		sequence_prefix: 'ARW',
+		ring_length: 7,
 		ring_count: 15,
 		earliest_date: '2022-06-15',
 		latest_date: '2024-05-10'
 	},
 	{
 		sequence_prefix: 'ABT',
-		ring_length: 8,
+		ring_length: 7,
 		ring_count: 6,
 		earliest_date: '2022-04-30',
 		latest_date: '2023-05-12'
+	},
+	{
+		sequence_prefix: 'ARW',
+		ring_length: 9,
+		ring_count: 8,
+		earliest_date: '2021-03-01',
+		latest_date: '2023-07-20'
 	}
 ];
 
@@ -59,7 +74,7 @@ describe('RingSequencesPage', () => {
 		expect(items[0].getAttribute('data-testid')).toBe('controls-accordion');
 	});
 
-	it('renders one accordion item per ring sequence summary', () => {
+	it('renders a section heading per populated ring size', () => {
 		render(
 			<RingSequencesPage
 				params={{}}
@@ -67,8 +82,51 @@ describe('RingSequencesPage', () => {
 				viewedGroupId={viewedGroupId}
 			/>
 		);
-		expect(screen.getByTestId('sequence-ARW-9')).toBeDefined();
-		expect(screen.getByTestId('sequence-ABT-8')).toBeDefined();
+		expect(screen.getByTestId('ring-size-AA')).toBeDefined();
+		expect(screen.getByTestId('ring-size-A')).toBeDefined();
+		expect(screen.getByTestId('ring-size-Large')).toBeDefined();
+	});
+
+	it('heading shows ring size name and total ring count', () => {
+		render(
+			<RingSequencesPage
+				params={{}}
+				data={mockSummaries}
+				viewedGroupId={viewedGroupId}
+			/>
+		);
+		const aSection = screen.getByTestId('ring-size-A');
+		// ARW (15) + ABT (6) = 21
+		expect(aSection.textContent).toContain('A');
+		expect(aSection.textContent).toContain('21 rings');
+	});
+
+	it('renders sequence accordions within correct ring size section', () => {
+		render(
+			<RingSequencesPage
+				params={{}}
+				data={mockSummaries}
+				viewedGroupId={viewedGroupId}
+			/>
+		);
+		const aaSection = screen.getByTestId('ring-size-AA');
+		expect(aaSection.querySelector('[data-testid="sequence-ARW-6"]')).toBeTruthy();
+
+		const aSection = screen.getByTestId('ring-size-A');
+		expect(aSection.querySelector('[data-testid="sequence-ARW-7"]')).toBeTruthy();
+		expect(aSection.querySelector('[data-testid="sequence-ABT-7"]')).toBeTruthy();
+	});
+
+	it('omits ring size sections with no sequences', () => {
+		render(
+			<RingSequencesPage
+				params={{}}
+				data={mockSummaries}
+				viewedGroupId={viewedGroupId}
+			/>
+		);
+		expect(screen.queryByTestId('ring-size-B, C, C2')).toBeNull();
+		expect(screen.queryByTestId('ring-size-D')).toBeNull();
 	});
 
 	it('shows sequence prefix, ring count, and date range in heading', () => {
@@ -79,7 +137,7 @@ describe('RingSequencesPage', () => {
 				viewedGroupId={viewedGroupId}
 			/>
 		);
-		const arwItem = screen.getByTestId('sequence-ARW-9');
+		const arwItem = screen.getByTestId('sequence-ARW-7');
 		expect(arwItem.textContent).toContain('ARW');
 		expect(arwItem.textContent).toContain('15 rings');
 		expect(arwItem.textContent).toContain('2022-06-15');
@@ -156,7 +214,7 @@ describe('RingSequencesPage', () => {
 		});
 
 		fireEvent.click(
-			screen.getByTestId('sequence-ARW-9').querySelector('button')!
+			screen.getByTestId('sequence-ARW-7').querySelector('button')!
 		);
 
 		await waitFor(() => {

--- a/app/components/layout/__tests__/GlobalNav.test.tsx
+++ b/app/components/layout/__tests__/GlobalNav.test.tsx
@@ -8,22 +8,30 @@ describe('DesktopNavItems', () => {
 	afterEach(cleanup);
 
 	it('renders Sessions link at top level', () => {
-		render(<DesktopNavItems classes="" moreExpanded={false} onMoreClick={noOp} />);
+		render(
+			<DesktopNavItems classes="" moreExpanded={false} onMoreClick={noOp} />
+		);
 		expect(screen.getByRole('link', { name: 'Sessions' })).toBeDefined();
 	});
 
 	it('renders Species link at top level', () => {
-		render(<DesktopNavItems classes="" moreExpanded={false} onMoreClick={noOp} />);
+		render(
+			<DesktopNavItems classes="" moreExpanded={false} onMoreClick={noOp} />
+		);
 		expect(screen.getByRole('link', { name: 'Species' })).toBeDefined();
 	});
 
 	it('renders a More button', () => {
-		render(<DesktopNavItems classes="" moreExpanded={false} onMoreClick={noOp} />);
+		render(
+			<DesktopNavItems classes="" moreExpanded={false} onMoreClick={noOp} />
+		);
 		expect(screen.getByRole('button', { name: /more/i })).toBeDefined();
 	});
 
 	it('More dropdown shows when moreExpanded is true', () => {
-		render(<DesktopNavItems classes="" moreExpanded={true} onMoreClick={noOp} />);
+		render(
+			<DesktopNavItems classes="" moreExpanded={true} onMoreClick={noOp} />
+		);
 		expect(screen.getByRole('link', { name: 'Mistakes' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Retraps' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Effort' })).toBeDefined();
@@ -31,19 +39,29 @@ describe('DesktopNavItems', () => {
 	});
 
 	it('More dropdown is hidden when moreExpanded is false', () => {
-		render(<DesktopNavItems classes="" moreExpanded={false} onMoreClick={noOp} />);
+		render(
+			<DesktopNavItems classes="" moreExpanded={false} onMoreClick={noOp} />
+		);
 		expect(screen.queryByRole('link', { name: 'Mistakes' })).toBeNull();
 	});
 
 	it('Ring Sequences link points to /ring-sequences', () => {
-		render(<DesktopNavItems classes="" moreExpanded={true} onMoreClick={noOp} />);
+		render(
+			<DesktopNavItems classes="" moreExpanded={true} onMoreClick={noOp} />
+		);
 		const link = screen.getByRole('link', { name: 'Ring Sequences' });
 		expect(link.getAttribute('href')).toBe('/ring-sequences');
 	});
 
 	it('calls onMoreClick when More button is clicked', () => {
 		const onMoreClick = vi.fn();
-		render(<DesktopNavItems classes="" moreExpanded={false} onMoreClick={onMoreClick} />);
+		render(
+			<DesktopNavItems
+				classes=""
+				moreExpanded={false}
+				onMoreClick={onMoreClick}
+			/>
+		);
 		fireEvent.click(screen.getByRole('button', { name: /more/i }));
 		expect(onMoreClick).toHaveBeenCalledOnce();
 	});

--- a/app/models/__tests__/ring-sequences.test.ts
+++ b/app/models/__tests__/ring-sequences.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from 'vitest';
-import { findUnusedRings } from '../ring-sequences';
+import {
+	findUnusedRings,
+	classifyRingSize,
+	groupSummariesByRingSize
+} from '../ring-sequences';
+import type { RingSequenceSummary } from '@/app/actions/ring-sequences';
+
+function makeSummary(
+	sequence_prefix: string,
+	ring_length: number,
+	ring_count = 1
+): RingSequenceSummary {
+	return {
+		sequence_prefix,
+		ring_length,
+		ring_count,
+		earliest_date: '2022-01-01',
+		latest_date: '2024-01-01'
+	};
+}
 
 describe('findUnusedRings', () => {
 	it('returns empty array when no gaps exist', () => {
@@ -26,5 +45,87 @@ describe('findUnusedRings', () => {
 
 	it('returns empty array when input is empty', () => {
 		expect(findUnusedRings([], 3)).toEqual([]);
+	});
+});
+
+describe('classifyRingSize', () => {
+	it('classifies 3-alpha prefix, length 6 as AA', () => {
+		expect(classifyRingSize(makeSummary('ARW', 6))).toBe('AA');
+	});
+
+	it('classifies 3-alpha prefix, length 7 as A', () => {
+		expect(classifyRingSize(makeSummary('ARW', 7))).toBe('A');
+	});
+
+	it('classifies 2-alpha, length 7, first letter B as B, C, C2', () => {
+		expect(classifyRingSize(makeSummary('BK', 7))).toBe('B, C, C2');
+	});
+
+	it('classifies 2-alpha, length 7, first letter C as B, C, C2', () => {
+		expect(classifyRingSize(makeSummary('CA', 7))).toBe('B, C, C2');
+	});
+
+	it('classifies 2-alpha, length 7, first letter D as D', () => {
+		expect(classifyRingSize(makeSummary('DA', 7))).toBe('D');
+	});
+
+	it('classifies 2-alpha, length 7, first letter E as E', () => {
+		expect(classifyRingSize(makeSummary('EB', 7))).toBe('E');
+	});
+
+	it('classifies 2-alpha, length 7, first letter F as F', () => {
+		expect(classifyRingSize(makeSummary('FA', 7))).toBe('F');
+	});
+
+	it('classifies 2-alpha, length 7, first letter S as SO', () => {
+		expect(classifyRingSize(makeSummary('SA', 7))).toBe('SO');
+	});
+
+	it('classifies 3-alpha prefix, length 9 as Large', () => {
+		expect(classifyRingSize(makeSummary('ARW', 9))).toBe('Large');
+	});
+
+	it('classifies 2-alpha prefix, length 8 as Large', () => {
+		expect(classifyRingSize(makeSummary('AB', 8))).toBe('Large');
+	});
+
+	it('classifies 1-alpha prefix, length 7 as Large', () => {
+		expect(classifyRingSize(makeSummary('A', 7))).toBe('Large');
+	});
+
+	it('classifies 4-alpha prefix, length 6 as Large', () => {
+		expect(classifyRingSize(makeSummary('ARWX', 6))).toBe('Large');
+	});
+});
+
+describe('groupSummariesByRingSize', () => {
+	it('returns groups in RING_SIZE_ORDER order', () => {
+		const summaries = [
+			makeSummary('BK', 7),
+			makeSummary('ARW', 6),
+			makeSummary('ARW', 7)
+		];
+		const groups = groupSummariesByRingSize(summaries);
+		expect(groups.map((g) => g.name)).toEqual(['AA', 'A', 'B, C, C2']);
+	});
+
+	it('sums ring_count across sequences within a group', () => {
+		const summaries = [makeSummary('ARW', 7, 10), makeSummary('ABT', 7, 5)];
+		const groups = groupSummariesByRingSize(summaries);
+		expect(groups[0].name).toBe('A');
+		expect(groups[0].totalRingCount).toBe(15);
+	});
+
+	it('omits empty categories', () => {
+		const summaries = [makeSummary('ARW', 7)];
+		const groups = groupSummariesByRingSize(summaries);
+		expect(groups.map((g) => g.name)).toEqual(['A']);
+	});
+
+	it('places multiple summaries of same size in same group', () => {
+		const summaries = [makeSummary('ARW', 7), makeSummary('ABT', 7)];
+		const groups = groupSummariesByRingSize(summaries);
+		expect(groups).toHaveLength(1);
+		expect(groups[0].summaries).toHaveLength(2);
 	});
 });

--- a/app/models/ring-sequences.ts
+++ b/app/models/ring-sequences.ts
@@ -1,3 +1,64 @@
+import type { RingSequenceSummary } from '@/app/actions/ring-sequences';
+
+export type RingSizeName = 'AA' | 'A' | 'B, C, C2' | 'D' | 'E' | 'F' | 'SO' | 'Large';
+
+export const RING_SIZE_ORDER: RingSizeName[] = [
+	'AA',
+	'A',
+	'B, C, C2',
+	'D',
+	'E',
+	'F',
+	'SO',
+	'Large'
+];
+
+export type RingSizeGroup = {
+	name: RingSizeName;
+	totalRingCount: number;
+	summaries: RingSequenceSummary[];
+};
+
+export function classifyRingSize(summary: RingSequenceSummary): RingSizeName {
+	const { sequence_prefix, ring_length } = summary;
+	const alphaCount = (sequence_prefix.match(/^[A-Za-z]+/) || [''])[0].length;
+
+	if (alphaCount === 3 && ring_length === 6) return 'AA';
+	if (alphaCount === 3 && ring_length === 7) return 'A';
+
+	if (alphaCount === 2 && ring_length === 7) {
+		const firstLetter = sequence_prefix[0].toUpperCase();
+		if (firstLetter === 'D') return 'D';
+		if (firstLetter === 'E') return 'E';
+		if (firstLetter === 'F') return 'F';
+		if (firstLetter === 'S') return 'SO';
+		return 'B, C, C2';
+	}
+
+	return 'Large';
+}
+
+export function groupSummariesByRingSize(
+	summaries: RingSequenceSummary[]
+): RingSizeGroup[] {
+	const buckets = new Map<RingSizeName, RingSequenceSummary[]>();
+
+	for (const summary of summaries) {
+		const name = classifyRingSize(summary);
+		if (!buckets.has(name)) buckets.set(name, []);
+		buckets.get(name)!.push(summary);
+	}
+
+	return RING_SIZE_ORDER.filter((name) => buckets.has(name)).map((name) => {
+		const groupSummaries = buckets.get(name)!;
+		return {
+			name,
+			totalRingCount: groupSummaries.reduce((sum, s) => sum + s.ring_count, 0),
+			summaries: groupSummaries
+		};
+	});
+}
+
 export function findUnusedRings(
 	rings: string[],
 	prefixLength: number


### PR DESCRIPTION
## Summary

- Adds `classifyRingSize` and `groupSummariesByRingSize` to `app/models/ring-sequences.ts` — post-processing classification into AA / A / B,C,C2 / D / E / F / SO / Large based on alpha prefix count and ring length
- Renders ring size sections as siblings to Controls on the ring sequences page, each headed with category name and total ring count
- Full test coverage for classification logic and updated component tests

## Test plan

- [ ] `npm run test:nowatch` — all 178 tests pass
- [ ] `npm run qa` — lint + type-check clean
- [ ] Browse `/ring-sequences` locally and confirm ring size headings appear with correct counts, Controls remains first

🤖 Generated with [Claude Code](https://claude.com/claude-code)