### PR TITLE
feat(#107): clearer wing and weight info on species page

### DIFF
--- a/app/components/SpStats.tsx
+++ b/app/components/SpStats.tsx
@@ -21,12 +21,65 @@ const statsByCategory: Record<string, SpeciesStatConfig[]> =
 		{} as Record<string, SpeciesStatConfig[]>
 	);
 
+type MeasurementCategoryProps = {
+	label: string;
+	min: number | null;
+	max: number | null;
+	avg: number | null;
+	median: number | null;
+	suffix: string;
+};
+
+function MeasurementCategory({
+	label,
+	min,
+	max,
+	avg,
+	median,
+	suffix
+}: MeasurementCategoryProps) {
+	return (
+		<li className="flex items-center gap-2 flex-wrap">
+			{label}: {min}-{max}
+			{suffix} (avg: {avg}
+			{suffix}, median: {median}
+			{suffix})
+		</li>
+	);
+}
+
 function StatsByCategory({
 	speciesStats
 }: {
 	speciesStats: AggregateStatsRow;
 }) {
 	return categoryOrder.map((categoryName) => {
+		if (categoryName === 'Weight') {
+			return (
+				<MeasurementCategory
+					key="Weight"
+					label="Weight"
+					min={speciesStats.min_weight}
+					max={speciesStats.max_weight}
+					avg={speciesStats.avg_weight}
+					median={speciesStats.median_weight}
+					suffix="g"
+				/>
+			);
+		}
+		if (categoryName === 'Wing') {
+			return (
+				<MeasurementCategory
+					key="Wing"
+					label="Wing"
+					min={speciesStats.min_wing}
+					max={speciesStats.max_wing}
+					avg={speciesStats.avg_wing}
+					median={speciesStats.median_wing}
+					suffix="mm"
+				/>
+			);
+		}
 		const subStats = statsByCategory[categoryName];
 		return (
 			<li className="flex items-center gap-2 flex-wrap" key={categoryName}>

--- a/app/components/__tests__/SpStats.test.tsx
+++ b/app/components/__tests__/SpStats.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { SpStats } from '../SpStats';
+import spPageSnapshot from '@/test-fixtures/snapshots/fetchSpPageData.alpha.robin.json';
+import type { FullFatPageData } from '@/app/(routes)/species/[speciesName]/page';
+
+const { topSessions, birds, speciesStats } =
+	spPageSnapshot as unknown as FullFatPageData;
+
+afterEach(() => {
+	cleanup();
+});
+
+describe('SpStats', () => {
+	describe('Weight category', () => {
+		it('shows min-max range with avg and median', () => {
+			render(
+				<SpStats
+					topSessions={topSessions}
+					birds={birds}
+					speciesStats={speciesStats}
+					speciesId={1}
+					speciesName="Robin"
+					viewedGroupId={1}
+				/>
+			);
+			expect(
+				screen.getByText(/Weight:.*16\.5-21g.*avg: 18\.3g.*median: 18g/i)
+			).toBeDefined();
+		});
+	});
+
+	describe('Wing category', () => {
+		it('shows min-max range with avg and median', () => {
+			render(
+				<SpStats
+					topSessions={topSessions}
+					birds={birds}
+					speciesStats={speciesStats}
+					speciesId={1}
+					speciesName="Robin"
+					viewedGroupId={1}
+				/>
+			);
+			expect(
+				screen.getByText(/Wing:.*72-80mm.*avg: 74\.2mm.*median: 74mm/i)
+			).toBeDefined();
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Replaces 4 separate min/avg/max/median badges for Wing and Weight with a single consolidated line per measurement
- Format: `{min}-{max}{unit} (avg: {avg}{unit}, median: {median}{unit})`
- Adds `SpStats` component tests verifying the new display

## Changes
- `app/components/SpStats.tsx` — new `MeasurementCategory` component; `StatsByCategory` renders Wing/Weight categories with it
- `app/components/__tests__/SpStats.test.tsx` — new test file

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)