### PR TITLE
feat(#223): session chronology stats and by-time tab

### DIFF
--- a/app/components/SingleSessionTable.tsx
+++ b/app/components/SingleSessionTable.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useState } from 'react';
 import { type SessionEncounter } from '@/app/models/session';
+import { type NetRound } from '@/app/models/session-chronology';
 import { NoPrefetchLink } from '@/app/components/shared/NoPrefetchLink';
 import { InlineTable } from './shared/DesignSystem';
 import { AccordionTableBody } from './shared/AccordionTableBody';
@@ -157,19 +159,154 @@ function SessionTableBody({
 	);
 }
 
-export function SessionTable({
-	speciesList
+function EncounterRow({ encounter }: { encounter: SessionEncounter }) {
+	return (
+		<tr>
+			<td>{encounter.capture_time}</td>
+			<td>
+				<NoPrefetchLink
+					className="link"
+					href={`/bird/${encounter.bird.ring_no}`}
+				>
+					{encounter.bird.ring_no}
+				</NoPrefetchLink>
+			</td>
+			<td>{encounter.bird.species.species_name}</td>
+			<td>{encounter.record_type}</td>
+			<td>{encounter.age_code}</td>
+			<td>{encounter.sex}</td>
+			<td>{encounter.sexing_method}</td>
+			<td>{encounter.breeding_condition}</td>
+			<td>{encounter.wing_length}</td>
+			<td>{encounter.weight}</td>
+			<td>{encounter.moult_code}</td>
+		</tr>
+	);
+}
+
+function ChronologicalView({ netRounds }: { netRounds: NetRound[] }) {
+	return (
+		<div>
+			{netRounds.map((round, index) => (
+				<div key={round.startTime}>
+					<h3 className="mt-4 mb-2 font-semibold">
+						Net round {index + 1}: {round.startTime.slice(0, 5)}
+					</h3>
+					<InlineTable>
+						<thead>
+							<tr>
+								<th>Time</th>
+								<th>Ring No</th>
+								<th>Species</th>
+								<th>Type</th>
+								<th>Age</th>
+								<th>Sex</th>
+								<th>Sexing Method</th>
+								<th>Breeding Condition</th>
+								<th>Wing</th>
+								<th>Weight</th>
+								<th>Moult Code</th>
+							</tr>
+						</thead>
+						<tbody>
+							{round.encounters.map((encounter) => (
+								<EncounterRow key={encounter.id} encounter={encounter} />
+							))}
+						</tbody>
+					</InlineTable>
+				</div>
+			))}
+		</div>
+	);
+}
+
+function ConditionalTabPanel({
+	loadedTabs,
+	tabId,
+	activeTabId,
+	children
+}: {
+	loadedTabs: Set<string>;
+	tabId: string;
+	activeTabId: string;
+	children: React.ReactNode;
+}) {
+	if (loadedTabs.has(tabId)) {
+		return tabId === activeTabId ? (
+			<div>{children}</div>
+		) : (
+			<div className="hidden" aria-hidden="true">
+				{children}
+			</div>
+		);
+	}
+	return null;
+}
+
+export function SessionTabs({
+	speciesList,
+	netRounds
 }: {
 	speciesList: SpeciesWithEncounters[];
+	netRounds: NetRound[];
 }) {
+	const [loadedTabs, setLoadedTabs] = useState<Set<string>>(
+		new Set(['by-species'])
+	);
+	const [activeTab, setActiveTab] = useState('by-species');
+
+	function handleTabClick(event: React.MouseEvent<HTMLButtonElement>) {
+		const tab = event.currentTarget.id.replace('session-tabs-control-', '');
+		setLoadedTabs((prev) => new Set([...prev, tab]));
+		setActiveTab(tab);
+	}
+
 	return (
-		<SortableTable<SpeciesWithEncounters, RowModel>
-			columnConfigs={columnConfigs}
-			data={speciesList}
-			testId="session-table"
-			initialSortColumn="total"
-			rowDataTransform={rowDataTransform}
-			TableBodyComponent={SessionTableBody}
-		/>
+		<>
+			<nav
+				className="bg-base-200 rounded-field w-fit space-x-1 overflow-x-auto p-1 mt-4"
+				aria-label="Tabs"
+				role="tablist"
+				aria-orientation="horizontal"
+			>
+				<button
+					type="button"
+					id="session-tabs-control-by-species"
+					className={`btn ${activeTab === 'by-species' ? 'btn-default' : 'btn-secondary'}`}
+					onClick={handleTabClick}
+				>
+					By species
+				</button>
+				<button
+					type="button"
+					id="session-tabs-control-by-time"
+					className={`btn ${activeTab === 'by-time' ? 'btn-default' : 'btn-secondary'}`}
+					onClick={handleTabClick}
+				>
+					By time
+				</button>
+			</nav>
+			<ConditionalTabPanel
+				loadedTabs={loadedTabs}
+				tabId="by-species"
+				activeTabId={activeTab}
+			>
+				<SortableTable<SpeciesWithEncounters, RowModel>
+					columnConfigs={columnConfigs}
+					data={speciesList}
+					testId="session-table"
+					initialSortColumn="total"
+					rowDataTransform={rowDataTransform}
+					TableBodyComponent={SessionTableBody}
+				/>
+			</ConditionalTabPanel>
+			<ConditionalTabPanel
+				loadedTabs={loadedTabs}
+				tabId="by-time"
+				activeTabId={activeTab}
+			>
+				<ChronologicalView netRounds={netRounds} />
+			</ConditionalTabPanel>
+		</>
 	);
 }

--- a/app/components/__tests__/SingleSessionTable.test.tsx
+++ b/app/components/__tests__/SingleSessionTable.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { SessionTabs } from '../SingleSessionTable';
+import type { SpeciesWithEncounters } from '../SingleSessionTable';
+import type { NetRound } from '@/app/models/session-chronology';
+import type { SessionEncounter } from '@/app/models/session';
+
+function makeEncounter(
+	id: number,
+	species: string,
+	capture_time: string
+): SessionEncounter {
+	return {
+		id,
+		session_id: 1,
+		age_code: 4,
+		breeding_condition: null,
+		capture_time,
+		moult_code: null,
+		record_type: 'N',
+		ringing_group_id: 1,
+		sex: 'M',
+		sexing_method: null,
+		weight: null,
+		wing_length: null,
+		bird: {
+			ring_no: `RING${id}`,
+			species: { id: 1, species_name: species }
+		}
+	} as unknown as SessionEncounter;
+}
+
+const robinEncounter = makeEncounter(1, 'Robin', '09:00:00');
+const titmouseEncounter = makeEncounter(2, 'Blue Tit', '09:30:00');
+
+const speciesList: SpeciesWithEncounters[] = [
+	{ species: 'Robin', encounters: [robinEncounter] },
+	{ species: 'Blue Tit', encounters: [titmouseEncounter] }
+];
+
+const netRounds: NetRound[] = [
+	{ startTime: '09:00:00', encounters: [robinEncounter] },
+	{ startTime: '09:30:00', encounters: [titmouseEncounter] }
+];
+
+describe('SessionTabs', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders both tab buttons', () => {
+		render(<SessionTabs speciesList={speciesList} netRounds={netRounds} />);
+		expect(
+			screen.getByRole('button', { name: 'By species' }).textContent
+		).toContain('By species');
+		expect(
+			screen.getByRole('button', { name: 'By time' }).textContent
+		).toContain('By time');
+	});
+
+	it('shows species table by default', () => {
+		render(<SessionTabs speciesList={speciesList} netRounds={netRounds} />);
+		expect(screen.getByTestId('session-table')).not.toBeNull();
+	});
+
+	it('shows chronological view when By time tab clicked', () => {
+		render(<SessionTabs speciesList={speciesList} netRounds={netRounds} />);
+		fireEvent.click(screen.getByRole('button', { name: 'By time' }));
+		expect(screen.getByText('Net round 1: 09:00').textContent).toContain(
+			'Net round 1: 09:00'
+		);
+		expect(screen.getByText('Net round 2: 09:30').textContent).toContain(
+			'Net round 2: 09:30'
+		);
+	});
+});

