### PR TITLE
feat(#199): add species filter to bird ring search results

### DIFF
--- a/app/(routes)/bird/page.tsx
+++ b/app/(routes)/bird/page.tsx
@@ -1,20 +1,11 @@
 import { BootstrapPageData } from '@/app/components/layout/BootstrapPageData';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
-import {
-	BoxyList,
-	PageWrapper,
-	PrimaryHeading
-} from '@/app/components/shared/DesignSystem';
 import { redirect } from 'next/navigation';
-import { NoPrefetchLink } from '@/app/components/shared/NoPrefetchLink';
-import { RingSearchForm } from '@/app/components/shared/RingSearchForm';
-
-type SearchResult = {
-	ring_no: string;
-	species_name: string;
-	closeness_score: number;
-};
+import {
+	BirdSearchResults,
+	type SearchResult
+} from '@/app/components/BirdSearchResults';
 
 type SearchParams = { q: string };
 type PageProps = { searchParams: Promise<SearchParams> };
@@ -37,34 +28,6 @@ async function searchByRing({ q }: SearchParams, _viewedGroupId: number) {
 		.then(catchSupabaseErrors);
 }
 
-function SearchResults({
-	params: { q },
-	data
-}: {
-	params: SearchParams;
-	data: SearchResult[];
-}) {
-	return (
-		<PageWrapper>
-			<PrimaryHeading>Search results</PrimaryHeading>
-			<p>No exact match found for {q}. Showing closest matches.</p>
-			<div className="mt-4 mb-4 w-full sm:w-1/2 lg:w-1/3 xl:w-1/4">
-				{' '}
-				<RingSearchForm q={q} buttonText="Search again" />
-			</div>
-			<BoxyList>
-				{data.map(({ ring_no, species_name }) => (
-					<li key={ring_no}>
-						<NoPrefetchLink className="link" href={`/bird/${ring_no}`}>
-							{ring_no}: {species_name}
-						</NoPrefetchLink>
-					</li>
-				))}
-			</BoxyList>
-		</PageWrapper>
-	);
-}
-
 export default async function BirdPage(props: PageProps) {
 	return (
 		<BootstrapPageData<SearchResult[], PageProps, SearchParams>
@@ -74,7 +37,7 @@ export default async function BirdPage(props: PageProps) {
 			})}
 			getCacheKeys={(params: SearchParams) => ['search', params.q]}
 			dataFetcher={searchByRing}
-			PageComponent={SearchResults}
+			PageComponent={BirdSearchResults}
 		/>
 	);
 }

--- a/app/components/BirdSearchResults.tsx
+++ b/app/components/BirdSearchResults.tsx
@@ -1,0 +1,63 @@
+'use client';
+import { useState } from 'react';
+import { BoxyList, PageWrapper, PrimaryHeading } from './shared/DesignSystem';
+import { NoPrefetchLink } from './shared/NoPrefetchLink';
+import { RingSearchForm } from './shared/RingSearchForm';
+
+export type SearchResult = {
+	ring_no: string;
+	species_name: string;
+	closeness_score: number;
+};
+
+export function BirdSearchResults({
+	params: { q },
+	data
+}: {
+	params: { q: string };
+	data: SearchResult[];
+}) {
+	const [selectedSpecies, setSelectedSpecies] = useState('all');
+
+	const uniqueSpecies = [...new Set(data.map((r) => r.species_name))].sort();
+	const filteredData =
+		selectedSpecies === 'all'
+			? data
+			: data.filter((r) => r.species_name === selectedSpecies);
+
+	return (
+		<PageWrapper>
+			<PrimaryHeading>Search results</PrimaryHeading>
+			<p>No exact match found for {q}. Showing closest matches.</p>
+			<div className="mt-4 mb-4 w-full sm:w-1/2 lg:w-1/3 xl:w-1/4">
+				<RingSearchForm q={q} buttonText="Search again" />
+			</div>
+			{uniqueSpecies.length > 1 && (
+				<div className="mt-2 mb-4">
+					<select
+						className="select"
+						value={selectedSpecies}
+						onChange={(e) => setSelectedSpecies(e.target.value)}
+						aria-label="Filter by species"
+					>
+						<option value="all">All species</option>
+						{uniqueSpecies.map((species) => (
+							<option key={species} value={species}>
+								{species}
+							</option>
+						))}
+					</select>
+				</div>
+			)}
+			<BoxyList>
+				{filteredData.map(({ ring_no, species_name }) => (
+					<li key={ring_no}>
+						<NoPrefetchLink className="link" href={`/bird/${ring_no}`}>
+							{ring_no}: {species_name}
+						</NoPrefetchLink>
+					</li>
+				))}
+			</BoxyList>
+		</PageWrapper>
+	);
+}

