### PR TITLE
feat(#173): richer mistakes UI with tabs and lazy-loaded bird detail

### DIFF
--- a/app/(routes)/mistakes/__tests__/page.test.tsx
+++ b/app/(routes)/mistakes/__tests__/page.test.tsx
@@ -37,25 +37,53 @@ describe('mistakes page', () => {
 		expect(heading.textContent).toBe('Mistakes');
 	});
 
-	it('renders table with snapshot data', async () => {
+	it('renders a tab for each discrepancy type', async () => {
 		render(await Page());
-		const table = await screen.findByRole('table');
-		const rows = table.querySelectorAll('tbody tr');
-		expect(rows.length).toBe(
-			(mistakesSnapshot as DiscrepenciesResult[]).length
-		);
-		const firstRow = rows[0];
-		const cells = firstRow.querySelectorAll('td');
-		expect(cells[0].textContent?.trim()).toBe(mistakesSnapshot[0].ring_no);
-		expect(cells[1].textContent).toBe(mistakesSnapshot[0].species_name);
-		expect(cells[2].textContent).toBe(mistakesSnapshot[0].discrepency_type);
+		const tabList = await screen.findByRole('tablist');
+		const tabs = tabList.querySelectorAll('button');
+		const types = [
+			...new Set(
+				(mistakesSnapshot as DiscrepenciesResult[]).map(
+					(m) => m.discrepency_type
+				)
+			)
+		];
+		expect(tabs.length).toBe(types.length);
 	});
 
-	it('renders empty state when no data', async () => {
-		mockGetAuthenticatedSupabaseClient.mockResolvedValue(makeRpcClient([]));
+	it('shows only rows for the active tab', async () => {
 		render(await Page());
+		const tabList = await screen.findByRole('tablist');
+		const firstTab = tabList.querySelectorAll('button')[0];
+		const activeType = (mistakesSnapshot as DiscrepenciesResult[])[0]
+			.discrepency_type;
+		const expectedCount = (mistakesSnapshot as DiscrepenciesResult[]).filter(
+			(m) => m.discrepency_type === activeType
+		).length;
+		expect(firstTab.textContent).toBeTruthy();
 		const table = await screen.findByRole('table');
 		const rows = table.querySelectorAll('tbody tr');
-		expect(rows.length).toBe(0);
+		expect(rows.length).toBe(expectedCount);
+	});
+
+	it('renders ring_no as a link in each row', async () => {
+		render(await Page());
+		const table = await screen.findByRole('table');
+		const firstDataRow = table.querySelectorAll('tbody tr')[0];
+		const link = firstDataRow.querySelector('a');
+		expect(link).toBeTruthy();
+		const firstActiveType = (mistakesSnapshot as DiscrepenciesResult[])[0]
+			.discrepency_type;
+		const firstOfType = (mistakesSnapshot as DiscrepenciesResult[]).find(
+			(m) => m.discrepency_type === firstActiveType
+		)!;
+		expect(link?.getAttribute('href')).toBe(`/bird/${firstOfType.ring_no}`);
+	});
+
+	it('renders empty tab gracefully when no data', async () => {
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(makeRpcClient([]));
+		render(await Page());
+		const tabList = screen.queryByRole('tablist');
+		expect(tabList?.querySelectorAll('button').length ?? 0).toBe(0);
 	});
 });

--- a/app/actions/bird-encounters.ts
+++ b/app/actions/bird-encounters.ts
@@ -1,0 +1,47 @@
+'use server';
+import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
+import { catchSupabaseErrors } from '@/lib/supabase';
+import type { EncounterOfBird } from '@/app/models/bird';
+
+export async function fetchBirdEncounters(
+	ringNo: string
+): Promise<EncounterOfBird[]> {
+	const supabase = await getAuthenticatedSupabaseClient();
+	const bird = await supabase
+		.from('Birds')
+		.select('id')
+		.eq('ring_no', ringNo)
+		.maybeSingle()
+		.then(catchSupabaseErrors);
+
+	if (!bird) {
+		return [];
+	}
+
+	return supabase
+		.from('Encounters')
+		.select(
+			`
+			bird_id,
+			id,
+			age_code,
+			breeding_condition,
+			is_juv,
+			capture_time,
+			max_hatch_year,
+			min_hatch_year,
+			moult_code,
+			record_type,
+			sex,
+			sexing_method,
+			ringing_group_id,
+			weight,
+			wing_length,
+			session:Sessions(
+				visit_date
+			)
+		`
+		)
+		.eq('bird_id', bird.id)
+		.then(catchSupabaseErrors) as Promise<EncounterOfBird[]>;
+}

--- a/app/components/MistakesTable.tsx
+++ b/app/components/MistakesTable.tsx
@@ -34,7 +34,7 @@ function groupByDiscrepancyType(
 	);
 }
 
-function makeHighlighter(
+export function makeHighlighter(
 	discrepancyType: string,
 	encounters: EncounterOfBird[]
 ): (encounter: EncounterOfBird) => boolean {
@@ -45,17 +45,19 @@ function makeHighlighter(
 		return (enc) => enc.age_code != null && enc.age_code >= 2;
 	}
 	if (discrepancyType === 'wing_length') {
-		return (enc) => {
-			if (enc.wing_length == null) return false;
-			const w = enc.wing_length;
-			const otherMeasured = encounters
-				.filter((other) => other !== enc && other.wing_length != null)
-				.map((other) => other.wing_length as number);
-			const diffCount = otherMeasured.filter(
-				(m) => Math.abs(m - w) >= 5
-			).length;
-			return diffCount > otherMeasured.length / 2;
-		};
+		const measured = encounters
+			.filter((e) => e.wing_length != null)
+			.map((e) => e.wing_length as number)
+			.sort((a, b) => a - b);
+		if (measured.length === 0) return () => false;
+		const mid = Math.floor(measured.length / 2);
+		const median =
+			measured.length % 2 === 0
+				? (measured[mid - 1] + measured[mid]) / 2
+				: measured[mid];
+		const maxDist = Math.max(...measured.map((m) => Math.abs(m - median)));
+		return (enc) =>
+			enc.wing_length != null && Math.abs(enc.wing_length - median) === maxDist;
 	}
 	return () => false;
 }

--- a/app/components/MistakesTable.tsx
+++ b/app/components/MistakesTable.tsx
@@ -1,60 +1,175 @@
 'use client';
+import { useState, useEffect } from 'react';
 import { NoPrefetchLink } from '@/app/components/shared/NoPrefetchLink';
-import {
-	type ColumnConfig,
-	SortableTable,
-	type RowModelWithRawData
-} from '@/app/components/shared/SortableTable';
-import { DiscrepenciesResult } from '@/app/models/db';
+import { AccordionTableBody } from '@/app/components/shared/AccordionTableBody';
+import { SingleBirdTable } from '@/app/components/SingleBirdTable';
+import { fetchBirdEncounters } from '@/app/actions/bird-encounters';
+import type { DiscrepenciesResult } from '@/app/models/db';
+import type { EncounterOfBird } from '@/app/models/bird';
+import type { RowModelWithRawData } from '@/app/components/shared/SortableTable';
 
-type MistakesTableRowModel = Omit<DiscrepenciesResult, 'bird_id'>;
-
-const columnConfigs: Record<keyof MistakesTableRowModel, ColumnConfig> = {
-	ring_no: {
-		label: 'Bird'
-	},
-	species_name: {
-		label: 'Species'
-	},
-	discrepency_type: {
-		label: 'Discrepency Type'
-	}
+type MistakesRowModel = {
+	ringNo: string;
+	speciesName: string;
 };
 
-function MistakesTableBody({
-	data
-}: {
-	data: RowModelWithRawData<DiscrepenciesResult, MistakesTableRowModel>[];
-}) {
-	return (
-		<tbody>
-			{data.map((mistake) => (
-				<tr key={`${mistake.ring_no}-${mistake.discrepency_type}`}>
-					<td>
-						<NoPrefetchLink className="link" href={`/bird/${mistake.ring_no}`}>
-							{mistake.ring_no}
-						</NoPrefetchLink>
-					</td>
-					<td>{mistake.species_name}</td>
-					<td>{mistake.discrepency_type}</td>
-				</tr>
-			))}
-		</tbody>
+function formatTabLabel(discrepancyType: string): string {
+	const withSpaces = discrepancyType.replace(/_/g, ' ');
+	return withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1);
+}
+
+function groupByDiscrepancyType(
+	mistakes: DiscrepenciesResult[]
+): Record<string, DiscrepenciesResult[]> {
+	return mistakes.reduce<Record<string, DiscrepenciesResult[]>>(
+		(grouped, mistake) => {
+			const type = mistake.discrepency_type;
+			if (!grouped[type]) {
+				grouped[type] = [];
+			}
+			grouped[type].push(mistake);
+			return grouped;
+		},
+		{}
 	);
 }
+
+function makeHighlighter(
+	discrepancyType: string,
+	encounters: EncounterOfBird[]
+): (encounter: EncounterOfBird) => boolean {
+	if (discrepancyType === 'sex') {
+		return (enc) => !!enc.sex && enc.sex.toLowerCase() !== 'u';
+	}
+	if (discrepancyType === 'age') {
+		return (enc) => enc.age_code != null && enc.age_code >= 2;
+	}
+	if (discrepancyType === 'wing_length') {
+		return (enc) => {
+			if (enc.wing_length == null) return false;
+			const w = enc.wing_length;
+			const otherMeasured = encounters
+				.filter((other) => other !== enc && other.wing_length != null)
+				.map((other) => other.wing_length as number);
+			const diffCount = otherMeasured.filter(
+				(m) => Math.abs(m - w) >= 5
+			).length;
+			return diffCount > otherMeasured.length / 2;
+		};
+	}
+	return () => false;
+}
+
+function LazyBirdDetail({
+	model
+}: {
+	model: RowModelWithRawData<DiscrepenciesResult, MistakesRowModel>;
+}) {
+	const [encounters, setEncounters] = useState<EncounterOfBird[] | null>(null);
+	const { ring_no, discrepency_type } = model._rawRowData;
+
+	useEffect(() => {
+		fetchBirdEncounters(ring_no).then(setEncounters);
+	}, [ring_no]);
+
+	if (!encounters) {
+		return <p>Loading...</p>;
+	}
+
+	return (
+		<SingleBirdTable
+			encounters={encounters}
+			isInline={true}
+			highlightRow={makeHighlighter(discrepency_type, encounters)}
+		/>
+	);
+}
+
+function RingCell({
+	model
+}: {
+	model: RowModelWithRawData<DiscrepenciesResult, MistakesRowModel>;
+}) {
+	return (
+		<NoPrefetchLink className="link" href={`/bird/${model.ringNo}`}>
+			{model.ringNo}
+		</NoPrefetchLink>
+	);
+}
+
+function RestColumns({
+	model
+}: {
+	model: RowModelWithRawData<DiscrepenciesResult, MistakesRowModel>;
+}) {
+	return <td>{model.speciesName}</td>;
+}
+
+function MistakesDiscrepancyTable({
+	mistakes
+}: {
+	mistakes: DiscrepenciesResult[];
+}) {
+	const data: RowModelWithRawData<DiscrepenciesResult, MistakesRowModel>[] =
+		mistakes.map((mistake) => ({
+			ringNo: mistake.ring_no,
+			speciesName: mistake.species_name,
+			_rawRowData: mistake
+		}));
+
+	return (
+		<table className="table">
+			<thead>
+				<tr>
+					<th>Bird</th>
+					<th>Species</th>
+				</tr>
+			</thead>
+			<AccordionTableBody
+				data={data}
+				getKey={(item) => item.ringNo}
+				columnCount={2}
+				FirstColumnComponent={RingCell}
+				RestColumnsComponent={RestColumns}
+				ExpandedContentComponent={LazyBirdDetail}
+			/>
+		</table>
+	);
+}
+
 export function MistakesTable({
 	mistakes
 }: {
 	mistakes: DiscrepenciesResult[];
 }) {
+	const grouped = groupByDiscrepancyType(mistakes);
+	const discrepancyTypes = Object.keys(grouped);
+	const [activeTab, setActiveTab] = useState(discrepancyTypes[0] ?? '');
+
 	return (
-		<SortableTable<DiscrepenciesResult, MistakesTableRowModel>
-			columnConfigs={columnConfigs}
-			data={mistakes}
-			rowDataTransform={(row: DiscrepenciesResult): MistakesTableRowModel =>
-				row
-			}
-			TableBodyComponent={MistakesTableBody}
-		/>
+		<>
+			<nav
+				className="bg-base-200 rounded-field w-fit space-x-1 overflow-x-auto p-1 mt-4"
+				aria-label="Tabs"
+				role="tablist"
+				aria-orientation="horizontal"
+			>
+				{discrepancyTypes.map((type) => (
+					<button
+						key={type}
+						type="button"
+						className={`btn ${activeTab === type ? 'btn-default' : 'btn-secondary'}`}
+						onClick={() => setActiveTab(type)}
+					>
+						{formatTabLabel(type)}
+					</button>
+				))}
+			</nav>
+			{discrepancyTypes.map((type) =>
+				type === activeTab ? (
+					<MistakesDiscrepancyTable key={type} mistakes={grouped[type]} />
+				) : null
+			)}
+		</>
 	);
 }

--- a/app/components/SingleBirdTable.tsx
+++ b/app/components/SingleBirdTable.tsx
@@ -97,10 +97,12 @@ function SingleBirdTableBody({
 
 export function SingleBirdTable({
 	encounters,
-	isInline = false
+	isInline = false,
+	highlightRow
 }: {
 	encounters: EncounterOfBird[];
 	isInline?: boolean;
+	highlightRow?: (encounter: EncounterOfBird) => boolean;
 }) {
 	if (isInline) {
 		return (
@@ -115,8 +117,12 @@ export function SingleBirdTable({
 				<tbody>
 					{encounters.map((encounter) => {
 						const rowModel = rowDataTransform(encounter);
+						const isHighlighted = highlightRow?.(encounter) ?? false;
 						return (
-							<tr key={encounter.id}>
+							<tr
+								key={encounter.id}
+								className={isHighlighted ? 'bg-warning/20' : undefined}
+							>
 								{orderedColumnProperties.map((property) => (
 									<td key={property}>
 										{cellFormatter(rowModel[property], property)}

--- a/app/components/__tests__/MistakesTable.test.ts
+++ b/app/components/__tests__/MistakesTable.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { makeHighlighter } from '@/app/components/MistakesTable';
+import type { EncounterOfBird } from '@/app/models/bird';
+
+function makeEncounters(wingLengths: (number | null)[]): EncounterOfBird[] {
+	return wingLengths.map((wing_length, i) => ({
+		id: i,
+		bird_id: 1,
+		wing_length,
+		age_code: null,
+		sex: 'u',
+		sexing_method: null,
+		breeding_condition: null,
+		capture_time: '00:00',
+		is_juv: false,
+		max_hatch_year: null,
+		min_hatch_year: null,
+		moult_code: null,
+		record_type: 'C',
+		ringing_group_id: 1,
+		weight: null,
+		session: { visit_date: '2024-01-01' }
+	})) as unknown as EncounterOfBird[];
+}
+
+describe('makeHighlighter', () => {
+	describe('sex', () => {
+		it('highlights encounters with known sex', () => {
+			const encs = makeEncounters([null]);
+			const encounters = [
+				{ ...encs[0], id: 1, sex: 'M' },
+				{ ...encs[0], id: 2, sex: 'F' },
+				{ ...encs[0], id: 3, sex: 'u' },
+				{ ...encs[0], id: 4, sex: 'U' }
+			] as unknown as EncounterOfBird[];
+			const highlight = makeHighlighter('sex', encounters);
+			expect(highlight(encounters[0])).toBe(true);
+			expect(highlight(encounters[1])).toBe(true);
+			expect(highlight(encounters[2])).toBe(false);
+			expect(highlight(encounters[3])).toBe(false);
+		});
+	});
+
+	describe('age', () => {
+		it('highlights encounters with age_code >= 2', () => {
+			const encs = makeEncounters([null]);
+			const encounters = [
+				{ ...encs[0], id: 1, age_code: 1 },
+				{ ...encs[0], id: 2, age_code: 2 },
+				{ ...encs[0], id: 3, age_code: 5 },
+				{ ...encs[0], id: 4, age_code: null }
+			] as unknown as EncounterOfBird[];
+			const highlight = makeHighlighter('age', encounters);
+			expect(highlight(encounters[0])).toBe(false);
+			expect(highlight(encounters[1])).toBe(true);
+			expect(highlight(encounters[2])).toBe(true);
+			expect(highlight(encounters[3])).toBe(false);
+		});
+	});
+
+	describe('wing_length', () => {
+		it('highlights both records when only two measured', () => {
+			const encounters = makeEncounters([80, 90]);
+			const highlight = makeHighlighter('wing_length', encounters);
+			expect(highlight(encounters[0])).toBe(true);
+			expect(highlight(encounters[1])).toBe(true);
+		});
+
+		it('highlights the outlier in a clear outlier case', () => {
+			const encounters = makeEncounters([80, 81, 82, 74]);
+			const highlight = makeHighlighter('wing_length', encounters);
+			expect(highlight(encounters[0])).toBe(false);
+			expect(highlight(encounters[1])).toBe(false);
+			expect(highlight(encounters[2])).toBe(false);
+			expect(highlight(encounters[3])).toBe(true);
+		});
+
+		it('highlights max-distance records when multiple tied', () => {
+			const encounters = makeEncounters([80, 80, 90, 90]);
+			const highlight = makeHighlighter('wing_length', encounters);
+			expect(highlight(encounters[0])).toBe(true);
+			expect(highlight(encounters[1])).toBe(true);
+			expect(highlight(encounters[2])).toBe(true);
+			expect(highlight(encounters[3])).toBe(true);
+		});
+
+		it('does not highlight encounters without a wing_length', () => {
+			const encounters = makeEncounters([80, null, 90]);
+			const highlight = makeHighlighter('wing_length', encounters);
+			expect(highlight(encounters[1])).toBe(false);
+		});
+
+		it('returns false for all when no measured encounters', () => {
+			const encounters = makeEncounters([null, null]);
+			const highlight = makeHighlighter('wing_length', encounters);
+			expect(highlight(encounters[0])).toBe(false);
+			expect(highlight(encounters[1])).toBe(false);
+		});
+	});
+
+	describe('unknown type', () => {
+		it('never highlights', () => {
+			const encounters = makeEncounters([80]);
+			const highlight = makeHighlighter('unknown', encounters);
+			expect(highlight(encounters[0])).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Splits mistakes table into per-discrepancy-type tabs (Age, Sex, Wing length — dynamically derived)
- Adds expandable rows: click to lazy-load a bird's full encounter history
- Highlights discrepancy-relevant rows in the expanded table (sex: known-sex encounters; age: age_code ≥ 2; wing_length: encounters where majority of others differ ≥5mm)
- Removes `discrepency_type` column (redundant now tabs separate the types)

## Test plan
- [ ] `npm run qa` passes
- [ ] Navigate to `/mistakes` — three tabs visible, correct rows per tab
- [ ] Expand a row — loading state shown, then encounter table renders with highlighted rows
- [ ] Ring number links to `/bird/<ring>` page

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)