### PR TITLE
feat: session highlights — species record highlights (#315)

### DIFF
--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -98,14 +98,16 @@ describe('fetchSessionHighlights', () => {
 		expect(args.temporal_unit).toBe('day');
 		expect(args.metric_name).toBe('encounters');
 		expect(args.filters.ringing_group_filter).toBe(GROUP_ID);
-		expect(highlights).toEqual([
-			expect.objectContaining({
-				type: 'session-total-record',
-				metric: 'encounters',
-				scope: 'all-time',
-				value: 74
-			})
-		]);
+		expect(highlights).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					type: 'session-total-record',
+					metric: 'encounters',
+					scope: 'all-time',
+					value: 74
+				})
+			])
+		);
 	});
 
 	it('fetches session dates', async () => {

--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -3,6 +3,7 @@ import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { fetchAllPaginatedRows } from '@/lib/supabase';
 import {
 	deriveSessionTotalRecords,
+	deriveSpeciesRecords,
 	sortHighlights,
 	type SessionHighlight,
 	type SessionStatsData
@@ -70,5 +71,8 @@ export async function fetchSessionHighlights({
 	viewedGroupId: number;
 }): Promise<SessionHighlight[]> {
 	const stats = await fetchSessionStats(viewedGroupId);
-	return sortHighlights(deriveSessionTotalRecords({ date, stats }));
+	return sortHighlights([
+		...deriveSessionTotalRecords({ date, stats }),
+		...deriveSpeciesRecords({ date, stats })
+	]);
 }

--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -32,6 +32,31 @@ const mockHighlights: SessionHighlight[] = [
 	}
 ];
 
+const mockHighlightsWithSpeciesRecord: SessionHighlight[] = [
+	{
+		type: 'session-total-record',
+		metric: 'encounters',
+		scope: 'all-time',
+		value: 74,
+		seasonName: 'autumn',
+		year: 2024,
+		isCurrentYear: false,
+		isCurrentSeason: false,
+		seasonPeriodLabel: 'autumn 2024'
+	},
+	{
+		type: 'species-count-record',
+		speciesName: 'Reed Warbler',
+		scope: 'all-time',
+		value: 12,
+		seasonName: 'autumn',
+		year: 2024,
+		isCurrentYear: false,
+		isCurrentSeason: false,
+		seasonPeriodLabel: 'autumn 2024'
+	}
+];
+
 describe('SessionHighlights', () => {
 	afterEach(() => {
 		cleanup();
@@ -103,5 +128,25 @@ describe('SessionHighlights', () => {
 		});
 		expect(container.innerHTML).toBe('');
 		expect(consoleErrorSpy).toHaveBeenCalled();
+	});
+
+	it('renders species record sentences alongside session-total records', async () => {
+		const { fetchSessionHighlights } =
+			await import('@/app/actions/session-highlights');
+		vi.mocked(fetchSessionHighlights).mockResolvedValue(
+			mockHighlightsWithSpeciesRecord
+		);
+		render(<SessionHighlights date="2024-09-15" viewedGroupId={1} />);
+		await waitFor(() => {
+			expect(screen.getByRole('heading', { name: 'Highlights' })).toBeDefined();
+		});
+		const items = screen
+			.getByTestId('session-highlights')
+			.querySelectorAll('li');
+		expect(items.length).toBe(2);
+		expect(items[0].textContent).toBe('Busiest session ever — 74 birds');
+		expect(items[1].textContent).toBe(
+			'Record day for Reed Warbler — 12 caught, the most ever'
+		);
 	});
 });

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
 	buildHighlightSentence,
 	deriveSessionTotalRecords,
+	deriveSpeciesRecords,
 	type SessionStatsData,
-	type SessionTotalRecordHighlight
+	type SessionTotalRecordHighlight,
+	type SpeciesCountRecordHighlight
 } from '../session-highlights';
 import type { DaySpeciesMetricRow } from '@/app/models/db';
 
@@ -303,5 +305,224 @@ describe('buildHighlightSentence — session-total-record', () => {
 		expect(
 			buildHighlightSentence(makeHighlight({ recordEqualledYearsAgo: 3 }))
 		).toBe('Busiest session for 3 years — 74 birds');
+	});
+});
+
+// ---- deriveSpeciesRecords ----
+
+const REED_WARBLER = 'Reed Warbler';
+const ROBIN = 'Robin';
+
+function speciesRow(
+	date: string,
+	species: string,
+	count: number
+): DaySpeciesMetricRow {
+	return { visit_date: date, species_name: species, metric_value: count };
+}
+
+function statsForSpecies(rows: DaySpeciesMetricRow[]): SessionStatsData {
+	return {
+		daySpeciesCounts: rows,
+		sessionDates: [...new Set(rows.map((row) => row.visit_date))]
+	};
+}
+
+function deriveSpecies(rows: DaySpeciesMetricRow[], today = PAST_PERIOD_TODAY) {
+	return deriveSpeciesRecords({
+		date: SESSION_DATE,
+		stats: statsForSpecies(rows),
+		today
+	});
+}
+
+describe('deriveSpeciesRecords', () => {
+	it('reports the broadest scope achieved per species', () => {
+		// All-time beaten: prior autumn (any-season) had 5, but a spring day also had 5
+		// Session has 10, so it beats all-time
+		const highlights = deriveSpecies([
+			speciesRow(SESSION_DATE, REED_WARBLER, 10),
+			speciesRow(PRIOR_AUTUMN_OTHER_YEAR, REED_WARBLER, 5),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 5)
+		]);
+		expect(highlights).toHaveLength(1);
+		expect(highlights[0]).toMatchObject({
+			type: 'species-count-record',
+			speciesName: REED_WARBLER,
+			scope: 'all-time',
+			value: 10
+		});
+	});
+
+	it('reports multiple species records from one session', () => {
+		const highlights = deriveSpecies([
+			speciesRow(SESSION_DATE, REED_WARBLER, 10),
+			speciesRow(SESSION_DATE, ROBIN, 8),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 5),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, ROBIN, 3)
+		]);
+		const speciesNames = highlights.map((h) => h.speciesName);
+		expect(speciesNames).toContain(REED_WARBLER);
+		expect(speciesNames).toContain(ROBIN);
+	});
+
+	it('requires the species to appear on a prior day in scope', () => {
+		// Reed Warbler only appears on the session day — no prior day, no record
+		const highlights = deriveSpecies([
+			speciesRow(SESSION_DATE, REED_WARBLER, 10),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, ROBIN, 3)
+		]);
+		expect(highlights.map((h) => h.speciesName)).not.toContain(REED_WARBLER);
+	});
+
+	it('ignores days after the session date', () => {
+		// A later day with more Reed Warblers should not affect the record
+		const highlights = deriveSpecies([
+			speciesRow(SESSION_DATE, REED_WARBLER, 10),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 5),
+			speciesRow(LATER_DAY, REED_WARBLER, 100)
+		]);
+		expect(highlights).toHaveLength(1);
+		expect(highlights[0]).toMatchObject({
+			speciesName: REED_WARBLER,
+			scope: 'all-time',
+			value: 10
+		});
+	});
+
+	it('reports an all-time tie older than a year as a for-N-years record', () => {
+		// Prior date is >1 year before SESSION_DATE (2024-09-15)
+		const highlights = deriveSpecies([
+			speciesRow(SESSION_DATE, REED_WARBLER, 10),
+			speciesRow(PRIOR_AUTUMN_OTHER_YEAR, REED_WARBLER, 10) // 2021-09-10 — 3 years ago
+		]);
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				speciesName: REED_WARBLER,
+				scope: 'all-time',
+				value: 10,
+				recordEqualledYearsAgo: 3
+			})
+		);
+	});
+
+	it('ignores ties under a year old and ties in narrower scopes', () => {
+		// all-time tie under a year old — not reportable
+		const tooRecentTie = deriveSpecies([
+			speciesRow(SESSION_DATE, REED_WARBLER, 10),
+			speciesRow(PRIOR_SPRING_THIS_YEAR, REED_WARBLER, 10) // 2024-05-01 — < 1 year
+		]);
+		expect(tooRecentTie).toHaveLength(0);
+
+		// all-time beaten by a big non-autumn day, any-season tied — tie not reportable
+		const anySeasonTie = deriveSpecies([
+			speciesRow(SESSION_DATE, REED_WARBLER, 10),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 20), // beats all-time
+			speciesRow(PRIOR_AUTUMN_OTHER_YEAR, REED_WARBLER, 10) // any-season tie
+		]);
+		expect(anySeasonTie).toHaveLength(0);
+	});
+
+	it('sets current-period flags from the injected today', () => {
+		// today during the session period: isCurrentYear and isCurrentSeason both true
+		const highlights = deriveSpecies(
+			[
+				speciesRow(SESSION_DATE, REED_WARBLER, 10),
+				speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 5)
+			],
+			new Date('2024-10-20')
+		);
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				speciesName: REED_WARBLER,
+				isCurrentYear: true,
+				isCurrentSeason: true
+			})
+		);
+	});
+});
+
+// ---- buildHighlightSentence — species-count-record ----
+
+function makeSpeciesHighlight(
+	overrides: Partial<SpeciesCountRecordHighlight>
+): SpeciesCountRecordHighlight {
+	return {
+		type: 'species-count-record',
+		speciesName: 'Reed Warbler',
+		scope: 'all-time',
+		value: 12,
+		seasonName: 'autumn',
+		year: 2024,
+		isCurrentYear: false,
+		isCurrentSeason: false,
+		seasonPeriodLabel: 'autumn 2024',
+		...overrides
+	};
+}
+
+describe('buildHighlightSentence — species-count-record', () => {
+	it('renders all-time copy', () => {
+		expect(buildHighlightSentence(makeSpeciesHighlight({}))).toBe(
+			'Record day for Reed Warbler — 12 caught, the most ever'
+		);
+	});
+
+	it('renders any-season copy', () => {
+		expect(
+			buildHighlightSentence(makeSpeciesHighlight({ scope: 'any-season' }))
+		).toBe('Record day for Reed Warbler — 12 caught, the most in any autumn');
+	});
+
+	it('renders current-year this-year copy ("this year")', () => {
+		expect(
+			buildHighlightSentence(
+				makeSpeciesHighlight({ scope: 'this-year', isCurrentYear: true })
+			)
+		).toBe('Record day for Reed Warbler — 12 caught, the most this year');
+	});
+
+	it('renders past-year this-year copy ("of 2024")', () => {
+		expect(
+			buildHighlightSentence(makeSpeciesHighlight({ scope: 'this-year' }))
+		).toBe('Record day for Reed Warbler — 12 caught, the most in 2024');
+	});
+
+	it('renders current-season this-season copy ("this autumn")', () => {
+		expect(
+			buildHighlightSentence(
+				makeSpeciesHighlight({ scope: 'this-season', isCurrentSeason: true })
+			)
+		).toBe('Record day for Reed Warbler — 12 caught, the most this autumn');
+	});
+
+	it('renders past-period this-season copy ("in autumn 2024")', () => {
+		expect(
+			buildHighlightSentence(makeSpeciesHighlight({ scope: 'this-season' }))
+		).toBe('Record day for Reed Warbler — 12 caught, the most in autumn 2024');
+	});
+
+	it('renders past winter copy ("in winter 2023/24")', () => {
+		expect(
+			buildHighlightSentence(
+				makeSpeciesHighlight({
+					scope: 'this-season',
+					seasonName: 'winter',
+					seasonPeriodLabel: 'winter 2023/24'
+				})
+			)
+		).toBe(
+			'Record day for Reed Warbler — 12 caught, the most in winter 2023/24'
+		);
+	});
+
+	it('renders record-equalling for-N-years copy', () => {
+		expect(
+			buildHighlightSentence(
+				makeSpeciesHighlight({ recordEqualledYearsAgo: 2 })
+			)
+		).toBe(
+			'Record-equalling day for Reed Warbler — 12 caught, most for 2 years'
+		);
 	});
 });

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -43,7 +43,58 @@ export type SessionTotalRecordHighlight = {
 	recordEqualledYearsAgo?: number;
 };
 
