### PR TITLE
fix: correct winter season year assignment in getSeasonMonths

### DIFF
--- a/app/models/__tests__/seasons.test.ts
+++ b/app/models/__tests__/seasons.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { getSeasonMonths } from '../seasons';
+
+describe('getSeasonMonths', () => {
+	it('returns numeric months when thisYear is false', () => {
+		const date = new Date('2024-11-15');
+		expect(getSeasonMonths(date, false)).toEqual([11, 12, 1, 2, 3]);
+	});
+
+	it('returns YYYY-MM strings for a spring date', () => {
+		const date = new Date('2024-05-10');
+		expect(getSeasonMonths(date, true)).toEqual([
+			'2024-04',
+			'2024-05',
+			'2024-06',
+			'2024-07'
+		]);
+	});
+
+	it('assigns Nov/Dec to the starting year and Jan–Mar to the following year for a November winter date', () => {
+		const date = new Date('2024-11-15');
+		expect(getSeasonMonths(date, true)).toEqual([
+			'2024-11',
+			'2024-12',
+			'2025-01',
+			'2025-02',
+			'2025-03'
+		]);
+	});
+
+	it('assigns Nov/Dec to the previous year for a January winter date', () => {
+		const date = new Date('2025-01-20');
+		expect(getSeasonMonths(date, true)).toEqual([
+			'2024-11',
+			'2024-12',
+			'2025-01',
+			'2025-02',
+			'2025-03'
+		]);
+	});
+});

--- a/app/models/seasons.ts
+++ b/app/models/seasons.ts
@@ -39,8 +39,12 @@ export function getSeasonMonths(
 	const months = seasonToMonthsMap[season];
 	if (thisYear) {
 		if (season === Season.WINTER) {
-			return months.map(
-				(month) => `${year > 9 ? year - 1 : year}-${month}`
+			const monthIndex = date.getMonth();
+			const seasonStartYear = monthIndex >= 10 ? year : year - 1;
+			return months.map((month) =>
+				Number(month) >= 11
+					? `${seasonStartYear}-${month}`
+					: `${seasonStartYear + 1}-${month}`
 			) as string[];
 		}
 		return months.map((month) => `${year}-${month}`) as string[];


### PR DESCRIPTION
## Summary

- Fixes a bug in `app/models/seasons.ts` where `year > 9 ? year - 1 : year` was always using `year - 1` because real years (e.g. 2024) are always greater than 9
- Replaces the broken condition with correct per-month logic: Nov/Dec months get the season-start year, Jan–Mar months get season-start year + 1, where season-start year is derived from the date's own month (Nov/Dec → current year; Jan–Mar → previous year)
- Adds `app/models/__tests__/seasons.test.ts` with 4 tests covering the specified cases

## Test plan

- [x] `returns numeric months when thisYear is false`
- [x] `returns YYYY-MM strings for a spring date`
- [x] `assigns Nov/Dec to the starting year and Jan–Mar to the following year for a November winter date`
- [x] `assigns Nov/Dec to the previous year for a January winter date`

Closes #312

Part of #219 (first increment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)