### PR TITLE
refactor: restyle tabs as paper tabs, extract shared TabNav

### DIFF
--- a/app/components/MistakesTable.tsx
+++ b/app/components/MistakesTable.tsx
@@ -7,6 +7,7 @@ import { fetchBirdEncounters } from '@/app/actions/bird-encounters';
 import type { DiscrepenciesResult } from '@/app/models/db';
 import type { EncounterOfBird } from '@/app/models/bird';
 import type { RowModelWithRawData } from '@/app/components/shared/SortableTable';
+import { TabNav } from '@/app/components/TabNav';
 
 type MistakesRowModel = {
 	ringNo: string;
@@ -150,23 +151,14 @@ export function MistakesTable({
 
 	return (
 		<>
-			<nav
-				className="bg-base-200 rounded-field w-fit space-x-1 overflow-x-auto p-1 mt-4"
-				aria-label="Tabs"
-				role="tablist"
-				aria-orientation="horizontal"
-			>
-				{discrepancyTypes.map((type) => (
-					<button
-						key={type}
-						type="button"
-						className={`btn ${activeTab === type ? 'btn-default' : 'btn-secondary'}`}
-						onClick={() => setActiveTab(type)}
-					>
-						{formatTabLabel(type)}
-					</button>
-				))}
-			</nav>
+			<TabNav
+				tabs={discrepancyTypes.map((type) => ({
+					id: type,
+					label: formatTabLabel(type)
+				}))}
+				activeTab={activeTab}
+				onTabChange={setActiveTab}
+			/>
 			{discrepancyTypes.map((type) =>
 				type === activeTab ? (
 					<MistakesDiscrepancyTable key={type} mistakes={grouped[type]} />

--- a/app/components/SingleSessionTable.tsx
+++ b/app/components/SingleSessionTable.tsx
@@ -15,6 +15,7 @@ import {
 	SortableTable,
 	type RowModelWithRawData
 } from './shared/SortableTable';
+import { TabNav } from './TabNav';
 
 function SpeciesNameCell({
 	model: { species }
@@ -255,37 +256,19 @@ export function SessionTabs({
 	);
 	const [activeTab, setActiveTab] = useState('by-species');
 
-	function handleTabClick(event: React.MouseEvent<HTMLButtonElement>) {
-		const tab = event.currentTarget.id.replace('session-tabs-control-', '');
-		setLoadedTabs((prev) => new Set([...prev, tab]));
-		setActiveTab(tab);
-	}
-
 	return (
 		<>
-			<nav
-				className="bg-base-200 rounded-field w-fit space-x-1 overflow-x-auto p-1 mt-4"
-				aria-label="Tabs"
-				role="tablist"
-				aria-orientation="horizontal"
-			>
-				<button
-					type="button"
-					id="session-tabs-control-by-species"
-					className={`btn ${activeTab === 'by-species' ? 'btn-default' : 'btn-secondary'}`}
-					onClick={handleTabClick}
-				>
-					By species
-				</button>
-				<button
-					type="button"
-					id="session-tabs-control-by-time"
-					className={`btn ${activeTab === 'by-time' ? 'btn-default' : 'btn-secondary'}`}
-					onClick={handleTabClick}
-				>
-					By time
-				</button>
-			</nav>
+			<TabNav
+				tabs={[
+					{ id: 'by-species', label: 'By species' },
+					{ id: 'by-time', label: 'By time' }
+				]}
+				activeTab={activeTab}
+				onTabChange={(tab) => {
+					setLoadedTabs((prev) => new Set([...prev, tab]));
+					setActiveTab(tab);
+				}}
+			/>
 			<ConditionalTabPanel
 				loadedTabs={loadedTabs}
 				tabId="by-species"

--- a/app/components/SpPage.tsx
+++ b/app/components/SpPage.tsx
@@ -16,6 +16,7 @@ import { SpNotableRetrapsTab } from './SpNotableRetrapsTab';
 import { SpStatsHistoryTab } from './SpStatsHistoryTab';
 import { SpWeightWingTab } from './SpWeightWingTab';
 import { SpYearComparisonTab } from './SpYearComparisonTab';
+import { TabNav } from './TabNav';
 
 function ConditionalTabPanel({
 	loadedTabs,
@@ -52,8 +53,7 @@ function SpeciesData({
 	);
 	const [activeTab, setActiveTab] = useState('bird-list');
 
-	function handleTabClick(event: React.MouseEvent<HTMLButtonElement>) {
-		const tab = event.currentTarget.id.replace('tabs-control-', '');
+	function handleTabChange(tab: string) {
 		setLoadedTabs((prev) => new Set([...prev, tab]));
 		setActiveTab(tab);
 	}
@@ -61,53 +61,17 @@ function SpeciesData({
 	return (
 		<>
 			<SpStats {...data} viewedGroupId={viewedGroupId} />
-			<nav
-				className="bg-base-200 rounded-field w-fit space-x-1 overflow-x-auto p-1 mt-4"
-				aria-label="Tabs"
-				role="tablist"
-				aria-orientation="horizontal"
-			>
-				<button
-					type="button"
-					id="tabs-control-bird-list"
-					className={`btn  ${activeTab === 'bird-list' ? 'btn-default' : 'btn-secondary'}`}
-					onClick={handleTabClick}
-				>
-					Bird list
-				</button>
-				<button
-					type="button"
-					id="tabs-control-retraps"
-					className={`btn ${activeTab === 'retraps' ? 'btn-default' : 'btn-secondary'}`}
-					onClick={handleTabClick}
-				>
-					Retraps
-				</button>
-				<button
-					type="button"
-					id="tabs-control-trend-charts"
-					className={`btn ${activeTab === 'trend-charts' ? 'btn-default' : 'btn-secondary'}`}
-					onClick={handleTabClick}
-				>
-					Trend charts
-				</button>
-				<button
-					type="button"
-					id="tabs-control-year-comparison"
-					className={`btn ${activeTab === 'year-comparison' ? 'btn-default' : 'btn-secondary'}`}
-					onClick={handleTabClick}
-				>
-					Year comparison
-				</button>
-				<button
-					type="button"
-					id="tabs-control-size-plot"
-					className={`btn ${activeTab === 'size-plot' ? 'btn-default' : 'btn-secondary'}`}
-					onClick={handleTabClick}
-				>
-					Size plot
-				</button>
-			</nav>
+			<TabNav
+				tabs={[
+					{ id: 'bird-list', label: 'Bird list' },
+					{ id: 'retraps', label: 'Retraps' },
+					{ id: 'trend-charts', label: 'Trend charts' },
+					{ id: 'year-comparison', label: 'Year comparison' },
+					{ id: 'size-plot', label: 'Size plot' }
+				]}
+				activeTab={activeTab}
+				onTabChange={handleTabChange}
+			/>
 			<ConditionalTabPanel
 				loadedTabs={loadedTabs}
 				tabId="bird-list"

--- a/app/components/TabNav.tsx
+++ b/app/components/TabNav.tsx
@@ -30,7 +30,7 @@ export function TabNav({
 					key={id}
 					type="button"
 					id={id}
-					aria-selected={activeTab === id}
+					aria-current={activeTab === id ? 'true' : undefined}
 					className={
 						activeTab === id
 							? 'px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm whitespace-nowrap font-medium bg-base-100 border border-base-300 border-b-base-100 rounded-t-sm -mb-px'

--- a/app/components/TabNav.tsx
+++ b/app/components/TabNav.tsx
@@ -33,7 +33,7 @@ export function TabNav({
 					aria-current={activeTab === id ? 'true' : undefined}
 					className={
 						activeTab === id
-							? 'px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm whitespace-nowrap font-medium bg-base-100 border border-base-300 border-b-base-100 rounded-t-sm -mb-px'
+							? 'px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm whitespace-nowrap font-medium bg-base-100 border border-base-300 border-b-0 rounded-t-sm -mb-px'
 							: 'px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm whitespace-nowrap text-base-content/60 hover:text-base-content cursor-pointer'
 					}
 					onClick={() => onTabChange(id)}

--- a/app/components/TabNav.tsx
+++ b/app/components/TabNav.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+interface TabConfig {
+	id: string;
+	label: string;
+}
+
+interface TabNavProps {
+	tabs: TabConfig[];
+	activeTab: string;
+	onTabChange: (id: string) => void;
+	ariaLabel?: string;
+}
+
+export function TabNav({
+	tabs,
+	activeTab,
+	onTabChange,
+	ariaLabel = 'Tabs'
+}: TabNavProps) {
+	return (
+		<nav
+			className="flex overflow-x-auto mt-4 border-b border-base-300"
+			role="tablist"
+			aria-label={ariaLabel}
+			aria-orientation="horizontal"
+		>
+			{tabs.map(({ id, label }) => (
+				<button
+					key={id}
+					type="button"
+					id={id}
+					aria-selected={activeTab === id}
+					className={
+						activeTab === id
+							? 'px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm whitespace-nowrap font-medium bg-base-100 border border-base-300 border-b-base-100 rounded-t-sm -mb-px'
+							: 'px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm whitespace-nowrap text-base-content/60 hover:text-base-content cursor-pointer'
+					}
+					onClick={() => onTabChange(id)}
+				>
+					{label}
+				</button>
+			))}
+		</nav>
+	);
+}

--- a/app/components/TabNav.tsx
+++ b/app/components/TabNav.tsx
@@ -19,28 +19,30 @@ export function TabNav({
 	ariaLabel = 'Tabs'
 }: TabNavProps) {
 	return (
-		<nav
-			className="flex overflow-x-auto mt-4 border-b border-base-300"
-			role="tablist"
-			aria-label={ariaLabel}
-			aria-orientation="horizontal"
-		>
-			{tabs.map(({ id, label }) => (
-				<button
-					key={id}
-					type="button"
-					id={id}
-					aria-current={activeTab === id ? 'true' : undefined}
-					className={
-						activeTab === id
-							? 'px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm whitespace-nowrap font-medium bg-base-100 border border-base-300 border-b-0 rounded-t-sm -mb-px'
-							: 'px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm whitespace-nowrap text-base-content/60 hover:text-base-content cursor-pointer'
-					}
-					onClick={() => onTabChange(id)}
-				>
-					{label}
-				</button>
-			))}
-		</nav>
+		<div className="overflow-x-auto mt-4">
+			<nav
+				className="flex border-b border-base-300 min-w-max"
+				role="tablist"
+				aria-label={ariaLabel}
+				aria-orientation="horizontal"
+			>
+				{tabs.map(({ id, label }) => (
+					<button
+						key={id}
+						type="button"
+						id={id}
+						aria-current={activeTab === id ? 'true' : undefined}
+						className={
+							activeTab === id
+								? 'px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm whitespace-nowrap font-medium bg-base-100 border border-base-300 border-b-0 rounded-t-sm translate-y-px'
+								: 'px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm whitespace-nowrap text-base-content/60 hover:text-base-content cursor-pointer'
+						}
+						onClick={() => onTabChange(id)}
+					>
+						{label}
+					</button>
+				))}
+			</nav>
+		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- Replaces toggle-button tab styling with classic paper-tab look: full-width bottom border, active tab opens at bottom (white background, no bottom border), inactive tabs grey
- Responsive sizing: `text-xs sm:text-sm`, smaller padding on mobile
- Tab row uses `overflow-x-auto` — buttons never wrap, scroll horizontally when needed
- Extracts shared `TabNav` component (DRY — same pattern existed in 3 places)

## Test plan

- [ ] All 219 existing tests pass (verified locally)
- [ ] Visually check tabs on species page, session page, and mistakes page
- [ ] Resize browser to mobile width and confirm tabs shrink and scroll rather than wrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)