### PR TITLE
fix: paginate session stats past PostgREST 1000-row cap

### DIFF
--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -11,8 +11,35 @@ vi.mock('@/lib/group-auth', () => ({
 
 const SESSION_DATE = '2024-09-15';
 const GROUP_ID = 1;
+const PAGE_SIZE = 1000;
 
+// Queries are paginated (PostgREST caps responses at 1000 rows), so the
+// mock builders serve rows page by page from these arrays
+let rpcPages: {
+	species_name: string;
+	visit_date: string;
+	metric_value: number;
+}[][];
+let sessionPages: { visit_date: string }[][];
+
+function pageForRange(pages: unknown[][], fromRow: number) {
+	return Promise.resolve({
+		data: pages[fromRow / PAGE_SIZE] ?? [],
+		error: null
+	});
+}
+
+const mockRpcOrder = vi.fn();
+const mockRpcRange = vi.fn();
+const rpcQueryBuilder = { order: mockRpcOrder, range: mockRpcRange };
 const mockRpc = vi.fn();
+
+const mockSessionsOrder = vi.fn();
+const mockSessionsRange = vi.fn();
+const sessionsQueryBuilder = {
+	order: mockSessionsOrder,
+	range: mockSessionsRange
+};
 const mockEq = vi.fn();
 const mockSelect = vi.fn(() => ({ eq: mockEq }));
 const mockFrom = vi.fn(() => ({ select: mockSelect }));
@@ -26,20 +53,25 @@ async function importFetchSessionHighlights() {
 }
 
 beforeEach(() => {
-	mockRpc.mockReset();
-	mockEq.mockReset();
-	mockRpc.mockResolvedValue({
-		data: [
+	vi.clearAllMocks();
+	rpcPages = [
+		[
 			{ species_name: 'Robin', visit_date: SESSION_DATE, metric_value: 74 },
 			{ species_name: 'Robin', visit_date: '2022-05-01', metric_value: 30 },
 			{ species_name: 'Wren', visit_date: '2022-05-01', metric_value: 30 }
-		],
-		error: null
-	});
-	mockEq.mockResolvedValue({
-		data: [{ visit_date: '2022-05-01' }, { visit_date: SESSION_DATE }],
-		error: null
-	});
+		]
+	];
+	sessionPages = [[{ visit_date: '2022-05-01' }, { visit_date: SESSION_DATE }]];
+	mockRpc.mockReturnValue(rpcQueryBuilder);
+	mockRpcOrder.mockReturnValue(rpcQueryBuilder);
+	mockRpcRange.mockImplementation((fromRow: number) =>
+		pageForRange(rpcPages, fromRow)
+	);
+	mockEq.mockReturnValue(sessionsQueryBuilder);
+	mockSessionsOrder.mockReturnValue(sessionsQueryBuilder);
+	mockSessionsRange.mockImplementation((fromRow: number) =>
+		pageForRange(sessionPages, fromRow)
+	);
 	mockGetAuthenticatedSupabaseClient.mockResolvedValue({
 		rpc: mockRpc,
 		from: mockFrom
@@ -85,6 +117,55 @@ describe('fetchSessionHighlights', () => {
 		expect(mockFrom).toHaveBeenCalledWith('Sessions');
 		expect(mockSelect).toHaveBeenCalledWith('visit_date');
 		expect(mockEq).toHaveBeenCalledWith('ringing_group_id', GROUP_ID);
+	});
+
+	it('requests deterministic ordering for paginated queries', async () => {
+		const fetchSessionHighlights = await importFetchSessionHighlights();
+		await fetchSessionHighlights({
+			date: SESSION_DATE,
+			viewedGroupId: GROUP_ID
+		});
+		expect(mockRpcOrder).toHaveBeenCalledWith('visit_date');
+		expect(mockRpcOrder).toHaveBeenCalledWith('species_name');
+		expect(mockRpcRange).toHaveBeenCalledWith(0, PAGE_SIZE - 1);
+		expect(mockSessionsOrder).toHaveBeenCalledWith('visit_date');
+		expect(mockSessionsRange).toHaveBeenCalledWith(0, PAGE_SIZE - 1);
+	});
+
+	it('derives highlights from rows beyond the first page', async () => {
+		rpcPages = [
+			Array.from({ length: PAGE_SIZE }, (_, index) => ({
+				species_name: `Species ${index}`,
+				visit_date: '2022-05-01',
+				metric_value: 1
+			})),
+			[
+				{
+					species_name: 'Robin',
+					visit_date: SESSION_DATE,
+					metric_value: 2000
+				}
+			]
+		];
+		const fetchSessionHighlights = await importFetchSessionHighlights();
+		const highlights = await fetchSessionHighlights({
+			date: SESSION_DATE,
+			viewedGroupId: GROUP_ID
+		});
+		expect(mockRpcRange).toHaveBeenCalledTimes(2);
+		expect(mockRpcRange).toHaveBeenNthCalledWith(
+			2,
+			PAGE_SIZE,
+			2 * PAGE_SIZE - 1
+		);
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				type: 'session-total-record',
+				metric: 'encounters',
+				scope: 'all-time',
+				value: 2000
+			})
+		);
 	});
 
 	it('returns cached data within the TTL', async () => {

--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -1,6 +1,6 @@
 'use server';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
-import { catchSupabaseErrors } from '@/lib/supabase';
+import { fetchAllPaginatedRows } from '@/lib/supabase';
 import {
 	deriveSessionTotalRecords,
 	sortHighlights,
@@ -29,24 +29,31 @@ async function fetchSessionStats(
 	}
 	const supabase = await getAuthenticatedSupabaseClient();
 	const [daySpeciesCounts, sessionRows] = await Promise.all([
-		supabase
-			.rpc('metrics_by_period_and_species', {
-				temporal_unit: 'day',
-				metric_name: 'encounters',
-				filters: {
-					ringing_group_filter: viewedGroupId
-				} as TopMetricsFilterParams
-			})
-			.then(catchSupabaseErrors) as Promise<DaySpeciesMetricRow[] | null>,
-		supabase
-			.from('Sessions')
-			.select('visit_date')
-			.eq('ringing_group_id', viewedGroupId)
-			.then(catchSupabaseErrors) as Promise<{ visit_date: string }[] | null>
+		fetchAllPaginatedRows<DaySpeciesMetricRow>((fromRow, toRow) =>
+			supabase
+				.rpc('metrics_by_period_and_species', {
+					temporal_unit: 'day',
+					metric_name: 'encounters',
+					filters: {
+						ringing_group_filter: viewedGroupId
+					} as TopMetricsFilterParams
+				})
+				.order('visit_date')
+				.order('species_name')
+				.range(fromRow, toRow)
+		),
+		fetchAllPaginatedRows<{ visit_date: string }>((fromRow, toRow) =>
+			supabase
+				.from('Sessions')
+				.select('visit_date')
+				.eq('ringing_group_id', viewedGroupId)
+				.order('visit_date')
+				.range(fromRow, toRow)
+		)
 	]);
 	const stats: SessionStatsData = {
-		daySpeciesCounts: daySpeciesCounts ?? [],
-		sessionDates: (sessionRows ?? []).map((row) => row.visit_date)
+		daySpeciesCounts,
+		sessionDates: sessionRows.map((row) => row.visit_date)
 	};
 	sessionStatsCache.set(viewedGroupId, {
 		expiresAt: Date.now() + SESSION_STATS_CACHE_TTL_MS,

--- a/lib/__tests__/supabase.test.ts
+++ b/lib/__tests__/supabase.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { PostgrestSingleResponse } from '@supabase/supabase-js';
+import { fetchAllPaginatedRows } from '../supabase';
+
+const PAGE_SIZE = 1000;
+
+function successResponse<T>(rows: T[]): PostgrestSingleResponse<T[]> {
+	return {
+		data: rows,
+		error: null,
+		count: null,
+		status: 200,
+		statusText: 'OK'
+	};
+}
+
+function buildRows(count: number, offset = 0) {
+	return Array.from({ length: count }, (_, index) => ({
+		id: offset + index
+	}));
+}
+
+describe('fetchAllPaginatedRows', () => {
+	it('returns all rows from a single short page', async () => {
+		const rows = buildRows(3);
+		const buildPageQuery = vi.fn().mockResolvedValue(successResponse(rows));
+		const result = await fetchAllPaginatedRows(buildPageQuery);
+		expect(result).toEqual(rows);
+		expect(buildPageQuery).toHaveBeenCalledTimes(1);
+		expect(buildPageQuery).toHaveBeenCalledWith(0, PAGE_SIZE - 1);
+	});
+
+	it('keeps fetching pages while pages are full and concatenates results', async () => {
+		const firstPage = buildRows(PAGE_SIZE);
+		const secondPage = buildRows(30, PAGE_SIZE);
+		const buildPageQuery = vi
+			.fn()
+			.mockResolvedValueOnce(successResponse(firstPage))
+			.mockResolvedValueOnce(successResponse(secondPage));
+		const result = await fetchAllPaginatedRows(buildPageQuery);
+		expect(result).toEqual([...firstPage, ...secondPage]);
+		expect(buildPageQuery).toHaveBeenCalledTimes(2);
+		expect(buildPageQuery).toHaveBeenNthCalledWith(1, 0, PAGE_SIZE - 1);
+		expect(buildPageQuery).toHaveBeenNthCalledWith(
+			2,
+			PAGE_SIZE,
+			2 * PAGE_SIZE - 1
+		);
+	});
+
+	it('makes a final empty request when total rows are an exact multiple of the page size', async () => {
+		const fullPage = buildRows(PAGE_SIZE);
+		const buildPageQuery = vi
+			.fn()
+			.mockResolvedValueOnce(successResponse(fullPage))
+			.mockResolvedValueOnce(successResponse([]));
+		const result = await fetchAllPaginatedRows(buildPageQuery);
+		expect(result).toEqual(fullPage);
+		expect(buildPageQuery).toHaveBeenCalledTimes(2);
+	});
+
+	it('throws when any page returns an error', async () => {
+		const buildPageQuery = vi.fn().mockResolvedValue({
+			data: null,
+			error: { message: 'boom' },
+			count: null,
+			status: 500,
+			statusText: 'Internal Server Error'
+		});
+		await expect(fetchAllPaginatedRows(buildPageQuery)).rejects.toThrow(
+			'Failed to fetch data: boom'
+		);
+	});
+});

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -27,3 +27,31 @@ export function catchSupabaseErrors<T>({
 	}
 	return data || null;
 }
+
+// PostgREST silently caps every response at this many rows (the Supabase
+// db-max-rows default), so unbounded queries must page through results.
+// Queries passed in must apply a deterministic order for paging to be stable.
+const SUPABASE_MAX_ROWS_PER_REQUEST = 1000;
+
+export async function fetchAllPaginatedRows<T>(
+	buildPageQuery: (
+		fromRow: number,
+		toRow: number
+	) => PromiseLike<PostgrestSingleResponse<T[]>>
+): Promise<T[]> {
+	const allRows: T[] = [];
+	for (let page = 0; ; page++) {
+		const fromRow = page * SUPABASE_MAX_ROWS_PER_REQUEST;
+		const pageRows =
+			catchSupabaseErrors(
+				await buildPageQuery(
+					fromRow,
+					fromRow + SUPABASE_MAX_ROWS_PER_REQUEST - 1
+				)
+			) ?? [];
+		allRows.push(...pageRows);
+		if (pageRows.length < SUPABASE_MAX_ROWS_PER_REQUEST) {
+			return allRows;
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Session highlights were missing on sessions that are genuinely records — e.g. group 1's `2025-09-06` (busiest ever, 158 birds) and `2026-06-20` (busiest of 2026, 120 birds) showed no highlights in prod.

## Root cause

PostgREST silently caps every response at 1000 rows (Supabase `db-max-rows` default). `fetchSessionStats` fetched the day-species stats blob from `metrics_by_period_and_species` in a single request; group 1 has 1430 rows and the RPC has no `ORDER BY`, so which 1000 rows survived was arbitrary. Both record dates got zero rows back, scored 0 encounters / 0 species, and `0 > previousBest` never fired. Local/seed data stays under 1000 rows, so tests passed.

## Fix

- New `fetchAllPaginatedRows` helper in `lib/supabase.ts` — pages through `.range()` windows until a short page, erroring via `catchSupabaseErrors` per page.
- `fetchSessionStats` wraps both queries (RPC + `Sessions` dates) in the helper, with deterministic `.order()` (`visit_date`, `species_name`) so paging is stable.

## Verification

- Unit tests for the helper (single page, multi-page, exact-multiple, error) plus action-level regression test deriving a highlight from rows on page 2.
- Read-only probe against prod through the new code path returns 1430 rows and yields the expected sentences: "Busiest session ever — 158 birds" (2025-09-06) and "Busiest session of 2026 — 120 birds" (2026-06-20).

Also investigated adding an `exclude_null_rows` param to the RPC: prod data shows zero rows with null/zero metric or null species — the SQL `GROUP BY` only emits (period, species) groups with ≥1 encounter, so there is nothing to exclude and the param was omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)