### PR TITLE
fix: use absolute period labels for past-session highlights

### DIFF
--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -14,7 +14,10 @@ const mockHighlights: SessionHighlight[] = [
 		scope: 'all-time',
 		value: 74,
 		seasonName: 'autumn',
-		year: 2024
+		year: 2024,
+		isCurrentYear: false,
+		isCurrentSeason: false,
+		seasonPeriodLabel: 'autumn 2024'
 	},
 	{
 		type: 'session-total-record',
@@ -22,7 +25,10 @@ const mockHighlights: SessionHighlight[] = [
 		scope: 'this-season',
 		value: 18,
 		seasonName: 'autumn',
-		year: 2024
+		year: 2024,
+		isCurrentYear: true,
+		isCurrentSeason: true,
+		seasonPeriodLabel: 'autumn 2024'
 	}
 ];
 

--- a/app/models/__tests__/seasons.test.ts
+++ b/app/models/__tests__/seasons.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { getSeasonMonths } from '../seasons';
+import {
+	getSeasonMonths,
+	getSeasonPeriodLabel,
+	isCurrentSeasonPeriod
+} from '../seasons';
 
 describe('getSeasonMonths', () => {
 	it('returns numeric months when thisYear is false', () => {
@@ -37,5 +41,49 @@ describe('getSeasonMonths', () => {
 			'2025-02',
 			'2025-03'
 		]);
+	});
+});
+
+describe('getSeasonPeriodLabel', () => {
+	it('labels a spring date with its calendar year', () => {
+		expect(getSeasonPeriodLabel(new Date('2024-05-10'))).toBe('spring 2024');
+	});
+
+	it('labels an autumn date with its calendar year', () => {
+		expect(getSeasonPeriodLabel(new Date('2023-09-15'))).toBe('autumn 2023');
+	});
+
+	it('labels a November winter date with its start year and end-year suffix', () => {
+		expect(getSeasonPeriodLabel(new Date('2024-11-15'))).toBe('winter 2024/25');
+	});
+
+	it('labels a February winter date with the previous start year', () => {
+		expect(getSeasonPeriodLabel(new Date('2025-02-10'))).toBe('winter 2024/25');
+	});
+});
+
+describe('isCurrentSeasonPeriod', () => {
+	it('returns true when today falls within the same season period', () => {
+		expect(
+			isCurrentSeasonPeriod(new Date('2024-09-15'), new Date('2024-10-20'))
+		).toBe(true);
+	});
+
+	it('returns true across the year end within one winter', () => {
+		expect(
+			isCurrentSeasonPeriod(new Date('2024-12-05'), new Date('2025-01-20'))
+		).toBe(true);
+	});
+
+	it('returns false when today is in the same season of a later year', () => {
+		expect(
+			isCurrentSeasonPeriod(new Date('2023-09-15'), new Date('2024-09-15'))
+		).toBe(false);
+	});
+
+	it('returns false when today is outside the season months of the same year', () => {
+		expect(
+			isCurrentSeasonPeriod(new Date('2024-05-10'), new Date('2024-09-15'))
+		).toBe(false);
 	});
 });

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -8,6 +8,9 @@ import {
 import type { DaySpeciesMetricRow } from '@/app/models/db';
 
 const SESSION_DATE = '2024-09-15'; // autumn
+// A fixed "today" after the session's year and season, so current-period
+// flags are deterministically false unless a test passes its own today
+const PAST_PERIOD_TODAY = new Date('2025-06-01');
 
 // Prior days used across tests, chosen for their scope membership
 // relative to SESSION_DATE:
@@ -35,10 +38,11 @@ function statsFor(rows: DaySpeciesMetricRow[]): SessionStatsData {
 	};
 }
 
