### PR TITLE
feat: compare session highlights against all sessions in scope

### DIFF
--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -182,7 +182,15 @@ describe('fetchSessionHighlights', () => {
 		});
 		expect(mockRpc).toHaveBeenCalledTimes(1);
 		expect(mockEq).toHaveBeenCalledTimes(1);
-		// the cached blob still serves other session dates
-		expect(secondResult).toEqual([]);
+		// the cached blob still serves other session dates — the 2022 session
+		// holds the most-varied record (2 species vs 1 on the 2024 day)
+		expect(secondResult).toEqual([
+			expect.objectContaining({
+				type: 'session-total-record',
+				metric: 'species',
+				scope: 'all-time',
+				value: 2
+			})
+		]);
 	});
 });

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -14,13 +14,15 @@ const SESSION_DATE = '2024-09-15'; // autumn
 // flags are deterministically false unless a test passes its own today
 const PAST_PERIOD_TODAY = new Date('2025-06-01');
 
-// Prior days used across tests, chosen for their scope membership
+// Comparison days used across tests, chosen for their scope membership
 // relative to SESSION_DATE:
 const PRIOR_AUTUMN_OTHER_YEAR = '2021-09-10'; // any-season only (3+ years ago)
 const PRIOR_SPRING_OTHER_YEAR = '2022-05-01'; // all-time only
 const PRIOR_SPRING_THIS_YEAR = '2024-05-01'; // this-year (and all-time)
 const PRIOR_THIS_SEASON = '2024-08-20'; // this-season (and all narrower)
-const LATER_DAY = '2024-10-01';
+const LATER_DAY = '2024-10-01'; // after the session, but in every scope
+const LATER_DAY_TWO = '2024-10-05';
+const LATER_DAY_THREE = '2024-10-20';
 // Additional all-time-only days for multi-day placement-tier scenarios
 const PRIOR_SPRING_YEAR_ONE = '2021-05-01';
 const PRIOR_SPRING_YEAR_ONE_LATER = '2021-05-15';
@@ -53,7 +55,7 @@ function derive(rows: DaySpeciesMetricRow[], today = PAST_PERIOD_TODAY) {
 }
 
 describe('deriveSessionTotalRecords', () => {
-	it('returns a busiest record when the session total beats all prior days in scope', () => {
+	it('returns a busiest record when the session total beats all other days in scope', () => {
 		const highlights = derive([
 			...dayRows(SESSION_DATE, { Robin: 40, Chiffchaff: 34 }),
 			...dayRows(PRIOR_SPRING_OTHER_YEAR, {
@@ -96,17 +98,71 @@ describe('deriveSessionTotalRecords', () => {
 		).toEqual([]);
 	});
 
-	it('ignores sessions after the session date', () => {
+	it('counts later sessions when finding records', () => {
+		// the later day beats the session in every scope — no record
 		const highlights = derive([
 			...dayRows(SESSION_DATE, { Robin: 74 }),
 			...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 60 }),
 			...dayRows(LATER_DAY, { Robin: 200, Chiffchaff: 200 })
+		]);
+		expect(
+			highlights.filter((highlight) => highlight.metric === 'encounters')
+		).toEqual([]);
+	});
+
+	it('holds a record when later sessions are all lower', () => {
+		const highlights = derive([
+			...dayRows(SESSION_DATE, { Robin: 74 }),
+			...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 60 }),
+			...dayRows(LATER_DAY, { Robin: 50 })
 		]);
 		expect(highlights).toContainEqual(
 			expect.objectContaining({
 				metric: 'encounters',
 				scope: 'all-time',
 				value: 74
+			})
+		);
+	});
+
+	it('uses a later session as the comparison baseline', () => {
+		// previously suppressed as the group's first session; a later
+		// session now provides the required comparison
+		const highlights = derive([
+			...dayRows(SESSION_DATE, { Robin: 74 }),
+			...dayRows(LATER_DAY, { Robin: 50 })
+		]);
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				metric: 'encounters',
+				scope: 'all-time',
+				value: 74
+			})
+		);
+	});
+
+	it('treats a tie held only by a later session as unreportable', () => {
+		const highlights = derive([
+			...dayRows(SESSION_DATE, { Robin: 74 }),
+			...dayRows(LATER_DAY, { Robin: 74 })
+		]);
+		expect(
+			highlights.filter((highlight) => highlight.metric === 'encounters')
+		).toEqual([]);
+	});
+
+	it('computes for-N-years from prior tied days even when a later day also ties', () => {
+		const highlights = derive([
+			...dayRows(SESSION_DATE, { Robin: 74 }),
+			...dayRows(PRIOR_AUTUMN_OTHER_YEAR, { Robin: 74 }),
+			...dayRows(LATER_DAY, { Robin: 74 })
+		]);
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				metric: 'encounters',
+				scope: 'all-time',
+				value: 74,
+				recordEqualledYearsAgo: 3
 			})
 		);
 	});
@@ -186,8 +242,8 @@ describe('deriveSessionTotalRecords', () => {
 		).toEqual([]);
 	});
 
