### PR TITLE
test(#294): add explicit casualty encounter tests

### DIFF
--- a/lib/__tests__/demon-import.test.ts
+++ b/lib/__tests__/demon-import.test.ts
@@ -219,12 +219,29 @@ describe('processEncounterRow', () => {
 		});
 	});
 
-	it('throws CasualtyEncounterError when ring_no is empty', async () => {
-		const row = makeDemonRow({ ring_no: '' });
-		await expect(
-			processEncounterRow(row, upsert, RINGING_GROUP_ID)
-		).rejects.toBeInstanceOf(CasualtyEncounterError);
-		expect(upsert).not.toHaveBeenCalled();
+	describe('casualty encounters', () => {
+		it('throws CasualtyEncounterError when ring_no is empty', async () => {
+			const row = makeDemonRow({ ring_no: '' });
+			await expect(
+				processEncounterRow(row, upsert, RINGING_GROUP_ID)
+			).rejects.toBeInstanceOf(CasualtyEncounterError);
+		});
+
+		it('does not call upsert when ring_no is empty', async () => {
+			const row = makeDemonRow({ ring_no: '' });
+			await expect(
+				processEncounterRow(row, upsert, RINGING_GROUP_ID)
+			).rejects.toBeInstanceOf(CasualtyEncounterError);
+			expect(upsert).not.toHaveBeenCalled();
+		});
+
+		it('processes normally when ring_no is present (already-ringed bird)', async () => {
+			const row = makeDemonRow({ ring_no: 'A123456' });
+			await expect(
+				processEncounterRow(row, upsert, RINGING_GROUP_ID)
+			).resolves.toBeDefined();
+			expect(upsert).toHaveBeenCalled();
+		});
 	});
 
 	it('upserts Species with the species name', async () => {


### PR DESCRIPTION
## Summary

- Splits the single existing casualty test into two (throws + does not call upsert)
- Adds a third test: a bird with a `ring_no` present (already-ringed casualty) is processed normally
- Groups all three under a `describe('casualty encounters')` block for clarity

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)