-function derive(rows: DaySpeciesMetricRow[]) {
+function derive(rows: DaySpeciesMetricRow[], today = PAST_PERIOD_TODAY) {
 	return deriveSessionTotalRecords({
 		date: SESSION_DATE,
-		stats: statsFor(rows)
+		stats: statsFor(rows),
+		today
 	});
 }
 
@@ -58,7 +62,10 @@ describe('deriveSessionTotalRecords', () => {
 			scope: 'all-time',
 			value: 74,
 			seasonName: 'autumn',
-			year: 2024
+			year: 2024,
+			isCurrentYear: false,
+			isCurrentSeason: false,
+			seasonPeriodLabel: 'autumn 2024'
 		});
 		// three species on the prior day vs two today — no variety record
 		expect(
@@ -180,6 +187,23 @@ describe('deriveSessionTotalRecords', () => {
 		);
 	});
 
+	it('marks the session year and season current when today falls within them', () => {
+		const highlights = derive(
+			[
+				...dayRows(SESSION_DATE, { Robin: 74 }),
+				...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 60 })
+			],
+			new Date('2024-10-20')
+		);
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				metric: 'encounters',
+				isCurrentYear: true,
+				isCurrentSeason: true
+			})
+		);
+	});
+
 	it('counts zero-encounter sessions as prior sessions in scope', () => {
 		const stats: SessionStatsData = {
 			daySpeciesCounts: dayRows(SESSION_DATE, { Robin: 74 }),
@@ -209,6 +233,9 @@ function makeHighlight(
 		value: 74,
 		seasonName: 'autumn',
 		year: 2024,
+		isCurrentYear: false,
+		isCurrentSeason: false,
+		seasonPeriodLabel: 'autumn 2024',
 		...overrides
 	};
 }
@@ -226,16 +253,44 @@ describe('buildHighlightSentence — session-total-record', () => {
 		);
 	});
 
-	it('renders this-year busiest copy', () => {
+	it('renders this-year busiest copy as "this year" for a current-year session', () => {
+		expect(
+			buildHighlightSentence(
+				makeHighlight({ scope: 'this-year', isCurrentYear: true })
+			)
+		).toBe('Busiest session this year — 74 birds');
+	});
+
+	it('renders this-year busiest copy with the year for a past session', () => {
 		expect(buildHighlightSentence(makeHighlight({ scope: 'this-year' }))).toBe(
 			'Busiest session of 2024 — 74 birds'
 		);
 	});
 
-	it('renders this-season busiest copy', () => {
+	it('renders this-season busiest copy as "this <season>" for a current-season session', () => {
+		expect(
+			buildHighlightSentence(
+				makeHighlight({ scope: 'this-season', isCurrentSeason: true })
+			)
+		).toBe('Busiest session this autumn — 74 birds');
+	});
+
+	it('renders this-season busiest copy with the season period for a past session', () => {
 		expect(
 			buildHighlightSentence(makeHighlight({ scope: 'this-season' }))
-		).toBe('Busiest session this autumn — 74 birds');
+		).toBe('Busiest session in autumn 2024 — 74 birds');
+	});
+
+	it('renders past winter copy with the split-year label', () => {
+		expect(
+			buildHighlightSentence(
+				makeHighlight({
+					scope: 'this-season',
+					seasonName: 'winter',
+					seasonPeriodLabel: 'winter 2023/24'
+				})
+			)
+		).toBe('Busiest session in winter 2023/24 — 74 birds');
 	});
 
 	it('renders most-varied copy for the species metric', () => {

--- a/app/models/seasons.ts
+++ b/app/models/seasons.ts
@@ -52,6 +52,25 @@ export function getSeasonMonths(
 	return months.map((month) => Number(month)) as number[];
 }
 
+// "autumn 2023" / "spring 2024" / "winter 2023/24" — winter is labelled by its
+// start year because it spans the year end
+export function getSeasonPeriodLabel(date: Date): string {
+	const season = getSeasonName(date);
+	const year = date.getFullYear();
+	if (season === Season.WINTER) {
+		const seasonStartYear = date.getMonth() >= 10 ? year : year - 1;
+		const endYearSuffix = String(seasonStartYear + 1).slice(2);
+		return `${season} ${seasonStartYear}/${endYearSuffix}`;
+	}
+	return `${season} ${year}`;
+}
+
+export function isCurrentSeasonPeriod(date: Date, today: Date): boolean {
+	const seasonYearMonths = getSeasonMonths(date, true) as string[];
+	const todayYearMonth = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}`;
+	return seasonYearMonths.includes(todayYearMonth);
+}
+
 export function getCESMonths(
 	date: Date,
 	thisYear?: boolean

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -1,5 +1,10 @@
 import { differenceInYears } from 'date-fns';
-import { getSeasonMonths, getSeasonName } from '@/app/models/seasons';
+import {
+	getSeasonMonths,
+	getSeasonName,
+	getSeasonPeriodLabel,
+	isCurrentSeasonPeriod
+} from '@/app/models/seasons';
 import type { DaySpeciesMetricRow } from '@/app/models/db';
 
 export const SESSION_TOTAL_METRICS = ['encounters', 'species'] as const;
@@ -29,6 +34,11 @@ export type SessionTotalRecordHighlight = {
 	value: number;
 	seasonName: string;
 	year: number;
+	// 'this year' / 'this autumn' copy is only correct while the session's
+	// period is still current; otherwise the sentence uses the absolute labels
+	isCurrentYear: boolean;
+	isCurrentSeason: boolean;
+	seasonPeriodLabel: string;
 	// Set only for all-time ties where the equalled record is over a year old
 	recordEqualledYearsAgo?: number;
 };
@@ -90,10 +100,12 @@ function getScopeMatcher(
 
 export function deriveSessionTotalRecords({
 	date,
-	stats
+	stats,
+	today = new Date()
 }: {
 	date: string;
 	stats: SessionStatsData;
+	today?: Date;
 }): SessionTotalRecordHighlight[] {
 	const sessionDate = new Date(date);
 	const dayTotals = buildDayTotals(stats, date);
@@ -118,7 +130,10 @@ export function deriveSessionTotalRecords({
 				scope,
 				value: sessionValue,
 				seasonName: getSeasonName(sessionDate),
-				year: sessionDate.getFullYear()
+				year: sessionDate.getFullYear(),
+				isCurrentYear: sessionDate.getFullYear() === today.getFullYear(),
+				isCurrentSeason: isCurrentSeasonPeriod(sessionDate, today),
+				seasonPeriodLabel: getSeasonPeriodLabel(sessionDate)
 			};
 			if (sessionValue > previousBest) {
 				highlights.push(baseHighlight);
@@ -183,9 +198,13 @@ function buildSessionTotalRecordSentence(
 		case 'any-season':
 			return `${descriptor} ${highlight.seasonName} session ever — ${valueCopy}`;
 		case 'this-year':
-			return `${descriptor} session of ${highlight.year} — ${valueCopy}`;
+			return highlight.isCurrentYear
+				? `${descriptor} session this year — ${valueCopy}`
+				: `${descriptor} session of ${highlight.year} — ${valueCopy}`;
 		case 'this-season':
-			return `${descriptor} session this ${highlight.seasonName} — ${valueCopy}`;
+			return highlight.isCurrentSeason
+				? `${descriptor} session this ${highlight.seasonName} — ${valueCopy}`
+				: `${descriptor} session in ${highlight.seasonPeriodLabel} — ${valueCopy}`;
 	}
 }
 


### PR DESCRIPTION
Part of #219.

Session-highlight copy rendered relative period words unconditionally — a 2023 session that was the busiest of that autumn read "Busiest session this autumn". Relative words now appear only while the period is still current at view time:

- **this-season**: "this autumn" only when today falls within the session's season period (winter spans the year end, so a Dec 2025 session viewed in Jan 2026 still reads "this winter"); otherwise "in autumn 2023", winter "in winter 2023/24"
- **this-year**: "this year" when the session is in the current calendar year (new copy); otherwise "of 2023"

Implementation: two pure helpers in `app/models/seasons.ts` (`getSeasonPeriodLabel`, `isCurrentSeasonPeriod`); `deriveSessionTotalRecords` computes `isCurrentYear` / `isCurrentSeason` / `seasonPeriodLabel` at derive time with an injectable `today` param, since the sentence builder has no session date.

Ticket #315 (species records, next copy family) updated with the rule; global copy rule recorded on #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)