--- a/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
@@ -120,6 +120,15 @@ describe('session detail page', () => {
 		expect(stats.textContent).toContain('1 retraps');
 	});
 
+	it('renders session chronology stats', async () => {
+		render(await renderPage());
+		const stats = await screen.findByTestId('session-stats');
+		expect(stats.textContent).toContain('Start: 08:00');
+		expect(stats.textContent).toContain('End: 08:30');
+		expect(stats.textContent).toContain('Duration: 30m');
+		expect(stats.textContent).toContain('Net rounds: 3');
+	});
+
 	it('renders one table row per species', async () => {
 		render(await renderPage());
 		const table = await screen.findByTestId('session-table');

--- a/app/group/[groupId]/session/_shared.tsx
+++ b/app/group/[groupId]/session/_shared.tsx
@@ -1,5 +1,5 @@
 import {
-	SessionTable,
+	SessionTabs,
 	type SpeciesWithEncounters
 } from '@/app/components/SingleSessionTable';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
@@ -15,6 +15,8 @@ import {
 import Link from 'next/link';
 import { format as formatDate } from 'date-fns';
 import { Fragment } from 'react';
+import { calculateSessionChronology } from '@/app/models/session-chronology';
+import { formatMinutesForDisplay } from '@/lib/postgres-interval';
 
 export type PageParams = {
 	viewedGroupId: number;
@@ -167,6 +169,7 @@ export function SessionSummary({
 	};
 }) {
 	const speciesList = groupBySpecies(dayData.encounters);
+	const chronology = calculateSessionChronology(dayData.encounters);
 
 	if (dayData.locations.length === 0) {
 		return (
@@ -200,10 +203,14 @@ export function SessionSummary({
 					`${dayData.encounters.filter((encounter) => encounter.record_type === 'S').length} retraps`,
 					`${dayData.encounters.filter((encounter) => encounter.age_code > 3).length} adults`,
 					`${dayData.encounters.filter((encounter) => [1, 3].includes(encounter.age_code)).length} juvs`,
-					`${dayData.encounters.filter((encounter) => encounter.age_code === 2).length} unknown age`
+					`${dayData.encounters.filter((encounter) => encounter.age_code === 2).length} unknown age`,
+					`Start: ${chronology.startTime ? chronology.startTime.slice(0, 5) : '–'}`,
+					`End: ${chronology.endTime ? chronology.endTime.slice(0, 5) : '–'}`,
+					`Duration: ${chronology.durationMinutes !== null ? formatMinutesForDisplay(chronology.durationMinutes) : '–'}`,
+					`Net rounds: ${chronology.netRounds.length}`
 				]}
 			/>
-			<SessionTable speciesList={speciesList} />
+			<SessionTabs speciesList={speciesList} netRounds={chronology.netRounds} />
 		</PageWrapper>
 	);
 }

--- a/app/models/__tests__/session-chronology.test.ts
+++ b/app/models/__tests__/session-chronology.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import {
+	calculateSessionChronology,
+	NET_ROUND_GAP_MINUTES
+} from '../session-chronology';
+import type { SessionEncounter } from '../session';
+
+function makeEncounter(
+	id: number,
+	capture_time: string | null
+): SessionEncounter {
+	return {
+		id,
+		session_id: 1,
+		age_code: 4,
+		breeding_condition: null,
+		capture_time,
+		moult_code: null,
+		record_type: 'N',
+		ringing_group_id: 1,
+		sex: 'M',
+		sexing_method: null,
+		weight: null,
+		wing_length: null,
+		bird: {
+			ring_no: `RING${id}`,
+			species: { id: 1, species_name: 'Robin' }
+		}
+	} as unknown as SessionEncounter;
+}
+
+describe('calculateSessionChronology', () => {
+	it('returns nulls for empty encounters', () => {
+		const result = calculateSessionChronology([]);
+		expect(result).toEqual({
+			startTime: null,
+			endTime: null,
+			durationMinutes: null,
+			netRounds: []
+		});
+	});
+
+	it('skips encounters with null capture_time', () => {
+		const result = calculateSessionChronology([makeEncounter(1, null)]);
+		expect(result).toEqual({
+			startTime: null,
+			endTime: null,
+			durationMinutes: null,
+			netRounds: []
+		});
+	});
+
+	it('handles single encounter', () => {
+		const result = calculateSessionChronology([makeEncounter(1, '09:00:00')]);
+		expect(result.startTime).toBe('09:00:00');
+		expect(result.endTime).toBe('09:00:00');
+		expect(result.durationMinutes).toBe(0);
+		expect(result.netRounds).toHaveLength(1);
+		expect(result.netRounds[0].startTime).toBe('09:00:00');
+	});
+
+	it('merges encounters less than gap apart into same round', () => {
+		const result = calculateSessionChronology([
+			makeEncounter(1, '09:00:00'),
+			makeEncounter(2, '09:10:00')
+		]);
+		expect(result.netRounds).toHaveLength(1);
+		expect(result.netRounds[0].encounters).toHaveLength(2);
+	});
+
+	it(`starts new round at exactly ${NET_ROUND_GAP_MINUTES} minutes`, () => {
+		const result = calculateSessionChronology([
+			makeEncounter(1, '09:00:00'),
+			makeEncounter(2, '09:15:00')
+		]);
+		expect(result.netRounds).toHaveLength(2);
+	});
+
+	it('groups by round start, not previous timestamp', () => {
+		// 09:00, 09:10, 09:20: 09:10 merges (< 15 from round start 09:00),
+		// 09:20 is 20 min from round start 09:00 → new round
+		const result = calculateSessionChronology([
+			makeEncounter(1, '09:00:00'),
+			makeEncounter(2, '09:10:00'),
+			makeEncounter(3, '09:20:00')
+		]);
+		expect(result.netRounds).toHaveLength(2);
+		expect(result.netRounds[0].encounters).toHaveLength(2);
+		expect(result.netRounds[1].encounters).toHaveLength(1);
+	});
+
+	it('calculates start, end, and duration correctly', () => {
+		const result = calculateSessionChronology([
+			makeEncounter(1, '08:00:00'),
+			makeEncounter(2, '08:30:00'),
+			makeEncounter(3, '09:00:00')
+		]);
+		expect(result.startTime).toBe('08:00:00');
+		expect(result.endTime).toBe('09:00:00');
+		expect(result.durationMinutes).toBe(60);
+	});
+
+	it('sorts encounters by time regardless of input order', () => {
+		const result = calculateSessionChronology([
+			makeEncounter(3, '09:00:00'),
+			makeEncounter(1, '08:00:00'),
+			makeEncounter(2, '08:30:00')
+		]);
+		expect(result.startTime).toBe('08:00:00');
+		expect(result.endTime).toBe('09:00:00');
+	});
+});

--- a/app/models/session-chronology.ts
+++ b/app/models/session-chronology.ts
@@ -1,0 +1,66 @@
+import type { SessionEncounter } from './session';
+
+// Matches SQL: GREATEST(MAX(capture_time) - MIN(capture_time), '02:00:00') in aggregate_stats RPC.
+// That 2h floor applies to effort calculations only — display uses actual duration.
+export const SESSION_MINIMUM_EFFORT_MINUTES = 120;
+
+export const NET_ROUND_GAP_MINUTES = 15;
+
+export type NetRound = {
+	startTime: string;
+	encounters: SessionEncounter[];
+};
+
+export type SessionChronology = {
+	startTime: string | null;
+	endTime: string | null;
+	durationMinutes: number | null;
+	netRounds: NetRound[];
+};
+
+function timeToMinutes(time: string): number {
+	const [h, m] = time.split(':').map(Number);
+	return h * 60 + m;
+}
+
+export function calculateSessionChronology(
+	encounters: SessionEncounter[]
+): SessionChronology {
+	const timedEncounters = encounters.filter((e) => e.capture_time);
+
+	if (timedEncounters.length === 0) {
+		return {
+			startTime: null,
+			endTime: null,
+			durationMinutes: null,
+			netRounds: []
+		};
+	}
+
+	const sorted = [...timedEncounters].sort((a, b) =>
+		a.capture_time!.localeCompare(b.capture_time!)
+	);
+
+	const startTime = sorted[0].capture_time!;
+	const endTime = sorted[sorted.length - 1].capture_time!;
+	const durationMinutes = timeToMinutes(endTime) - timeToMinutes(startTime);
+
+	const netRounds: NetRound[] = [];
+	let currentRoundStart: string | null = null;
+
+	for (const encounter of sorted) {
+		const t = encounter.capture_time!;
+		if (
+			currentRoundStart === null ||
+			timeToMinutes(t) - timeToMinutes(currentRoundStart) >=
+				NET_ROUND_GAP_MINUTES
+		) {
+			netRounds.push({ startTime: t, encounters: [encounter] });
+			currentRoundStart = t;
+		} else {
+			netRounds[netRounds.length - 1].encounters.push(encounter);
+		}
+	}
+
+	return { startTime, endTime, durationMinutes, netRounds };
+}

--- a/lib/postgres-interval.test.ts
+++ b/lib/postgres-interval.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+	formatMinutesForDisplay,
 	formatPostgresIntervalForDisplay,
 	postgresIntervalToHours,
 	postgresIntervalToMinutes,
@@ -35,5 +36,23 @@ describe('postgresIntervalToMinutes', () => {
 describe('formatPostgresIntervalForDisplay', () => {
 	it('formats hours and minutes', () => {
 		expect(formatPostgresIntervalForDisplay('02:01:00')).toBe('2h 1m');
+	});
+});
+
+describe('formatMinutesForDisplay', () => {
+	it('returns "0m" for 0 minutes', () => {
+		expect(formatMinutesForDisplay(0)).toBe('0m');
+	});
+
+	it('returns minutes only for < 60 minutes', () => {
+		expect(formatMinutesForDisplay(45)).toBe('45m');
+	});
+
+	it('returns hours only when no remainder', () => {
+		expect(formatMinutesForDisplay(120)).toBe('2h');
+	});
+
+	it('returns hours and minutes', () => {
+		expect(formatMinutesForDisplay(90)).toBe('1h 30m');
 	});
 });

--- a/lib/postgres-interval.ts
+++ b/lib/postgres-interval.ts
@@ -42,3 +42,13 @@ export function formatPostgresIntervalForDisplay(raw: string): string {
 	if (m === 0) return `${h}h`;
 	return `${h}h ${m}m`;
 }
+
+/** Readable duration from a minute count (e.g. computed from capture_time diff). */
+export function formatMinutesForDisplay(minutes: number): string {
+	if (minutes === 0) return '0m';
+	const h = Math.floor(minutes / 60);
+	const m = minutes % 60;
+	if (h === 0) return `${m}m`;
+	if (m === 0) return `${h}h`;
+	return `${h}h ${m}m`;
+}


### PR DESCRIPTION
## Summary
- Adds start time, end time, duration, and net round count to the session summary badges
- Splits the main session table into "By species" (existing) and "By time" tabs
- "By time" view groups encounters by net round (≥15 min gap = new round), with a heading per round showing its start time
- New `app/models/session-chronology.ts` centralises all JS-side session time logic, documenting the SQL 2-hour minimum effort floor from `aggregate_stats` so rules stay consistent
- `formatMinutesForDisplay` added to `lib/postgres-interval.ts` to avoid reimplementing the formatting pattern

## Test plan
- [ ] Unit tests for `calculateSessionChronology` (empty, null times, merge, boundary, multi-round)
- [ ] Unit tests for `formatMinutesForDisplay`
- [ ] Page test asserts new badges (start/end/duration/net rounds)
- [ ] Component test asserts both tabs render and "By time" shows round headings
- [ ] `npm run qa` passes (194 tests, 0 errors)

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)