### PR TITLE
fix(#224): show all sessions from last 3 distinct dates on home page

### DIFF
--- a/app/(routes)/__tests__/page.test.tsx
+++ b/app/(routes)/__tests__/page.test.tsx
@@ -77,4 +77,55 @@ describe('home page', () => {
 			expect(sessionLinks.length).toBe(0);
 		});
 	});
+
+	describe('with multiple sessions on the same date', () => {
+		it('renders all sessions from the last 3 distinct dates', async () => {
+			const sessionsWithSharedDate = [
+				{
+					id: 1,
+					visit_date: '2024-05-10',
+					location_id: 1,
+					ringing_group_id: 3,
+					location: { location_name: 'Site A' },
+					encounters: [{ count: 4 }]
+				},
+				{
+					id: 2,
+					visit_date: '2024-05-10',
+					location_id: 2,
+					ringing_group_id: 3,
+					location: { location_name: 'Site B' },
+					encounters: [{ count: 2 }]
+				},
+				{
+					id: 3,
+					visit_date: '2024-04-15',
+					location_id: 1,
+					ringing_group_id: 3,
+					location: { location_name: 'Site A' },
+					encounters: [{ count: 1 }]
+				},
+				{
+					id: 4,
+					visit_date: '2024-03-20',
+					location_id: 1,
+					ringing_group_id: 3,
+					location: { location_name: 'Site A' },
+					encounters: [{ count: 3 }]
+				}
+			];
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+				makeChainClient(sessionsWithSharedDate)
+			);
+			render(await Page());
+			const heading = await screen.findByRole('heading', {
+				name: 'Recent Sessions'
+			});
+			const sessionLinks =
+				heading.nextElementSibling?.querySelectorAll('a') ?? [];
+			// 2 sessions on same date: 1 day-total link (StatOutput) + 2 site links
+			// + 1 link each for the 2 single-session dates = 5 total
+			expect(sessionLinks.length).toBe(5);
+		});
+	});
 });

--- a/app/(routes)/page.tsx
+++ b/app/(routes)/page.tsx
@@ -144,15 +144,20 @@ export async function fetchRecentSessions(
 	viewedGroupId: number
 ): Promise<SessionWithEncountersCount[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
-	return supabase
+	const sessions = (await supabase
 		.from('Sessions')
 		.select(
 			'id, visit_date, location_id, ringing_group_id, location:Locations(location_name), encounters:Encounters(count)'
 		)
 		.eq('ringing_group_id', viewedGroupId)
 		.order('visit_date', { ascending: false })
-		.limit(3)
-		.then(catchSupabaseErrors) as Promise<SessionWithEncountersCount[]>;
+		.limit(30)
+		.then(catchSupabaseErrors)) as SessionWithEncountersCount[];
+	const recentDates = [...new Set(sessions.map((s) => s.visit_date))].slice(
+		0,
+		3
+	);
+	return sessions.filter((s) => recentDates.includes(s.visit_date));
 }
 
 export async function fetchHomePageData(


### PR DESCRIPTION
## Summary

- `fetchRecentSessions` used `.limit(3)` which fetched 3 session rows rather than sessions for the 3 most-recent dates
- If multiple sites were visited on the same day, only one appeared in Recent Sessions
- Fix: fetch up to 30 sessions, then filter in the server action to sessions whose `visit_date` falls within the first 3 distinct dates

Relates to #224

Closes #224

## Test plan

- [ ] Existing page tests pass unchanged (fixture has 3 sessions × 3 distinct dates → filter is a no-op)
- [ ] New test asserts 4 sessions across 3 dates all render when 2 share a date

🤖 Generated with [Claude Code](https://claude.com/claude-code)