-export type SessionHighlight = SessionTotalRecordHighlight;
+export type SpeciesCountRecordHighlight = {
+	type: 'species-count-record';
+	speciesName: string;
+	scope: RecordScope;
+	value: number;
+	seasonName: string;
+	year: number;
+	// 'this year' / 'this autumn' copy is only correct while the session's
+	// period is still current; otherwise the sentence uses the absolute labels
+	isCurrentYear: boolean;
+	isCurrentSeason: boolean;
+	seasonPeriodLabel: string;
+	// Set only for all-time ties where the equalled record is over a year old
+	recordEqualledYearsAgo?: number;
+};
+
+export type SessionHighlight =
+	| SessionTotalRecordHighlight
+	| SpeciesCountRecordHighlight;
+
+type PeriodFields = {
+	scope: RecordScope;
+	seasonName: string;
+	year: number;
+	isCurrentYear: boolean;
+	isCurrentSeason: boolean;
+	seasonPeriodLabel: string;
+};
+
+// Returns the scope-qualified phrase for "this year" / "this season" scopes
+// where the copy changes depending on whether the period is still current.
+// Handles the shared conditional logic for both session-total and species-record families.
+// Returns null for all-time and any-season, which each family phrases differently.
+// yearPreposition: 'in' for species-count ("the most in 2024"),
+//                  'of' for session-total ("Busiest session of 2024")
+export function buildCurrentPeriodScopePhrase(
+	fields: PeriodFields,
+	yearPreposition: 'in' | 'of' = 'in'
+): string | null {
+	switch (fields.scope) {
+		case 'this-year':
+			return fields.isCurrentYear
+				? 'this year'
+				: `${yearPreposition} ${fields.year}`;
+		case 'this-season':
+			return fields.isCurrentSeason
+				? `this ${fields.seasonName}`
+				: `in ${fields.seasonPeriodLabel}`;
+		default:
+			return null;
+	}
+}
 
 type DayTotals = {
 	date: string;
@@ -161,8 +212,83 @@ export function deriveSessionTotalRecords({
 	return highlights;
 }
 
+export function deriveSpeciesRecords({
+	date,
+	stats,
+	today = new Date()
+}: {
+	date: string;
+	stats: SessionStatsData;
+	today?: Date;
+}): SpeciesCountRecordHighlight[] {
+	const sessionDate = new Date(date);
+	const sessionRows = stats.daySpeciesCounts.filter(
+		(row) => row.visit_date === date
+	);
+	if (sessionRows.length === 0) return [];
+
+	const sharedFields = {
+		seasonName: getSeasonName(sessionDate),
+		year: sessionDate.getFullYear(),
+		isCurrentYear: sessionDate.getFullYear() === today.getFullYear(),
+		isCurrentSeason: isCurrentSeasonPeriod(sessionDate, today),
+		seasonPeriodLabel: getSeasonPeriodLabel(sessionDate)
+	};
+
+	const highlights: SpeciesCountRecordHighlight[] = [];
+	for (const sessionRow of sessionRows) {
+		const { species_name: speciesName, metric_value: sessionValue } =
+			sessionRow;
+		for (const scope of RECORD_SCOPES) {
+			const scopeMatcher = getScopeMatcher(scope, sessionDate);
+			const priorRows = stats.daySpeciesCounts.filter(
+				(row) =>
+					row.species_name === speciesName &&
+					row.visit_date < date &&
+					scopeMatcher(row.visit_date)
+			);
+			// A record requires the species to appear on at least one prior day
+			// in scope (otherwise it's first-ever territory, covered by #317)
+			if (priorRows.length === 0) continue;
+			const previousBest = Math.max(
+				...priorRows.map((row) => row.metric_value)
+			);
+			const baseHighlight: SpeciesCountRecordHighlight = {
+				type: 'species-count-record',
+				speciesName,
+				scope,
+				value: sessionValue,
+				...sharedFields
+			};
+			if (sessionValue > previousBest) {
+				highlights.push(baseHighlight);
+				break;
+			}
+			if (sessionValue === previousBest && scope === 'all-time') {
+				const mostRecentTieDate = priorRows
+					.filter((row) => row.metric_value === previousBest)
+					.map((row) => row.visit_date)
+					.sort()
+					.at(-1)!;
+				const recordEqualledYearsAgo = differenceInYears(
+					sessionDate,
+					new Date(mostRecentTieDate)
+				);
+				if (recordEqualledYearsAgo >= 1) {
+					highlights.push({ ...baseHighlight, recordEqualledYearsAgo });
+					break;
+				}
+			}
+			// beaten or unreportable tie at this scope — a narrower scope may
+			// exclude the offending day and still hold a strict record
+		}
+	}
+	return highlights;
+}
+
 const HIGHLIGHT_TYPE_PRIORITY: SessionHighlight['type'][] = [
-	'session-total-record'
+	'session-total-record',
+	'species-count-record'
 ];
 
 export function sortHighlights(
@@ -183,34 +309,52 @@ const SESSION_TOTAL_METRIC_COPY: Record<
 	species: { descriptor: 'Most varied', unit: 'species' }
 };
 
+function buildYearsAgoCopy(yearsAgo: number): string {
+	return `${yearsAgo} ${yearsAgo === 1 ? 'year' : 'years'}`;
+}
+
 function buildSessionTotalRecordSentence(
 	highlight: SessionTotalRecordHighlight
 ): string {
 	const { descriptor, unit } = SESSION_TOTAL_METRIC_COPY[highlight.metric];
 	const valueCopy = `${highlight.value} ${unit}`;
 	if (highlight.recordEqualledYearsAgo !== undefined) {
-		const yearsCopy = `${highlight.recordEqualledYearsAgo} ${highlight.recordEqualledYearsAgo === 1 ? 'year' : 'years'}`;
-		return `${descriptor} session for ${yearsCopy} — ${valueCopy}`;
+		return `${descriptor} session for ${buildYearsAgoCopy(highlight.recordEqualledYearsAgo)} — ${valueCopy}`;
 	}
-	switch (highlight.scope) {
-		case 'all-time':
-			return `${descriptor} session ever — ${valueCopy}`;
-		case 'any-season':
-			return `${descriptor} ${highlight.seasonName} session ever — ${valueCopy}`;
-		case 'this-year':
-			return highlight.isCurrentYear
-				? `${descriptor} session this year — ${valueCopy}`
-				: `${descriptor} session of ${highlight.year} — ${valueCopy}`;
-		case 'this-season':
-			return highlight.isCurrentSeason
-				? `${descriptor} session this ${highlight.seasonName} — ${valueCopy}`
-				: `${descriptor} session in ${highlight.seasonPeriodLabel} — ${valueCopy}`;
+	const currentPeriodPhrase = buildCurrentPeriodScopePhrase(highlight, 'of');
+	if (currentPeriodPhrase !== null) {
+		return `${descriptor} session ${currentPeriodPhrase} — ${valueCopy}`;
 	}
+	// Remaining cases: all-time and any-season (this-year / this-season handled above)
+	if (highlight.scope === 'any-season') {
+		return `${descriptor} ${highlight.seasonName} session ever — ${valueCopy}`;
+	}
+	return `${descriptor} session ever — ${valueCopy}`;
+}
+
+function buildSpeciesCountRecordSentence(
+	highlight: SpeciesCountRecordHighlight
+): string {
+	const { speciesName, value } = highlight;
+	const valueCopy = `${value} caught`;
+	if (highlight.recordEqualledYearsAgo !== undefined) {
+		return `Record-equalling day for ${speciesName} — ${valueCopy}, most for ${buildYearsAgoCopy(highlight.recordEqualledYearsAgo)}`;
+	}
+	const currentPeriodPhrase = buildCurrentPeriodScopePhrase(highlight);
+	const mostPhrase =
+		currentPeriodPhrase !== null
+			? `the most ${currentPeriodPhrase}`
+			: highlight.scope === 'all-time'
+				? 'the most ever'
+				: `the most in any ${highlight.seasonName}`;
+	return `Record day for ${speciesName} — ${valueCopy}, ${mostPhrase}`;
 }
 
 export function buildHighlightSentence(highlight: SessionHighlight): string {
 	switch (highlight.type) {
 		case 'session-total-record':
 			return buildSessionTotalRecordSentence(highlight);
+		case 'species-count-record':
+			return buildSpeciesCountRecordSentence(highlight);
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `deriveSpeciesRecords` to `app/models/session-highlights.ts`: for each species caught in a session, compares its count against all prior days in scope (all-time / any-season / this-year / this-season, broadest wins). Requires the species to appear on at least one prior day in scope.
- Adds `buildSpeciesCountRecordSentence` to render sentences like "Record day for Reed Warbler — 12 caught, the most ever" and "Record-equalling day for Reed Warbler — 12 caught, most for 2 years".
- Extracts `buildCurrentPeriodScopePhrase` shared helper (with a `yearPreposition` param: `'of'` for session-total, `'in'` for species-count) to remove duplicated this-year / this-season conditional logic.
- Wires `deriveSpeciesRecords` into `fetchSessionHighlights` alongside the existing total-record derive call.
- Extends `sortHighlights` priority order: session-total-record → species-count-record.
- Adds all test cases specified in #315.

Closes #315

## Test plan

- [x] `npm run qa` passes (286 tests, 0 errors)
- [x] All `deriveSpeciesRecords` describe tests implemented and passing
- [x] All `buildHighlightSentence — species-count-record` describe tests implemented and passing
- [x] `SessionHighlights` component test "renders species record sentences alongside session-total records" added and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)