### PR TITLE
feat: session highlights 1 — UI scaffold + session-total records

### DIFF
--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchSessionHighlights } from '../session-highlights';
+import type { TopMetricsFilterParams } from '@/app/models/db';
+
+const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
+	mockGetAuthenticatedSupabaseClient: vi.fn()
+}));
+
+vi.mock('@/lib/group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+const SESSION_DATE = '2024-09-15';
+const GROUP_ID = 1;
+
+describe('fetchSessionHighlights', () => {
+	const mockRpc = vi.fn();
+
+	beforeEach(() => {
+		mockRpc.mockReset();
+		mockRpc.mockResolvedValue({ data: [], error: null });
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue({ rpc: mockRpc });
+	});
+
+	it('calls top_metrics_by_period once per metric and scope with ringing_group_filter set', async () => {
+		await fetchSessionHighlights({
+			date: SESSION_DATE,
+			viewedGroupId: GROUP_ID
+		});
+		expect(mockRpc).toHaveBeenCalledTimes(8);
+		const calls = mockRpc.mock.calls as [
+			string,
+			{
+				temporal_unit: string;
+				metric_name: string;
+				result_limit: number;
+				filters: TopMetricsFilterParams;
+			}
+		][];
+		calls.forEach(([functionName, args]) => {
+			expect(functionName).toBe('top_metrics_by_period');
+			expect(args.temporal_unit).toBe('day');
+			expect(args.result_limit).toBe(2);
+			expect(args.filters.ringing_group_filter).toBe(GROUP_ID);
+		});
+		const metricNames = calls.map(([, args]) => args.metric_name);
+		expect(metricNames.filter((name) => name === 'encounters').length).toBe(4);
+		expect(metricNames.filter((name) => name === 'species').length).toBe(4);
+	});
+
+	it('maps matching top results into session-total-record highlights', async () => {
+		mockRpc.mockImplementation(
+			(
+				_functionName: string,
+				args: { metric_name: string; filters: TopMetricsFilterParams }
+			) => {
+				const isAllTimeEncounters =
+					args.metric_name === 'encounters' &&
+					args.filters.months_filter === undefined &&
+					args.filters.year_filter === undefined &&
+					args.filters.exact_months_filter === undefined;
+				return Promise.resolve({
+					data: isAllTimeEncounters
+						? [
+								{ visit_date: SESSION_DATE, metric_value: 74 },
+								{ visit_date: '2022-05-01', metric_value: 60 }
+							]
+						: [],
+					error: null
+				});
+			}
+		);
+		const highlights = await fetchSessionHighlights({
+			date: SESSION_DATE,
+			viewedGroupId: GROUP_ID
+		});
+		expect(highlights).toEqual([
+			expect.objectContaining({
+				type: 'session-total-record',
+				metric: 'encounters',
+				scope: 'all-time',
+				value: 74
+			})
+		]);
+	});
+});

--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { fetchSessionHighlights } from '../session-highlights';
 import type { TopMetricsFilterParams } from '@/app/models/db';
 
 const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
@@ -13,67 +12,60 @@ vi.mock('@/lib/group-auth', () => ({
 const SESSION_DATE = '2024-09-15';
 const GROUP_ID = 1;
 
+const mockRpc = vi.fn();
+const mockEq = vi.fn();
+const mockSelect = vi.fn(() => ({ eq: mockEq }));
+const mockFrom = vi.fn(() => ({ select: mockSelect }));
+
+// the action memoises the stats blob at module scope, so each test
+// imports a fresh copy of the module
+async function importFetchSessionHighlights() {
+	vi.resetModules();
+	const { fetchSessionHighlights } = await import('../session-highlights');
+	return fetchSessionHighlights;
+}
+
+beforeEach(() => {
+	mockRpc.mockReset();
+	mockEq.mockReset();
+	mockRpc.mockResolvedValue({
+		data: [
+			{ species_name: 'Robin', visit_date: SESSION_DATE, metric_value: 74 },
+			{ species_name: 'Robin', visit_date: '2022-05-01', metric_value: 30 },
+			{ species_name: 'Wren', visit_date: '2022-05-01', metric_value: 30 }
+		],
+		error: null
+	});
+	mockEq.mockResolvedValue({
+		data: [{ visit_date: '2022-05-01' }, { visit_date: SESSION_DATE }],
+		error: null
+	});
+	mockGetAuthenticatedSupabaseClient.mockResolvedValue({
+		rpc: mockRpc,
+		from: mockFrom
+	});
+});
+
 describe('fetchSessionHighlights', () => {
-	const mockRpc = vi.fn();
-
-	beforeEach(() => {
-		mockRpc.mockReset();
-		mockRpc.mockResolvedValue({ data: [], error: null });
-		mockGetAuthenticatedSupabaseClient.mockResolvedValue({ rpc: mockRpc });
-	});
-
-	it('calls top_metrics_by_period once per metric and scope with ringing_group_filter set', async () => {
-		await fetchSessionHighlights({
-			date: SESSION_DATE,
-			viewedGroupId: GROUP_ID
-		});
-		expect(mockRpc).toHaveBeenCalledTimes(8);
-		const calls = mockRpc.mock.calls as [
-			string,
-			{
-				temporal_unit: string;
-				metric_name: string;
-				result_limit: number;
-				filters: TopMetricsFilterParams;
-			}
-		][];
-		calls.forEach(([functionName, args]) => {
-			expect(functionName).toBe('top_metrics_by_period');
-			expect(args.temporal_unit).toBe('day');
-			expect(args.result_limit).toBe(2);
-			expect(args.filters.ringing_group_filter).toBe(GROUP_ID);
-		});
-		const metricNames = calls.map(([, args]) => args.metric_name);
-		expect(metricNames.filter((name) => name === 'encounters').length).toBe(4);
-		expect(metricNames.filter((name) => name === 'species').length).toBe(4);
-	});
-
-	it('maps matching top results into session-total-record highlights', async () => {
-		mockRpc.mockImplementation(
-			(
-				_functionName: string,
-				args: { metric_name: string; filters: TopMetricsFilterParams }
-			) => {
-				const isAllTimeEncounters =
-					args.metric_name === 'encounters' &&
-					args.filters.months_filter === undefined &&
-					args.filters.year_filter === undefined &&
-					args.filters.exact_months_filter === undefined;
-				return Promise.resolve({
-					data: isAllTimeEncounters
-						? [
-								{ visit_date: SESSION_DATE, metric_value: 74 },
-								{ visit_date: '2022-05-01', metric_value: 60 }
-							]
-						: [],
-					error: null
-				});
-			}
-		);
+	it('fetches day-species metrics once with the group filter', async () => {
+		const fetchSessionHighlights = await importFetchSessionHighlights();
 		const highlights = await fetchSessionHighlights({
 			date: SESSION_DATE,
 			viewedGroupId: GROUP_ID
 		});
+		expect(mockRpc).toHaveBeenCalledTimes(1);
+		const [functionName, args] = mockRpc.mock.calls[0] as [
+			string,
+			{
+				temporal_unit: string;
+				metric_name: string;
+				filters: TopMetricsFilterParams;
+			}
+		];
+		expect(functionName).toBe('metrics_by_period_and_species');
+		expect(args.temporal_unit).toBe('day');
+		expect(args.metric_name).toBe('encounters');
+		expect(args.filters.ringing_group_filter).toBe(GROUP_ID);
 		expect(highlights).toEqual([
 			expect.objectContaining({
 				type: 'session-total-record',
@@ -82,5 +74,32 @@ describe('fetchSessionHighlights', () => {
 				value: 74
 			})
 		]);
+	});
+
+	it('fetches session dates', async () => {
+		const fetchSessionHighlights = await importFetchSessionHighlights();
+		await fetchSessionHighlights({
+			date: SESSION_DATE,
+			viewedGroupId: GROUP_ID
+		});
+		expect(mockFrom).toHaveBeenCalledWith('Sessions');
+		expect(mockSelect).toHaveBeenCalledWith('visit_date');
+		expect(mockEq).toHaveBeenCalledWith('ringing_group_id', GROUP_ID);
+	});
+
+	it('returns cached data within the TTL', async () => {
+		const fetchSessionHighlights = await importFetchSessionHighlights();
+		await fetchSessionHighlights({
+			date: SESSION_DATE,
+			viewedGroupId: GROUP_ID
+		});
+		const secondResult = await fetchSessionHighlights({
+			date: '2022-05-01',
+			viewedGroupId: GROUP_ID
+		});
+		expect(mockRpc).toHaveBeenCalledTimes(1);
+		expect(mockEq).toHaveBeenCalledTimes(1);
+		// the cached blob still serves other session dates
+		expect(secondResult).toEqual([]);
 	});
 });

--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -1,0 +1,47 @@
+'use server';
+import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
+import { catchSupabaseErrors } from '@/lib/supabase';
+import {
+	SESSION_TOTAL_METRICS,
+	deriveSessionTotalRecords,
+	getScopeFilters,
+	sortHighlights,
+	type ScopedTopPeriods,
+	type SessionHighlight,
+	type SessionTotalMetric
+} from '@/app/models/session-highlights';
+import type { TopMetricsFilterParams, TopPeriodsResult } from '@/app/models/db';
+
+export async function fetchSessionHighlights({
+	date,
+	viewedGroupId
+}: {
+	date: string;
+	viewedGroupId: number;
+}): Promise<SessionHighlight[]> {
+	const supabase = await getAuthenticatedSupabaseClient();
+	const scopeFilters = getScopeFilters(new Date(date), viewedGroupId);
+	const metricScopeCombinations = SESSION_TOTAL_METRICS.flatMap((metric) =>
+		scopeFilters.map((scopeFilter) => ({ metric, ...scopeFilter }))
+	);
+	const scopedResults = await Promise.all(
+		metricScopeCombinations.map(async ({ metric, scope, filters }) => {
+			const rows = (await supabase
+				.rpc('top_metrics_by_period', {
+					temporal_unit: 'day',
+					metric_name: metric,
+					result_limit: 2,
+					filters: filters as TopMetricsFilterParams
+				})
+				.then(catchSupabaseErrors)) as TopPeriodsResult[] | null;
+			return { metric, scope, rows: rows ?? [] };
+		})
+	);
+	const resultsByMetric = {} as Record<SessionTotalMetric, ScopedTopPeriods[]>;
+	for (const metric of SESSION_TOTAL_METRICS) {
+		resultsByMetric[metric] = scopedResults.filter(
+			(result) => result.metric === metric
+		);
+	}
+	return sortHighlights(deriveSessionTotalRecords({ date, resultsByMetric }));
+}

--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -2,15 +2,58 @@
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
 import {
-	SESSION_TOTAL_METRICS,
 	deriveSessionTotalRecords,
-	getScopeFilters,
 	sortHighlights,
-	type ScopedTopPeriods,
 	type SessionHighlight,
-	type SessionTotalMetric
+	type SessionStatsData
 } from '@/app/models/session-highlights';
-import type { TopMetricsFilterParams, TopPeriodsResult } from '@/app/models/db';
+import type {
+	DaySpeciesMetricRow,
+	TopMetricsFilterParams
+} from '@/app/models/db';
+
+// The stats blob only changes when new data is imported, so cache it
+// per group rather than re-scanning Encounters on every session page view
+const SESSION_STATS_CACHE_TTL_MS = 60 * 60 * 1000;
+const sessionStatsCache = new Map<
+	number,
+	{ expiresAt: number; stats: SessionStatsData }
+>();
+
+async function fetchSessionStats(
+	viewedGroupId: number
+): Promise<SessionStatsData> {
+	const cached = sessionStatsCache.get(viewedGroupId);
+	if (cached && cached.expiresAt > Date.now()) {
+		return cached.stats;
+	}
+	const supabase = await getAuthenticatedSupabaseClient();
+	const [daySpeciesCounts, sessionRows] = await Promise.all([
+		supabase
+			.rpc('metrics_by_period_and_species', {
+				temporal_unit: 'day',
+				metric_name: 'encounters',
+				filters: {
+					ringing_group_filter: viewedGroupId
+				} as TopMetricsFilterParams
+			})
+			.then(catchSupabaseErrors) as Promise<DaySpeciesMetricRow[] | null>,
+		supabase
+			.from('Sessions')
+			.select('visit_date')
+			.eq('ringing_group_id', viewedGroupId)
+			.then(catchSupabaseErrors) as Promise<{ visit_date: string }[] | null>
+	]);
+	const stats: SessionStatsData = {
+		daySpeciesCounts: daySpeciesCounts ?? [],
+		sessionDates: (sessionRows ?? []).map((row) => row.visit_date)
+	};
+	sessionStatsCache.set(viewedGroupId, {
+		expiresAt: Date.now() + SESSION_STATS_CACHE_TTL_MS,
+		stats
+	});
+	return stats;
+}
 
 export async function fetchSessionHighlights({
 	date,
@@ -19,29 +62,6 @@ export async function fetchSessionHighlights({
 	date: string;
 	viewedGroupId: number;
 }): Promise<SessionHighlight[]> {
-	const supabase = await getAuthenticatedSupabaseClient();
-	const scopeFilters = getScopeFilters(new Date(date), viewedGroupId);
-	const metricScopeCombinations = SESSION_TOTAL_METRICS.flatMap((metric) =>
-		scopeFilters.map((scopeFilter) => ({ metric, ...scopeFilter }))
-	);
-	const scopedResults = await Promise.all(
-		metricScopeCombinations.map(async ({ metric, scope, filters }) => {
-			const rows = (await supabase
-				.rpc('top_metrics_by_period', {
-					temporal_unit: 'day',
-					metric_name: metric,
-					result_limit: 2,
-					filters: filters as TopMetricsFilterParams
-				})
-				.then(catchSupabaseErrors)) as TopPeriodsResult[] | null;
-			return { metric, scope, rows: rows ?? [] };
-		})
-	);
-	const resultsByMetric = {} as Record<SessionTotalMetric, ScopedTopPeriods[]>;
-	for (const metric of SESSION_TOTAL_METRICS) {
-		resultsByMetric[metric] = scopedResults.filter(
-			(result) => result.metric === metric
-		);
-	}
-	return sortHighlights(deriveSessionTotalRecords({ date, resultsByMetric }));
+	const stats = await fetchSessionStats(viewedGroupId);
+	return sortHighlights(deriveSessionTotalRecords({ date, stats }));
 }

--- a/app/components/SessionHighlights.tsx
+++ b/app/components/SessionHighlights.tsx
@@ -1,0 +1,54 @@
+'use client';
+import { useState, useEffect } from 'react';
+import {
+	BoxyList,
+	SecondaryHeading
+} from '@/app/components/shared/DesignSystem';
+import { fetchSessionHighlights } from '@/app/actions/session-highlights';
+import {
+	buildHighlightSentence,
+	type SessionHighlight
+} from '@/app/models/session-highlights';
+
+export function SessionHighlights({
+	date,
+	viewedGroupId
+}: {
+	date: string;
+	viewedGroupId: number;
+}) {
+	const [highlights, setHighlights] = useState<SessionHighlight[]>([]);
+	const [isLoaded, setIsLoaded] = useState(false);
+	useEffect(() => {
+		fetchSessionHighlights({ date, viewedGroupId })
+			.then(setHighlights)
+			.catch((error) => {
+				console.error('Failed to fetch session highlights', {
+					date,
+					viewedGroupId,
+					error
+				});
+				setHighlights([]);
+			})
+			.then(() => setIsLoaded(true));
+	}, [date, viewedGroupId]);
+	if (!isLoaded) {
+		return (
+			<div className="flex items-center justify-center">
+				<div className="loading loading-spinner loading-xl"></div>
+			</div>
+		);
+	}
+	if (highlights.length === 0) return null;
+	return (
+		<section data-testid="session-highlights">
+			<SecondaryHeading>Highlights</SecondaryHeading>
+			<BoxyList>
+				{highlights.map((highlight) => {
+					const sentence = buildHighlightSentence(highlight);
+					return <li key={sentence}>{sentence}</li>;
+				})}
+			</BoxyList>
+		</section>
+	);
+}

--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { SessionHighlights } from '../SessionHighlights';
+import type { SessionHighlight } from '@/app/models/session-highlights';
+
+vi.mock('@/app/actions/session-highlights', () => ({
+	fetchSessionHighlights: vi.fn()
+}));
+
+const mockHighlights: SessionHighlight[] = [
+	{
+		type: 'session-total-record',
+		metric: 'encounters',
+		scope: 'all-time',
+		value: 74,
+		seasonName: 'autumn',
+		year: 2024
+	},
+	{
+		type: 'session-total-record',
+		metric: 'species',
+		scope: 'this-season',
+		value: 18,
+		seasonName: 'autumn',
+		year: 2024
+	}
+];
+
+describe('SessionHighlights', () => {
+	afterEach(() => {
+		cleanup();
+		vi.restoreAllMocks();
+	});
+
+	beforeEach(async () => {
+		const { fetchSessionHighlights } =
+			await import('@/app/actions/session-highlights');
+		vi.mocked(fetchSessionHighlights).mockResolvedValue(mockHighlights);
+	});
+
+	it('renders a loading spinner before data loads', async () => {
+		const { fetchSessionHighlights } =
+			await import('@/app/actions/session-highlights');
+		let resolveData!: (v: SessionHighlight[]) => void;
+		vi.mocked(fetchSessionHighlights).mockReturnValue(
+			new Promise((resolve) => {
+				resolveData = resolve;
+			})
+		);
+		render(<SessionHighlights date="2024-09-15" viewedGroupId={1} />);
+		expect(document.querySelector('.loading')).not.toBeNull();
+		resolveData(mockHighlights);
+	});
+
+	it('renders a Highlights heading and one item per highlight', async () => {
+		render(<SessionHighlights date="2024-09-15" viewedGroupId={1} />);
+		await waitFor(() => {
+			expect(screen.getByRole('heading', { name: 'Highlights' })).toBeDefined();
+		});
+		const items = screen
+			.getByTestId('session-highlights')
+			.querySelectorAll('li');
+		expect(items.length).toBe(2);
+		expect(items[0].textContent).toBe('Busiest session ever — 74 birds');
+		expect(items[1].textContent).toBe(
+			'Most varied session this autumn — 18 species'
+		);
+	});
+
+	it('renders nothing when there are no highlights', async () => {
+		const { fetchSessionHighlights } =
+			await import('@/app/actions/session-highlights');
+		vi.mocked(fetchSessionHighlights).mockResolvedValue([]);
+		const { container } = render(
+			<SessionHighlights date="2024-09-15" viewedGroupId={1} />
+		);
+		await waitFor(() => {
+			expect(document.querySelector('.loading')).toBeNull();
+		});
+		expect(container.innerHTML).toBe('');
+	});
+
+	it('renders nothing when the action rejects', async () => {
+		const consoleErrorSpy = vi
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
+		const { fetchSessionHighlights } =
+			await import('@/app/actions/session-highlights');
+		vi.mocked(fetchSessionHighlights).mockRejectedValue(
+			new Error('action failed')
+		);
+		const { container } = render(
+			<SessionHighlights date="2024-09-15" viewedGroupId={1} />
+		);
+		await waitFor(() => {
+			expect(document.querySelector('.loading')).toBeNull();
+		});
+		expect(container.innerHTML).toBe('');
+		expect(consoleErrorSpy).toHaveBeenCalled();
+	});
+});

--- a/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
@@ -10,6 +10,19 @@ vi.mock('@/lib/group-auth', () => ({
 	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
 }));
 
+vi.mock('@/app/actions/session-highlights', () => ({
+	fetchSessionHighlights: vi.fn().mockResolvedValue([
+		{
+			type: 'session-total-record',
+			metric: 'encounters',
+			scope: 'all-time',
+			value: 3,
+			seasonName: 'winter',
+			year: 2024
+		}
+	])
+}));
+
 const TEST_DATE = '2024-03-15';
 const TEST_GROUP_ID = '1';
 
@@ -134,5 +147,12 @@ describe('session detail page', () => {
 		const table = await screen.findByTestId('session-table');
 		const rows = table.querySelectorAll('tbody tr');
 		expect(rows.length).toBe(2);
+	});
+
+	it('renders the highlights section on the date-level page', async () => {
+		render(await renderPage());
+		const highlights = await screen.findByTestId('session-highlights');
+		expect(highlights.textContent).toContain('Highlights');
+		expect(highlights.textContent).toContain('Busiest session ever — 3 birds');
 	});
 });

--- a/app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import Page from '../page';
+
+const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
+	mockGetAuthenticatedSupabaseClient: vi.fn()
+}));
+
+vi.mock('@/lib/group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+vi.mock('@/app/actions/session-highlights', () => ({
+	fetchSessionHighlights: vi.fn().mockResolvedValue([
+		{
+			type: 'session-total-record',
+			metric: 'encounters',
+			scope: 'all-time',
+			value: 1,
+			seasonName: 'winter',
+			year: 2024
+		}
+	])
+}));
+
+const TEST_DATE = '2024-03-15';
+const TEST_GROUP_ID = '1';
+const TEST_LOCATION_ID = '10';
+
+const mockSessions = [
+	{
+		id: 1,
+		location_id: 10,
+		location: { id: 10, location_name: 'Test Reserve', ringing_group_id: 1 }
+	}
+];
+
+const mockEncounters = [
+	{
+		id: 1,
+		session_id: 1,
+		age_code: 4,
+		breeding_condition: null,
+		capture_time: '08:00:00',
+		moult_code: null,
+		record_type: 'N',
+		ringing_group_id: 1,
+		sex: 'M',
+		sexing_method: null,
+		weight: 18.5,
+		wing_length: 75,
+		bird: { ring_no: 'ABC001', species: { id: 1, species_name: 'Robin' } }
+	}
+];
+
+function makeSessionClient() {
+	const makeChain = (data: unknown) => ({
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		in: vi.fn().mockReturnThis(),
+		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+			Promise.resolve({ data, error: null }).then(resolve)
+	});
+	return {
+		from: vi
+			.fn()
+			.mockReturnValueOnce(makeChain(mockSessions))
+			.mockReturnValueOnce(makeChain(mockEncounters))
+	};
+}
+
+function renderPage() {
+	return Page({
+		params: Promise.resolve({
+			groupId: TEST_GROUP_ID,
+			date: TEST_DATE,
+			locationId: TEST_LOCATION_ID
+		})
+	});
+}
+
+describe('session site page', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	beforeEach(() => {
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(makeSessionClient());
+	});
+
+	it('renders date as heading', async () => {
+		render(await renderPage());
+		const heading = await screen.findByRole('heading', { level: 1 });
+		expect(heading.textContent).toContain('15th March 2024');
+	});
+
+	it('does not render highlights on the location-filtered page', async () => {
+		render(await renderPage());
+		await screen.findByTestId('session-stats');
+		const { fetchSessionHighlights } =
+			await import('@/app/actions/session-highlights');
+		expect(screen.queryByTestId('session-highlights')).toBeNull();
+		expect(vi.mocked(fetchSessionHighlights)).not.toHaveBeenCalled();
+	});
+});

--- a/app/group/[groupId]/session/_shared.tsx
+++ b/app/group/[groupId]/session/_shared.tsx
@@ -17,6 +17,7 @@ import { format as formatDate } from 'date-fns';
 import { Fragment } from 'react';
 import { calculateSessionChronology } from '@/app/models/session-chronology';
 import { formatMinutesForDisplay } from '@/lib/postgres-interval';
+import { SessionHighlights } from '@/app/components/SessionHighlights';
 
 export type PageParams = {
 	viewedGroupId: number;
@@ -210,6 +211,9 @@ export function SessionSummary({
 					`Net rounds: ${chronology.netRounds.length}`
 				]}
 			/>
+			{locationId ? null : (
+				<SessionHighlights date={date} viewedGroupId={viewedGroupId} />
+			)}
 			<SessionTabs speciesList={speciesList} netRounds={chronology.netRounds} />
 		</PageWrapper>
 	);

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -1,211 +1,201 @@
 import { describe, it, expect } from 'vitest';
 import {
-	RECORD_SCOPES,
 	buildHighlightSentence,
 	deriveSessionTotalRecords,
-	getScopeFilters,
-	type RecordScope,
-	type ScopedTopPeriods,
-	type SessionTotalMetric,
+	type SessionStatsData,
 	type SessionTotalRecordHighlight
 } from '../session-highlights';
-import type { TopPeriodsResult } from '@/app/models/db';
+import type { DaySpeciesMetricRow } from '@/app/models/db';
 
 const SESSION_DATE = '2024-09-15'; // autumn
-const GROUP_ID = 1;
 
-function findScopeFilters(scope: RecordScope) {
-	const scopeFilters = getScopeFilters(new Date(SESSION_DATE), GROUP_ID);
-	return scopeFilters.find((scopeFilter) => scopeFilter.scope === scope)!
-		.filters;
-}
+// Prior days used across tests, chosen for their scope membership
+// relative to SESSION_DATE:
+const PRIOR_AUTUMN_OTHER_YEAR = '2021-09-10'; // any-season only (3+ years ago)
+const PRIOR_SPRING_OTHER_YEAR = '2022-05-01'; // all-time only
+const PRIOR_SPRING_THIS_YEAR = '2024-05-01'; // this-year (and all-time)
+const PRIOR_THIS_SEASON = '2024-08-20'; // this-season (and all narrower)
+const LATER_DAY = '2024-10-01';
 
-describe('getScopeFilters', () => {
-	it('builds all-time filters with only ringing_group_filter', () => {
-		expect(findScopeFilters('all-time')).toEqual({
-			ringing_group_filter: GROUP_ID
-		});
-	});
-
-	it('builds this-year filters with year_filter from the session date', () => {
-		expect(findScopeFilters('this-year')).toEqual({
-			ringing_group_filter: GROUP_ID,
-			year_filter: 2024
-		});
-	});
-
-	it('builds any-season filters with numeric months_filter', () => {
-		expect(findScopeFilters('any-season')).toEqual({
-			ringing_group_filter: GROUP_ID,
-			months_filter: [8, 9, 10]
-		});
-	});
-
-	it('builds this-season filters with YYYY-MM exact_months_filter', () => {
-		expect(findScopeFilters('this-season')).toEqual({
-			ringing_group_filter: GROUP_ID,
-			exact_months_filter: ['2024-08', '2024-09', '2024-10']
-		});
-	});
-});
-
-function scopedRows(
-	rowsByScope: Partial<Record<RecordScope, TopPeriodsResult[]>>
-): ScopedTopPeriods[] {
-	return RECORD_SCOPES.map((scope) => ({
-		scope,
-		rows: rowsByScope[scope] ?? []
+function dayRows(
+	date: string,
+	speciesCounts: Record<string, number>
+): DaySpeciesMetricRow[] {
+	return Object.entries(speciesCounts).map(([species_name, metric_value]) => ({
+		species_name,
+		visit_date: date,
+		metric_value
 	}));
 }
 
-function deriveForMetrics({
-	encounters = {},
-	species = {}
-}: Partial<
-	Record<SessionTotalMetric, Partial<Record<RecordScope, TopPeriodsResult[]>>>
->) {
+function statsFor(rows: DaySpeciesMetricRow[]): SessionStatsData {
+	return {
+		daySpeciesCounts: rows,
+		sessionDates: [...new Set(rows.map((row) => row.visit_date))]
+	};
+}
+
+function derive(rows: DaySpeciesMetricRow[]) {
 	return deriveSessionTotalRecords({
 		date: SESSION_DATE,
-		resultsByMetric: {
-			encounters: scopedRows(encounters),
-			species: scopedRows(species)
-		}
+		stats: statsFor(rows)
 	});
 }
 
-const recordRows = (value: number): TopPeriodsResult[] => [
-	{ visit_date: SESSION_DATE, metric_value: value },
-	{ visit_date: '2022-05-01', metric_value: value - 10 }
-];
-
 describe('deriveSessionTotalRecords', () => {
-	it('returns a record when the top visit_date equals the session date', () => {
-		const highlights = deriveForMetrics({
-			encounters: { 'all-time': recordRows(74) }
-		});
-		expect(highlights).toEqual([
-			{
-				type: 'session-total-record',
-				metric: 'encounters',
-				scope: 'all-time',
-				value: 74,
-				seasonName: 'autumn',
-				year: 2024
-			}
+	it('returns a busiest record when the session total beats all prior days in scope', () => {
+		const highlights = derive([
+			...dayRows(SESSION_DATE, { Robin: 40, Chiffchaff: 34 }),
+			...dayRows(PRIOR_SPRING_OTHER_YEAR, {
+				Robin: 20,
+				Chiffchaff: 20,
+				Wren: 20
+			})
 		]);
+		expect(highlights).toContainEqual({
+			type: 'session-total-record',
+			metric: 'encounters',
+			scope: 'all-time',
+			value: 74,
+			seasonName: 'autumn',
+			year: 2024
+		});
+		// three species on the prior day vs two today — no variety record
+		expect(
+			highlights.filter((highlight) => highlight.metric === 'species')
+		).toEqual([]);
 	});
 
-	it('returns no record when the top visit_date differs', () => {
-		const highlights = deriveForMetrics({
-			encounters: {
-				'all-time': [
-					{ visit_date: '2022-05-01', metric_value: 80 },
-					{ visit_date: SESSION_DATE, metric_value: 74 }
-				]
-			}
-		});
-		expect(highlights).toEqual([]);
+	it('returns a most-varied record from per-day species counts', () => {
+		const highlights = derive([
+			...dayRows(SESSION_DATE, { Robin: 1, Chiffchaff: 1, Wren: 1 }),
+			...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 30, Chiffchaff: 30 })
+		]);
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				metric: 'species',
+				scope: 'all-time',
+				value: 3
+			})
+		);
+		expect(
+			highlights.filter((highlight) => highlight.metric === 'encounters')
+		).toEqual([]);
 	});
 
-	it('returns no record for empty RPC results', () => {
-		const highlights = deriveForMetrics({});
-		expect(highlights).toEqual([]);
-	});
-
-	it('reports only all-time when all four scopes are records', () => {
-		const highlights = deriveForMetrics({
-			encounters: {
-				'all-time': recordRows(74),
-				'any-season': recordRows(74),
-				'this-year': recordRows(74),
-				'this-season': recordRows(74)
-			}
-		});
-		expect(highlights.length).toBe(1);
-		expect(highlights[0].scope).toBe('all-time');
-	});
-
-	it('prefers any-season over this-year and this-year over this-season', () => {
-		const anySeasonAndNarrower = deriveForMetrics({
-			encounters: {
-				'any-season': recordRows(74),
-				'this-year': recordRows(74),
-				'this-season': recordRows(74)
-			}
-		});
-		expect(anySeasonAndNarrower.length).toBe(1);
-		expect(anySeasonAndNarrower[0].scope).toBe('any-season');
-
-		const thisYearAndNarrower = deriveForMetrics({
-			encounters: {
-				'this-year': recordRows(74),
-				'this-season': recordRows(74)
-			}
-		});
-		expect(thisYearAndNarrower.length).toBe(1);
-		expect(thisYearAndNarrower[0].scope).toBe('this-year');
-	});
-
-	it('derives encounters and species records independently', () => {
-		const highlights = deriveForMetrics({
-			encounters: { 'all-time': recordRows(74) },
-			species: { 'this-season': recordRows(18) }
-		});
-		expect(highlights).toEqual([
+	it('ignores sessions after the session date', () => {
+		const highlights = derive([
+			...dayRows(SESSION_DATE, { Robin: 74 }),
+			...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 60 }),
+			...dayRows(LATER_DAY, { Robin: 200, Chiffchaff: 200 })
+		]);
+		expect(highlights).toContainEqual(
 			expect.objectContaining({
 				metric: 'encounters',
 				scope: 'all-time',
 				value: 74
-			}),
-			expect.objectContaining({
-				metric: 'species',
-				scope: 'this-season',
-				value: 18
 			})
-		]);
+		);
 	});
 
-	it('reports an all-time tie as a for-N-years record when the tied date is over a year old', () => {
-		const highlights = deriveForMetrics({
-			encounters: {
-				'all-time': [
-					{ visit_date: SESSION_DATE, metric_value: 74 },
-					{ visit_date: '2021-09-10', metric_value: 74 }
-				]
-			}
-		});
-		expect(highlights).toEqual([
+	it('reports only all-time when all scopes are records', () => {
+		const highlights = derive([
+			...dayRows(SESSION_DATE, { Robin: 74 }),
+			...dayRows(PRIOR_AUTUMN_OTHER_YEAR, { Robin: 60 }),
+			...dayRows(PRIOR_SPRING_THIS_YEAR, { Robin: 50 }),
+			...dayRows(PRIOR_THIS_SEASON, { Robin: 40 })
+		]);
+		const encounterRecords = highlights.filter(
+			(highlight) => highlight.metric === 'encounters'
+		);
+		expect(encounterRecords.length).toBe(1);
+		expect(encounterRecords[0].scope).toBe('all-time');
+	});
+
+	it('prefers any-season over this-year and this-year over this-season', () => {
+		// all-time beaten by a big spring day, but best autumn day is beaten
+		const anySeason = derive([
+			...dayRows(SESSION_DATE, { Robin: 74 }),
+			...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 100 }),
+			...dayRows(PRIOR_AUTUMN_OTHER_YEAR, { Robin: 60 })
+		]);
+		expect(
+			anySeason.find((highlight) => highlight.metric === 'encounters')?.scope
+		).toBe('any-season');
+
+		// all-time and any-season beaten by a big autumn day in another year,
+		// but this year's best is beaten
+		const thisYear = derive([
+			...dayRows(SESSION_DATE, { Robin: 74 }),
+			...dayRows(PRIOR_AUTUMN_OTHER_YEAR, { Robin: 100 }),
+			...dayRows(PRIOR_SPRING_THIS_YEAR, { Robin: 60 }),
+			...dayRows(PRIOR_THIS_SEASON, { Robin: 50 })
+		]);
+		expect(
+			thisYear.find((highlight) => highlight.metric === 'encounters')?.scope
+		).toBe('this-year');
+	});
+
+	it('reports an all-time tie as for-N-years when the tied day is over a year old', () => {
+		const highlights = derive([
+			...dayRows(SESSION_DATE, { Robin: 74 }),
+			...dayRows(PRIOR_AUTUMN_OTHER_YEAR, { Robin: 74 })
+		]);
+		expect(highlights).toContainEqual(
 			expect.objectContaining({
 				metric: 'encounters',
 				scope: 'all-time',
 				value: 74,
 				recordEqualledYearsAgo: 3
 			})
+		);
+	});
+
+	it('ignores ties under a year old', () => {
+		const highlights = derive([
+			...dayRows(SESSION_DATE, { Robin: 74 }),
+			...dayRows(PRIOR_SPRING_THIS_YEAR, { Robin: 74 })
 		]);
+		expect(
+			highlights.filter((highlight) => highlight.metric === 'encounters')
+		).toEqual([]);
 	});
 
-	it('ignores an all-time tie under a year old', () => {
-		const highlights = deriveForMetrics({
-			encounters: {
-				'all-time': [
-					{ visit_date: SESSION_DATE, metric_value: 74 },
-					{ visit_date: '2024-05-01', metric_value: 74 }
-				]
-			}
-		});
-		expect(highlights).toEqual([]);
+	it('ignores ties in narrower scopes', () => {
+		// all-time beaten, any-season tied — the tie is not reportable there
+		const highlights = derive([
+			...dayRows(SESSION_DATE, { Robin: 74 }),
+			...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 100 }),
+			...dayRows(PRIOR_AUTUMN_OTHER_YEAR, { Robin: 74 })
+		]);
+		expect(
+			highlights.filter((highlight) => highlight.metric === 'encounters')
+		).toEqual([]);
 	});
 
-	it('ignores ties in non-all-time scopes', () => {
-		const highlights = deriveForMetrics({
-			encounters: {
-				'any-season': [
-					{ visit_date: SESSION_DATE, metric_value: 74 },
-					{ visit_date: '2021-09-10', metric_value: 74 }
-				]
-			}
+	it('suppresses records when no prior session exists in scope', () => {
+		// the group's first-ever session would otherwise be a record for everything
+		expect(derive(dayRows(SESSION_DATE, { Robin: 74, Chiffchaff: 3 }))).toEqual(
+			[]
+		);
+	});
+
+	it('counts zero-encounter sessions as prior sessions in scope', () => {
+		const stats: SessionStatsData = {
+			daySpeciesCounts: dayRows(SESSION_DATE, { Robin: 74 }),
+			sessionDates: [PRIOR_SPRING_OTHER_YEAR, SESSION_DATE]
+		};
+		const highlights = deriveSessionTotalRecords({
+			date: SESSION_DATE,
+			stats
 		});
-		expect(highlights).toEqual([]);
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				metric: 'encounters',
+				scope: 'all-time',
+				value: 74
+			})
+		);
 	});
 });
 

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect } from 'vitest';
+import {
+	RECORD_SCOPES,
+	buildHighlightSentence,
+	deriveSessionTotalRecords,
+	getScopeFilters,
+	type RecordScope,
+	type ScopedTopPeriods,
+	type SessionTotalMetric,
+	type SessionTotalRecordHighlight
+} from '../session-highlights';
+import type { TopPeriodsResult } from '@/app/models/db';
+
+const SESSION_DATE = '2024-09-15'; // autumn
+const GROUP_ID = 1;
+
+function findScopeFilters(scope: RecordScope) {
+	const scopeFilters = getScopeFilters(new Date(SESSION_DATE), GROUP_ID);
+	return scopeFilters.find((scopeFilter) => scopeFilter.scope === scope)!
+		.filters;
+}
+
+describe('getScopeFilters', () => {
+	it('builds all-time filters with only ringing_group_filter', () => {
+		expect(findScopeFilters('all-time')).toEqual({
+			ringing_group_filter: GROUP_ID
+		});
+	});
+
+	it('builds this-year filters with year_filter from the session date', () => {
+		expect(findScopeFilters('this-year')).toEqual({
+			ringing_group_filter: GROUP_ID,
+			year_filter: 2024
+		});
+	});
+
+	it('builds any-season filters with numeric months_filter', () => {
+		expect(findScopeFilters('any-season')).toEqual({
+			ringing_group_filter: GROUP_ID,
+			months_filter: [8, 9, 10]
+		});
+	});
+
+	it('builds this-season filters with YYYY-MM exact_months_filter', () => {
+		expect(findScopeFilters('this-season')).toEqual({
+			ringing_group_filter: GROUP_ID,
+			exact_months_filter: ['2024-08', '2024-09', '2024-10']
+		});
+	});
+});
+
+function scopedRows(
+	rowsByScope: Partial<Record<RecordScope, TopPeriodsResult[]>>
+): ScopedTopPeriods[] {
+	return RECORD_SCOPES.map((scope) => ({
+		scope,
+		rows: rowsByScope[scope] ?? []
+	}));
+}
+
+function deriveForMetrics({
+	encounters = {},
+	species = {}
+}: Partial<
+	Record<SessionTotalMetric, Partial<Record<RecordScope, TopPeriodsResult[]>>>
+>) {
+	return deriveSessionTotalRecords({
+		date: SESSION_DATE,
+		resultsByMetric: {
+			encounters: scopedRows(encounters),
+			species: scopedRows(species)
+		}
+	});
+}
+
+const recordRows = (value: number): TopPeriodsResult[] => [
+	{ visit_date: SESSION_DATE, metric_value: value },
+	{ visit_date: '2022-05-01', metric_value: value - 10 }
+];
+
+describe('deriveSessionTotalRecords', () => {
+	it('returns a record when the top visit_date equals the session date', () => {
+		const highlights = deriveForMetrics({
+			encounters: { 'all-time': recordRows(74) }
+		});
+		expect(highlights).toEqual([
+			{
+				type: 'session-total-record',
+				metric: 'encounters',
+				scope: 'all-time',
+				value: 74,
+				seasonName: 'autumn',
+				year: 2024
+			}
+		]);
+	});
+
+	it('returns no record when the top visit_date differs', () => {
+		const highlights = deriveForMetrics({
+			encounters: {
+				'all-time': [
+					{ visit_date: '2022-05-01', metric_value: 80 },
+					{ visit_date: SESSION_DATE, metric_value: 74 }
+				]
+			}
+		});
+		expect(highlights).toEqual([]);
+	});
+
+	it('returns no record for empty RPC results', () => {
+		const highlights = deriveForMetrics({});
+		expect(highlights).toEqual([]);
+	});
+
+	it('reports only all-time when all four scopes are records', () => {
+		const highlights = deriveForMetrics({
+			encounters: {
+				'all-time': recordRows(74),
+				'any-season': recordRows(74),
+				'this-year': recordRows(74),
+				'this-season': recordRows(74)
+			}
+		});
+		expect(highlights.length).toBe(1);
+		expect(highlights[0].scope).toBe('all-time');
+	});
+
+	it('prefers any-season over this-year and this-year over this-season', () => {
+		const anySeasonAndNarrower = deriveForMetrics({
+			encounters: {
+				'any-season': recordRows(74),
+				'this-year': recordRows(74),
+				'this-season': recordRows(74)
+			}
+		});
+		expect(anySeasonAndNarrower.length).toBe(1);
+		expect(anySeasonAndNarrower[0].scope).toBe('any-season');
+
+		const thisYearAndNarrower = deriveForMetrics({
+			encounters: {
+				'this-year': recordRows(74),
+				'this-season': recordRows(74)
+			}
+		});
+		expect(thisYearAndNarrower.length).toBe(1);
+		expect(thisYearAndNarrower[0].scope).toBe('this-year');
+	});
+
+	it('derives encounters and species records independently', () => {
+		const highlights = deriveForMetrics({
+			encounters: { 'all-time': recordRows(74) },
+			species: { 'this-season': recordRows(18) }
+		});
+		expect(highlights).toEqual([
+			expect.objectContaining({
+				metric: 'encounters',
+				scope: 'all-time',
+				value: 74
+			}),
+			expect.objectContaining({
+				metric: 'species',
+				scope: 'this-season',
+				value: 18
+			})
+		]);
+	});
+
+	it('reports an all-time tie as a for-N-years record when the tied date is over a year old', () => {
+		const highlights = deriveForMetrics({
+			encounters: {
+				'all-time': [
+					{ visit_date: SESSION_DATE, metric_value: 74 },
+					{ visit_date: '2021-09-10', metric_value: 74 }
+				]
+			}
+		});
+		expect(highlights).toEqual([
+			expect.objectContaining({
+				metric: 'encounters',
+				scope: 'all-time',
+				value: 74,
+				recordEqualledYearsAgo: 3
+			})
+		]);
+	});
+
+	it('ignores an all-time tie under a year old', () => {
+		const highlights = deriveForMetrics({
+			encounters: {
+				'all-time': [
+					{ visit_date: SESSION_DATE, metric_value: 74 },
+					{ visit_date: '2024-05-01', metric_value: 74 }
+				]
+			}
+		});
+		expect(highlights).toEqual([]);
+	});
+
+	it('ignores ties in non-all-time scopes', () => {
+		const highlights = deriveForMetrics({
+			encounters: {
+				'any-season': [
+					{ visit_date: SESSION_DATE, metric_value: 74 },
+					{ visit_date: '2021-09-10', metric_value: 74 }
+				]
+			}
+		});
+		expect(highlights).toEqual([]);
+	});
+});
+
+function makeHighlight(
+	overrides: Partial<SessionTotalRecordHighlight>
+): SessionTotalRecordHighlight {
+	return {
+		type: 'session-total-record',
+		metric: 'encounters',
+		scope: 'all-time',
+		value: 74,
+		seasonName: 'autumn',
+		year: 2024,
+		...overrides
+	};
+}
+
+describe('buildHighlightSentence — session-total-record', () => {
+	it('renders all-time busiest copy', () => {
+		expect(buildHighlightSentence(makeHighlight({}))).toBe(
+			'Busiest session ever — 74 birds'
+		);
+	});
+
+	it('renders any-season busiest copy', () => {
+		expect(buildHighlightSentence(makeHighlight({ scope: 'any-season' }))).toBe(
+			'Busiest autumn session ever — 74 birds'
+		);
+	});
+
+	it('renders this-year busiest copy', () => {
+		expect(buildHighlightSentence(makeHighlight({ scope: 'this-year' }))).toBe(
+			'Busiest session of 2024 — 74 birds'
+		);
+	});
+
+	it('renders this-season busiest copy', () => {
+		expect(
+			buildHighlightSentence(makeHighlight({ scope: 'this-season' }))
+		).toBe('Busiest session this autumn — 74 birds');
+	});
+
+	it('renders most-varied copy for the species metric', () => {
+		expect(
+			buildHighlightSentence(makeHighlight({ metric: 'species', value: 18 }))
+		).toBe('Most varied session ever — 18 species');
+	});
+
+	it('renders busiest-for-N-years copy for an all-time tie', () => {
+		expect(
+			buildHighlightSentence(makeHighlight({ recordEqualledYearsAgo: 3 }))
+		).toBe('Busiest session for 3 years — 74 birds');
+	});
+});

--- a/app/models/db.ts
+++ b/app/models/db.ts
@@ -19,6 +19,8 @@ export type TopSpeciesArgs =
 
 export type TopMetricsFilterParams =
 	Database['public']['CompositeTypes']['top_metrics_filter_params'];
+export type DaySpeciesMetricRow =
+	Database['public']['Functions']['metrics_by_period_and_species']['Returns'][number];
 export type AggregateStatsRow =
 	Database['public']['Functions']['aggregate_stats']['Returns'][number];
 

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -1,0 +1,166 @@
+import { differenceInYears } from 'date-fns';
+import { getSeasonMonths, getSeasonName } from '@/app/models/seasons';
+import type { TopMetricsFilterParams, TopPeriodsResult } from '@/app/models/db';
+
+export const SESSION_TOTAL_METRICS = ['encounters', 'species'] as const;
+export type SessionTotalMetric = (typeof SESSION_TOTAL_METRICS)[number];
+
+// Broadest first — a record is reported at the broadest scope it holds
+export const RECORD_SCOPES = [
+	'all-time',
+	'any-season',
+	'this-year',
+	'this-season'
+] as const;
+export type RecordScope = (typeof RECORD_SCOPES)[number];
+
+export type ScopeFilters = {
+	scope: RecordScope;
+	filters: Partial<TopMetricsFilterParams>;
+};
+
+export type SessionTotalRecordHighlight = {
+	type: 'session-total-record';
+	metric: SessionTotalMetric;
+	scope: RecordScope;
+	value: number;
+	seasonName: string;
+	year: number;
+	// Set only for all-time ties where the equalled record is over a year old
+	recordEqualledYearsAgo?: number;
+};
+
+export type SessionHighlight = SessionTotalRecordHighlight;
+
+export type ScopedTopPeriods = {
+	scope: RecordScope;
+	rows: TopPeriodsResult[];
+};
+
+export function getScopeFilters(
+	sessionDate: Date,
+	ringingGroupId: number
+): ScopeFilters[] {
+	return [
+		{
+			scope: 'all-time',
+			filters: { ringing_group_filter: ringingGroupId }
+		},
+		{
+			scope: 'any-season',
+			filters: {
+				ringing_group_filter: ringingGroupId,
+				months_filter: getSeasonMonths(sessionDate, false) as number[]
+			}
+		},
+		{
+			scope: 'this-year',
+			filters: {
+				ringing_group_filter: ringingGroupId,
+				year_filter: sessionDate.getFullYear()
+			}
+		},
+		{
+			scope: 'this-season',
+			filters: {
+				ringing_group_filter: ringingGroupId,
+				exact_months_filter: getSeasonMonths(sessionDate, true) as string[]
+			}
+		}
+	];
+}
+
+export function deriveSessionTotalRecords({
+	date,
+	resultsByMetric
+}: {
+	date: string;
+	resultsByMetric: Record<SessionTotalMetric, ScopedTopPeriods[]>;
+}): SessionTotalRecordHighlight[] {
+	const sessionDate = new Date(date);
+	const highlights: SessionTotalRecordHighlight[] = [];
+	for (const metric of SESSION_TOTAL_METRICS) {
+		const scopedResults = resultsByMetric[metric] ?? [];
+		for (const scope of RECORD_SCOPES) {
+			const rows =
+				scopedResults.find((result) => result.scope === scope)?.rows ?? [];
+			const [topRow, runnerUpRow] = rows;
+			if (!topRow || topRow.visit_date !== date) continue;
+			const baseHighlight: SessionTotalRecordHighlight = {
+				type: 'session-total-record',
+				metric,
+				scope,
+				value: topRow.metric_value,
+				seasonName: getSeasonName(sessionDate),
+				year: sessionDate.getFullYear()
+			};
+			const isTie = runnerUpRow?.metric_value === topRow.metric_value;
+			if (!isTie) {
+				highlights.push(baseHighlight);
+				break;
+			}
+			if (scope === 'all-time') {
+				const recordEqualledYearsAgo = differenceInYears(
+					sessionDate,
+					new Date(runnerUpRow.visit_date)
+				);
+				if (recordEqualledYearsAgo >= 1) {
+					highlights.push({ ...baseHighlight, recordEqualledYearsAgo });
+					break;
+				}
+			}
+			// unreportable tie at this scope — a narrower scope may still be a strict record
+		}
+	}
+	return highlights;
+}
+
+const HIGHLIGHT_TYPE_PRIORITY: SessionHighlight['type'][] = [
+	'session-total-record'
+];
+
+export function sortHighlights(
+	highlights: SessionHighlight[]
+): SessionHighlight[] {
+	return [...highlights].sort(
+		(a, b) =>
+			HIGHLIGHT_TYPE_PRIORITY.indexOf(a.type) -
+			HIGHLIGHT_TYPE_PRIORITY.indexOf(b.type)
+	);
+}
+
+const SESSION_TOTAL_METRIC_COPY: Record<
+	SessionTotalMetric,
+	{ descriptor: string; unit: string }
+> = {
+	encounters: { descriptor: 'Busiest', unit: 'birds' },
+	species: { descriptor: 'Most varied', unit: 'species' }
+};
+
+function buildSessionTotalRecordSentence(
+	highlight: SessionTotalRecordHighlight
+): string {
+	const { descriptor, unit } = SESSION_TOTAL_METRIC_COPY[highlight.metric];
+	const valueCopy = `${highlight.value} ${unit}`;
+	if (highlight.recordEqualledYearsAgo !== undefined) {
+		const yearsCopy = `${highlight.recordEqualledYearsAgo} ${highlight.recordEqualledYearsAgo === 1 ? 'year' : 'years'}`;
+		return `${descriptor} session for ${yearsCopy} — ${valueCopy}`;
+	}
+	switch (highlight.scope) {
+		case 'all-time':
+			return `${descriptor} session ever — ${valueCopy}`;
+		case 'any-season':
+			return `${descriptor} ${highlight.seasonName} session ever — ${valueCopy}`;
+		case 'this-year':
+			return `${descriptor} session of ${highlight.year} — ${valueCopy}`;
+		case 'this-season':
+			return `${descriptor} session this ${highlight.seasonName} — ${valueCopy}`;
+	}
+}
+
+export function buildHighlightSentence(highlight: SessionHighlight): string {
+	switch (highlight.type) {
+		case 'session-total-record':
+			return buildSessionTotalRecordSentence(highlight);
+	}
+}

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -1,6 +1,6 @@
 import { differenceInYears } from 'date-fns';
 import { getSeasonMonths, getSeasonName } from '@/app/models/seasons';
-import type { TopMetricsFilterParams, TopPeriodsResult } from '@/app/models/db';
+import type { DaySpeciesMetricRow } from '@/app/models/db';
 
 export const SESSION_TOTAL_METRICS = ['encounters', 'species'] as const;
 export type SessionTotalMetric = (typeof SESSION_TOTAL_METRICS)[number];
@@ -14,9 +14,12 @@ export const RECORD_SCOPES = [
 ] as const;
 export type RecordScope = (typeof RECORD_SCOPES)[number];
 
-export type ScopeFilters = {
-	scope: RecordScope;
-	filters: Partial<TopMetricsFilterParams>;
+// Everything needed to compare a session against the group's history,
+// fetched once per group: per-day-per-species encounter counts plus the
+// full list of session dates (so zero-encounter sessions still count)
+export type SessionStatsData = {
+	daySpeciesCounts: DaySpeciesMetricRow[];
+	sessionDates: string[];
 };
 
 export type SessionTotalRecordHighlight = {
@@ -32,84 +35,112 @@ export type SessionTotalRecordHighlight = {
 
 export type SessionHighlight = SessionTotalRecordHighlight;
 
-export type ScopedTopPeriods = {
-	scope: RecordScope;
-	rows: TopPeriodsResult[];
+type DayTotals = {
+	date: string;
+	encounters: number;
+	species: number;
 };
 
-export function getScopeFilters(
-	sessionDate: Date,
-	ringingGroupId: number
-): ScopeFilters[] {
-	return [
-		{
-			scope: 'all-time',
-			filters: { ringing_group_filter: ringingGroupId }
-		},
-		{
-			scope: 'any-season',
-			filters: {
-				ringing_group_filter: ringingGroupId,
-				months_filter: getSeasonMonths(sessionDate, false) as number[]
-			}
-		},
-		{
-			scope: 'this-year',
-			filters: {
-				ringing_group_filter: ringingGroupId,
-				year_filter: sessionDate.getFullYear()
-			}
-		},
-		{
-			scope: 'this-season',
-			filters: {
-				ringing_group_filter: ringingGroupId,
-				exact_months_filter: getSeasonMonths(sessionDate, true) as string[]
-			}
+// Highlights describe the session as it would have read on the day, so
+// every comparison only considers data up to and including the session date
+export function buildDayTotals(
+	{ daySpeciesCounts, sessionDates }: SessionStatsData,
+	sessionDate: string
+): DayTotals[] {
+	const totalsByDate = new Map<string, DayTotals>();
+	for (const date of sessionDates) {
+		if (date > sessionDate) continue;
+		totalsByDate.set(date, { date, encounters: 0, species: 0 });
+	}
+	for (const row of daySpeciesCounts) {
+		if (row.visit_date > sessionDate) continue;
+		const dayTotals = totalsByDate.get(row.visit_date) ?? {
+			date: row.visit_date,
+			encounters: 0,
+			species: 0
+		};
+		dayTotals.encounters += row.metric_value;
+		dayTotals.species += 1;
+		totalsByDate.set(row.visit_date, dayTotals);
+	}
+	return [...totalsByDate.values()];
+}
+
+function getScopeMatcher(
+	scope: RecordScope,
+	sessionDate: Date
+): (date: string) => boolean {
+	switch (scope) {
+		case 'all-time':
+			return () => true;
+		case 'any-season': {
+			const seasonMonths = getSeasonMonths(sessionDate, false) as number[];
+			return (date) => seasonMonths.includes(Number(date.slice(5, 7)));
 		}
-	];
+		case 'this-year': {
+			const yearPrefix = `${sessionDate.getFullYear()}-`;
+			return (date) => date.startsWith(yearPrefix);
+		}
+		case 'this-season': {
+			const seasonYearMonths = getSeasonMonths(sessionDate, true) as string[];
+			return (date) => seasonYearMonths.includes(date.slice(0, 7));
+		}
+	}
 }
 
 export function deriveSessionTotalRecords({
 	date,
-	resultsByMetric
+	stats
 }: {
 	date: string;
-	resultsByMetric: Record<SessionTotalMetric, ScopedTopPeriods[]>;
+	stats: SessionStatsData;
 }): SessionTotalRecordHighlight[] {
 	const sessionDate = new Date(date);
+	const dayTotals = buildDayTotals(stats, date);
+	const currentDay = dayTotals.find((day) => day.date === date);
+	if (!currentDay) return [];
+
 	const highlights: SessionTotalRecordHighlight[] = [];
 	for (const metric of SESSION_TOTAL_METRICS) {
-		const scopedResults = resultsByMetric[metric] ?? [];
+		const sessionValue = currentDay[metric];
 		for (const scope of RECORD_SCOPES) {
-			const rows =
-				scopedResults.find((result) => result.scope === scope)?.rows ?? [];
-			const [topRow, runnerUpRow] = rows;
-			if (!topRow || topRow.visit_date !== date) continue;
+			const scopeMatcher = getScopeMatcher(scope, sessionDate);
+			const priorDays = dayTotals.filter(
+				(day) => day.date < date && scopeMatcher(day.date)
+			);
+			// A record is only meaningful against at least one prior session
+			// (otherwise the group's first session is trivially a record)
+			if (priorDays.length === 0) continue;
+			const previousBest = Math.max(...priorDays.map((day) => day[metric]));
 			const baseHighlight: SessionTotalRecordHighlight = {
 				type: 'session-total-record',
 				metric,
 				scope,
-				value: topRow.metric_value,
+				value: sessionValue,
 				seasonName: getSeasonName(sessionDate),
 				year: sessionDate.getFullYear()
 			};
-			const isTie = runnerUpRow?.metric_value === topRow.metric_value;
-			if (!isTie) {
+			if (sessionValue > previousBest) {
 				highlights.push(baseHighlight);
 				break;
 			}
-			if (scope === 'all-time') {
+			if (sessionValue === previousBest && scope === 'all-time') {
+				const mostRecentTieDate = priorDays
+					.filter((day) => day[metric] === previousBest)
+					.map((day) => day.date)
+					.sort()
+					.at(-1)!;
 				const recordEqualledYearsAgo = differenceInYears(
 					sessionDate,
-					new Date(runnerUpRow.visit_date)
+					new Date(mostRecentTieDate)
 				);
 				if (recordEqualledYearsAgo >= 1) {
 					highlights.push({ ...baseHighlight, recordEqualledYearsAgo });
 					break;
 				}
 			}
-			// unreportable tie at this scope — a narrower scope may still be a strict record
+			// beaten or unreportable tie at this scope — a narrower scope may
+			// exclude the offending day and still hold a strict record
 		}
 	}
 	return highlights;


### PR DESCRIPTION
## Summary

Adds a lazily-loaded **Highlights** section to the session detail page, and ships the first highlight family: session-totals records (busiest / most varied) across four scopes (all-time, any-{season}, this year, this {season}).

**Architecture (v2 — reworked after review):** instead of fanning out per-scope RPC calls, the action makes two parallel fetches — the existing `metrics_by_period_and_species('day','encounters')` RPC (per-day per-species counts) and the group's `Sessions` visit dates — memoised per group (1h TTL, module-level cache). All record derivation happens in pure model functions (`app/models/session-highlights.ts`).

**Semantics: as-of-date.** Comparisons only consider data up to and including the session date, so highlights for an old session read as they would have on the day; later sessions beating the record don't erase it. The tie rule (all-time tie reportable when the equalled record is >1 year old — "Busiest session for 3 years") is evaluated as-of-date too. Because the first session would otherwise be trivially a record for everything, a record requires at least one prior session in scope; zero-encounter sessions still count as prior sessions via the `Sessions` dates fetch.

- `app/models/session-highlights.ts` — `buildDayTotals`, `deriveSessionTotalRecords`, `sortHighlights`, `buildHighlightSentence`
- `app/actions/session-highlights.ts` — `fetchSessionHighlights`, memoised stats-blob fetch
- `app/components/SessionHighlights.tsx` — lazy client component (spinner → list; hidden when empty; errors collapse to empty and are logged)
- Rendered in `SessionSummary` between the stat badges and the tabs, date-level pages only (`locationId === undefined`)

Part of #219 (see the architecture-v2 comment there). Closes #313.

## Assumptions
- An unreportable tie at a broad scope falls through — a narrower scope may still hold a strict record.
- "Over a year old" tie = `differenceInYears >= 1`.
- Highlights render as sentences in the shared `BoxyList` under a "Highlights" heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