--- a/app/components/__tests__/BirdSearchResults.test.tsx
+++ b/app/components/__tests__/BirdSearchResults.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { BirdSearchResults } from '../BirdSearchResults';
+import type { SearchResult } from '../BirdSearchResults';
+
+afterEach(cleanup);
+
+const singleSpeciesResults: SearchResult[] = [
+	{ ring_no: 'ABC123', species_name: 'Robin', closeness_score: 0.9 },
+	{ ring_no: 'ABC456', species_name: 'Robin', closeness_score: 0.7 }
+];
+
+const multiSpeciesResults: SearchResult[] = [
+	{ ring_no: 'ABC123', species_name: 'Robin', closeness_score: 0.9 },
+	{ ring_no: 'ABC456', species_name: 'Blue Tit', closeness_score: 0.7 },
+	{ ring_no: 'ABC789', species_name: 'Robin', closeness_score: 0.6 }
+];
+
+describe('BirdSearchResults', () => {
+	describe('with single species results', () => {
+		it('does not render species filter select', () => {
+			render(
+				<BirdSearchResults params={{ q: 'ABC' }} data={singleSpeciesResults} />
+			);
+			expect(
+				screen.queryByRole('combobox', { name: /filter by species/i })
+			).toBeNull();
+		});
+
+		it('renders all results', () => {
+			render(
+				<BirdSearchResults params={{ q: 'ABC' }} data={singleSpeciesResults} />
+			);
+			const list = screen.getByRole('list');
+			expect(list.querySelectorAll('li').length).toBe(2);
+		});
+	});
+
+	describe('with multiple species results', () => {
+		it('renders species filter select with "All species" and one option per species', () => {
+			render(
+				<BirdSearchResults params={{ q: 'ABC' }} data={multiSpeciesResults} />
+			);
+			const select = screen.getByRole('combobox', {
+				name: /filter by species/i
+			});
+			const options = Array.from(select.querySelectorAll('option'));
+			expect(options.map((o) => o.value)).toEqual(['all', 'Blue Tit', 'Robin']);
+		});
+
+		it('shows all results when "All species" selected (default)', () => {
+			render(
+				<BirdSearchResults params={{ q: 'ABC' }} data={multiSpeciesResults} />
+			);
+			const list = screen.getByRole('list');
+			expect(list.querySelectorAll('li').length).toBe(3);
+		});
+
+		it('filters results when a species is selected', () => {
+			render(
+				<BirdSearchResults params={{ q: 'ABC' }} data={multiSpeciesResults} />
+			);
+			const select = screen.getByRole('combobox', {
+				name: /filter by species/i
+			});
+			fireEvent.change(select, { target: { value: 'Blue Tit' } });
+			const list = screen.getByRole('list');
+			const items = list.querySelectorAll('li');
+			expect(items.length).toBe(1);
+			expect(items[0].textContent).toContain('ABC456');
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Extracts `SearchResults` from `bird/page.tsx` into a new `BirdSearchResults` client component
- Adds a species filter `<select>` between the search form and results list
- Filter is hidden when all results share the same species; shown with "All species" + sorted unique species options otherwise
- Filtering is client-side — no data refetch

Closes #199