### PR TITLE
fix: paginate species graphable encounter data past 1000-row cap

### DIFF
--- a/app/actions/__tests__/sp-data.test.ts
+++ b/app/actions/__tests__/sp-data.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
+	mockGetAuthenticatedSupabaseClient: vi.fn()
+}));
+
+vi.mock('@/lib/group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+const SPECIES_ID = 42;
+const GROUP_ID = 1;
+const PAGE_SIZE = 1000;
+
+// Queries are paginated (PostgREST caps responses at 1000 rows), so the
+// mock builder serves rows page by page from this array
+let birdPages: { encounters: { sex: string | null }[] }[][];
+
+const mockOrder = vi.fn();
+const mockRange = vi.fn();
+const mockContains = vi.fn();
+const mockEq = vi.fn();
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const birdsQueryBuilder = {
+	select: mockSelect,
+	eq: mockEq,
+	contains: mockContains,
+	order: mockOrder,
+	range: mockRange
+};
+
+function buildBird(sex: string | null = null) {
+	return {
+		encounters: [{ age_code: '3', sex, weight: 10, wing_length: 60 }]
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	birdPages = [[buildBird('M'), buildBird(null)]];
+	mockSelect.mockReturnValue(birdsQueryBuilder);
+	mockEq.mockReturnValue(birdsQueryBuilder);
+	mockContains.mockReturnValue(birdsQueryBuilder);
+	mockOrder.mockReturnValue(birdsQueryBuilder);
+	mockRange.mockImplementation((fromRow: number) =>
+		Promise.resolve({
+			data: birdPages[fromRow / PAGE_SIZE] ?? [],
+			error: null
+		})
+	);
+	mockFrom.mockReturnValue(birdsQueryBuilder);
+	mockGetAuthenticatedSupabaseClient.mockResolvedValue({ from: mockFrom });
+});
+
+async function importFetchGraphableEncounterData() {
+	vi.resetModules();
+	const { fetchGraphableEncounterData } = await import('../sp-data');
+	return fetchGraphableEncounterData;
+}
+
+describe('fetchGraphableEncounterData', () => {
+	it('returns sexed graphable birds with species and group filters', async () => {
+		const fetchGraphableEncounterData =
+			await importFetchGraphableEncounterData();
+		const birds = await fetchGraphableEncounterData(SPECIES_ID, GROUP_ID);
+		expect(mockFrom).toHaveBeenCalledWith('Birds');
+		expect(mockEq).toHaveBeenCalledWith('species_id', SPECIES_ID);
+		expect(mockContains).toHaveBeenCalledWith('ringing_group_ids', [GROUP_ID]);
+		expect(birds).toHaveLength(2);
+		// enriched via getSexOfBird
+		expect(birds[0]).toEqual(expect.objectContaining({ sex: 'M' }));
+	});
+
+	it('orders by bird id for stable pagination', async () => {
+		const fetchGraphableEncounterData =
+			await importFetchGraphableEncounterData();
+		await fetchGraphableEncounterData(SPECIES_ID, GROUP_ID);
+		expect(mockOrder).toHaveBeenCalledWith('id');
+		expect(mockRange).toHaveBeenCalledWith(0, PAGE_SIZE - 1);
+	});
+
+	it('fetches birds beyond the first page', async () => {
+		birdPages = [
+			Array.from({ length: PAGE_SIZE }, () => buildBird()),
+			[buildBird('F')]
+		];
+		const fetchGraphableEncounterData =
+			await importFetchGraphableEncounterData();
+		const birds = await fetchGraphableEncounterData(SPECIES_ID, GROUP_ID);
+		expect(mockRange).toHaveBeenCalledTimes(2);
+		expect(mockRange).toHaveBeenNthCalledWith(2, PAGE_SIZE, 2 * PAGE_SIZE - 1);
+		expect(birds).toHaveLength(PAGE_SIZE + 1);
+	});
+});

--- a/app/actions/sp-data.ts
+++ b/app/actions/sp-data.ts
@@ -6,7 +6,7 @@ import {
 	type EnrichedBirdOfSpecies
 } from '@/app/models/bird';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
-import { catchSupabaseErrors } from '@/lib/supabase';
+import { catchSupabaseErrors, fetchAllPaginatedRows } from '@/lib/supabase';
 import type { NotableRetrapsResult } from '@/app/models/db';
 import { getSexOfBird, type EncounterOfBird } from '@/app/models/bird';
 import type { GraphableBird } from '@/app/components/WeightAndWingChart';
@@ -75,20 +75,24 @@ export async function fetchGraphableEncounterData(
 	viewedGroupId: number
 ): Promise<SexedGraphableBird[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
-	const paginatedBirdResults = (await supabase
-		.from('Birds')
-		.select(
-			`encounters:Encounters (
-				age_code,
-				sex,
-				weight,
-				wing_length
-			)`
-		)
-		.eq('species_id', speciesId)
-		.contains('ringing_group_ids', [viewedGroupId])
-		.then(catchSupabaseErrors)) as GraphableBird[];
-	return paginatedBirdResults.map(
+	const graphableBirdResults = await fetchAllPaginatedRows<GraphableBird>(
+		(fromRow, toRow) =>
+			supabase
+				.from('Birds')
+				.select(
+					`encounters:Encounters (
+						age_code,
+						sex,
+						weight,
+						wing_length
+					)`
+				)
+				.eq('species_id', speciesId)
+				.contains('ringing_group_ids', [viewedGroupId])
+				.order('id')
+				.range(fromRow, toRow)
+	);
+	return graphableBirdResults.map(
 		(bird) =>
 			({
 				...bird,


### PR DESCRIPTION
## Problem

Same bug class as #330: the species page weight/wing chart (`fetchGraphableEncounterData`) fetches all Birds of a species in one unbounded query, silently capped at 1000 rows by PostgREST. Group 1 has 1056 Reed Warbler birds — 56 are already dropped from the chart, and the count grows with every import.

## Fix

Wrap the Birds query in `fetchAllPaginatedRows` (from #330), ordered by `id` for stable paging, and rename the misleading `paginatedBirdResults` variable. Audited the other species-page fetches: `fetchPageOfBirds` is already paginated (batch 100), `fetchNotableRetraps` limits to 10, and the `aggregate_stats` month/year queries return tens of rows — no other changes needed.

## Verification

- New action tests: filters + enrichment, `.order('id')`, multi-page fetch (regression for this bug).
- Read-only prod probe with the changed query shape: old query returns 1000 Reed Warbler birds (capped), paginated returns all 1056, every one with its embedded encounters.

**Stacked on #330** — base is `fix/session-highlights-rpc-row-cap`; retarget/merge after #330 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)