-	it('suppresses records when no prior session exists in scope', () => {
-		// the group's first-ever session would otherwise be a record for everything
+	it('suppresses records when no other session exists in scope', () => {
+		// the group's only session would otherwise be a record for everything
 		expect(derive(dayRows(SESSION_DATE, { Robin: 74, Chiffchaff: 3 }))).toEqual(
 			[]
 		);
@@ -210,7 +266,7 @@ describe('deriveSessionTotalRecords', () => {
 		);
 	});
 
-	it('counts zero-encounter sessions as prior sessions in scope', () => {
+	it('counts zero-encounter sessions as comparison sessions in scope', () => {
 		const stats: SessionStatsData = {
 			daySpeciesCounts: dayRows(SESSION_DATE, { Robin: 74 }),
 			sessionDates: [PRIOR_SPRING_OTHER_YEAR, SESSION_DATE]
@@ -370,8 +426,8 @@ describe('deriveSpeciesRecords', () => {
 		expect(speciesNames).toContain(ROBIN);
 	});
 
-	it('requires the species to appear on a prior day in scope', () => {
-		// Reed Warbler only appears on the session day — no prior day, no record
+	it('requires the species to appear on another day in scope', () => {
+		// Reed Warbler only appears on the session day — no other day, no record
 		const highlights = deriveSpecies([
 			speciesRow(SESSION_DATE, REED_WARBLER, 10),
 			speciesRow(PRIOR_SPRING_OTHER_YEAR, ROBIN, 3)
@@ -379,8 +435,7 @@ describe('deriveSpeciesRecords', () => {
 		expect(highlights.map((h) => h.speciesName)).not.toContain(REED_WARBLER);
 	});
 
-	it('ignores days after the session date', () => {
-		// A later day with more Reed Warblers should not affect the record
+	it('demotes the session to a placement when a later day has a higher count', () => {
 		const highlights = deriveSpecies([
 			speciesRow(SESSION_DATE, REED_WARBLER, 10),
 			speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 5),
@@ -390,8 +445,41 @@ describe('deriveSpeciesRecords', () => {
 		expect(highlights[0]).toMatchObject({
 			speciesName: REED_WARBLER,
 			scope: 'all-time',
-			value: 10
+			value: 10,
+			placementRank: 2,
+			isJointPlacement: false
 		});
+	});
+
+	it('reports a joint best day when only a later day ties the session count', () => {
+		const highlights = deriveSpecies([
+			speciesRow(SESSION_DATE, REED_WARBLER, 10),
+			speciesRow(LATER_DAY, REED_WARBLER, 10)
+		]);
+		expect(highlights).toHaveLength(1);
+		expect(highlights[0]).toMatchObject({
+			speciesName: REED_WARBLER,
+			scope: 'all-time',
+			value: 10,
+			placementRank: 1,
+			isJointPlacement: true
+		});
+	});
+
+	it('keeps the for-N-years copy for an old prior tie even when a later day also ties', () => {
+		const highlights = deriveSpecies([
+			speciesRow(SESSION_DATE, REED_WARBLER, 10),
+			speciesRow(PRIOR_AUTUMN_OTHER_YEAR, REED_WARBLER, 10),
+			speciesRow(LATER_DAY, REED_WARBLER, 10)
+		]);
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				speciesName: REED_WARBLER,
+				scope: 'all-time',
+				value: 10,
+				recordEqualledYearsAgo: 3
+			})
+		);
 	});
 
 	it('reports an all-time tie older than a year as a for-N-years record', () => {
@@ -568,6 +656,17 @@ describe('deriveSpeciesRecords', () => {
 			expect(highlights).toHaveLength(1);
 			expect(highlights[0]).toMatchObject({ scope: 'any-season', value: 8 });
 			expect(highlights[0].placementRank).toBeUndefined();
+		});
+
+		it('counts later days when building placement tiers', () => {
+			// three later days at the top value block 2nd place
+			const highlights = deriveSpecies([
+				speciesRow(SESSION_DATE, REED_WARBLER, 8),
+				speciesRow(LATER_DAY, REED_WARBLER, 10),
+				speciesRow(LATER_DAY_TWO, REED_WARBLER, 10),
+				speciesRow(LATER_DAY_THREE, REED_WARBLER, 10)
+			]);
+			expect(highlights).toHaveLength(0);
 		});
 
 		it('does not report 2nd place when three prior days share the top value', () => {

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -107,19 +107,17 @@ type DayTotals = {
 	species: number;
 };
 
-// Highlights describe the session as it would have read on the day, so
-// every comparison only considers data up to and including the session date
-export function buildDayTotals(
-	{ daySpeciesCounts, sessionDates }: SessionStatsData,
-	sessionDate: string
-): DayTotals[] {
+// Highlights compare the session against every other session in scope,
+// whenever it happened — later data can erase or demote a record
+export function buildDayTotals({
+	daySpeciesCounts,
+	sessionDates
+}: SessionStatsData): DayTotals[] {
 	const totalsByDate = new Map<string, DayTotals>();
 	for (const date of sessionDates) {
-		if (date > sessionDate) continue;
 		totalsByDate.set(date, { date, encounters: 0, species: 0 });
 	}
 	for (const row of daySpeciesCounts) {
-		if (row.visit_date > sessionDate) continue;
 		const dayTotals = totalsByDate.get(row.visit_date) ?? {
 			date: row.visit_date,
 			encounters: 0,
@@ -164,7 +162,7 @@ export function deriveSessionTotalRecords({
 	today?: Date;
 }): SessionTotalRecordHighlight[] {
 	const sessionDate = new Date(date);
-	const dayTotals = buildDayTotals(stats, date);
+	const dayTotals = buildDayTotals(stats);
 	const currentDay = dayTotals.find((day) => day.date === date);
 	if (!currentDay) return [];
 
@@ -173,13 +171,15 @@ export function deriveSessionTotalRecords({
 		const sessionValue = currentDay[metric];
 		for (const scope of RECORD_SCOPES) {
 			const scopeMatcher = getScopeMatcher(scope, sessionDate);
-			const priorDays = dayTotals.filter(
-				(day) => day.date < date && scopeMatcher(day.date)
+			const otherDaysInScope = dayTotals.filter(
+				(day) => day.date !== date && scopeMatcher(day.date)
 			);
-			// A record is only meaningful against at least one prior session
-			// (otherwise the group's first session is trivially a record)
-			if (priorDays.length === 0) continue;
-			const previousBest = Math.max(...priorDays.map((day) => day[metric]));
+			// A record is only meaningful against at least one other session
+			// (otherwise the group's only session is trivially a record)
+			if (otherDaysInScope.length === 0) continue;
+			const bestOtherValue = Math.max(
+				...otherDaysInScope.map((day) => day[metric])
+			);
 			const baseHighlight: SessionTotalRecordHighlight = {
 				type: 'session-total-record',
 				metric,
@@ -191,23 +191,27 @@ export function deriveSessionTotalRecords({
 				isCurrentSeason: isCurrentSeasonPeriod(sessionDate, today),
 				seasonPeriodLabel: getSeasonPeriodLabel(sessionDate)
 			};
-			if (sessionValue > previousBest) {
+			if (sessionValue > bestOtherValue) {
 				highlights.push(baseHighlight);
 				break;
 			}
-			if (sessionValue === previousBest && scope === 'all-time') {
-				const mostRecentTieDate = priorDays
-					.filter((day) => day[metric] === previousBest)
+			if (sessionValue === bestOtherValue && scope === 'all-time') {
+				// The for-N-years copy describes how long the record stood, so
+				// only prior tied days count — a later-only tie is unreportable
+				const mostRecentPriorTieDate = otherDaysInScope
+					.filter((day) => day[metric] === bestOtherValue && day.date < date)
 					.map((day) => day.date)
 					.sort()
-					.at(-1)!;
-				const recordEqualledYearsAgo = differenceInYears(
-					sessionDate,
-					new Date(mostRecentTieDate)
-				);
-				if (recordEqualledYearsAgo >= 1) {
-					highlights.push({ ...baseHighlight, recordEqualledYearsAgo });
-					break;
+					.at(-1);
+				if (mostRecentPriorTieDate !== undefined) {
+					const recordEqualledYearsAgo = differenceInYears(
+						sessionDate,
+						new Date(mostRecentPriorTieDate)
+					);
+					if (recordEqualledYearsAgo >= 1) {
+						highlights.push({ ...baseHighlight, recordEqualledYearsAgo });
+						break;
+					}
 				}
 			}
 			// beaten or unreportable tie at this scope — a narrower scope may
@@ -218,20 +222,20 @@ export function deriveSessionTotalRecords({
 }
 
 // 2nd/3rd placements are only reported while the top tiers are sparsely
-// held: 2nd place needs fewer than three prior days at the top value, 3rd
-// place needs fewer than three prior days across the top two values. The
+// held: 2nd place needs fewer than three other days at the top value, 3rd
+// place needs fewer than three other days across the top two values. The
 // session must also equal or exceed an included tier value — a count below
-// every prior value is not a placement, however thin the history.
+// every other value is not a placement, however thin the history.
 function deriveAllTimePlacement(
 	sessionValue: number,
-	priorValues: number[]
+	otherValues: number[]
 ): { placementRank: 2 | 3; isJointPlacement: boolean } | null {
-	const distinctValuesDescending = [...new Set(priorValues)].sort(
+	const distinctValuesDescending = [...new Set(otherValues)].sort(
 		(a, b) => b - a
 	);
 	const [topValue, secondValue, thirdValue] = distinctValuesDescending;
 	const daysAt = (value: number) =>
-		priorValues.filter((priorValue) => priorValue === value).length;
+		otherValues.filter((otherValue) => otherValue === value).length;
 	const includedValues = [topValue];
 	if (secondValue !== undefined && daysAt(topValue) < 3) {
 		includedValues.push(secondValue);
@@ -244,14 +248,14 @@ function deriveAllTimePlacement(
 	}
 	const minIncludedValue = includedValues.at(-1)!;
 	if (sessionValue < minIncludedValue || sessionValue >= topValue) return null;
-	// The tier rule above means at most two prior days can outrank a
+	// The tier rule above means at most two other days can outrank a
 	// qualifying value, so the rank is always 2 or 3
-	const placementRank = (priorValues.filter(
-		(priorValue) => priorValue > sessionValue
+	const placementRank = (otherValues.filter(
+		(otherValue) => otherValue > sessionValue
 	).length + 1) as 2 | 3;
 	return {
 		placementRank,
-		isJointPlacement: priorValues.includes(sessionValue)
+		isJointPlacement: otherValues.includes(sessionValue)
 	};
 }
 
@@ -286,17 +290,17 @@ export function deriveSpeciesRecords({
 		if (sessionValue === 1) continue;
 		for (const scope of RECORD_SCOPES) {
 			const scopeMatcher = getScopeMatcher(scope, sessionDate);
-			const priorRows = stats.daySpeciesCounts.filter(
+			const otherRowsInScope = stats.daySpeciesCounts.filter(
 				(row) =>
 					row.species_name === speciesName &&
-					row.visit_date < date &&
+					row.visit_date !== date &&
 					scopeMatcher(row.visit_date)
 			);
-			// A record requires the species to appear on at least one prior day
+			// A record requires the species to appear on at least one other day
 			// in scope (otherwise it's first-ever territory, covered by #317)
-			if (priorRows.length === 0) continue;
-			const previousBest = Math.max(
-				...priorRows.map((row) => row.metric_value)
+			if (otherRowsInScope.length === 0) continue;
+			const bestOtherValue = Math.max(
+				...otherRowsInScope.map((row) => row.metric_value)
 			);
 			const baseHighlight: SpeciesCountRecordHighlight = {
 				type: 'species-count-record',
@@ -305,20 +309,26 @@ export function deriveSpeciesRecords({
 				value: sessionValue,
 				...sharedFields
 			};
-			if (sessionValue > previousBest) {
+			if (sessionValue > bestOtherValue) {
 				highlights.push(baseHighlight);
 				break;
 			}
-			if (sessionValue === previousBest && scope === 'all-time') {
-				const mostRecentTieDate = priorRows
-					.filter((row) => row.metric_value === previousBest)
+			if (sessionValue === bestOtherValue && scope === 'all-time') {
+				// The for-N-years copy describes how long the record stood, so
+				// only prior tied days count towards it; a tie held only by a
+				// later day still reads as a joint best day
+				const mostRecentPriorTieDate = otherRowsInScope
+					.filter(
+						(row) =>
+							row.metric_value === bestOtherValue && row.visit_date < date
+					)
 					.map((row) => row.visit_date)
 					.sort()
-					.at(-1)!;
-				const recordEqualledYearsAgo = differenceInYears(
-					sessionDate,
-					new Date(mostRecentTieDate)
-				);
+					.at(-1);
+				const recordEqualledYearsAgo =
+					mostRecentPriorTieDate === undefined
+						? 0
+						: differenceInYears(sessionDate, new Date(mostRecentPriorTieDate));
 				highlights.push(
 					recordEqualledYearsAgo >= 1
 						? { ...baseHighlight, recordEqualledYearsAgo }
@@ -329,7 +339,7 @@ export function deriveSpeciesRecords({
 			if (scope === 'all-time') {
 				const placement = deriveAllTimePlacement(
 					sessionValue,
-					priorRows.map((row) => row.metric_value)
+					otherRowsInScope.map((row) => row.metric_value)
 				);
 				if (placement) {
 					highlights.push({ ...baseHighlight, ...placement });


### PR DESCRIPTION
## What

Session highlights previously used as-of-date semantics: records and placements only compared against sessions up to the viewed session's date, so old sessions read as they would have on the day. This PR switches to all-sessions semantics: every comparison spans all of the group's other sessions in the scope period (all-time / any-season / this-year / this-season), including later ones. A 2023 session now shows "Busiest session ever" only if nothing since has beaten it, and later data can demote a species record to a 2nd/3rd placement.

## Semantics decisions

- Comparison set is every *other* day in scope (`!== date` rather than `< date`); the only-session guard is unchanged in spirit (≥1 other session in scope required).
- **Later ties (symmetric joint):** a later day tying a species count reads "Joint best day for X ever" (`placementRank: 1`), same as a <1yr prior tie. The for-N-years copy describes how long a record stood, so it derives from *prior* tied days only — a prior tie ≥1yr old keeps that copy even when a later day also ties. A session-total tie held only by later days is unreported (no sensible copy).
- Placement tiers and ranks now count later days.

Long-absence retrap highlights (#318/#319, unimplemented) deliberately stay prior-only — "absent for 2 years" is inherently backward-looking. Weight extremes (#320/#321) will follow all-sessions semantics.

## Changes

- `app/models/session-highlights.ts`: dropped the date cutoff from `buildDayTotals` (param removed) and switched both derive functions from prior-days filters to other-days filters; tie branches now compute for-N-years from prior tied days only.
- Model tests updated/extended for the new behaviour matrix (later day beats / lower / ties, later-only tie, prior+later tie, later days in placement tiers, later session as comparison baseline).
- One action test updated: a cached-blob assertion relied on the old as-of behaviour.

Part of #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)