### PR TITLE
feat: first-ever and first-of-year species highlights (session highlights #317)

### DIFF
--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -3,6 +3,7 @@ import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { fetchAllPaginatedRows } from '@/lib/supabase';
 import {
 	deriveFirstEverSpecies,
+	deriveFirstOfYearSpecies,
 	deriveSessionTotalRecords,
 	deriveSpeciesRecords,
 	sortHighlights,
@@ -75,6 +76,7 @@ export async function fetchSessionHighlights({
 	return sortHighlights([
 		...deriveSessionTotalRecords({ date, stats }),
 		...deriveSpeciesRecords({ date, stats }),
-		...deriveFirstEverSpecies({ date, stats })
+		...deriveFirstEverSpecies({ date, stats }),
+		...deriveFirstOfYearSpecies({ date, stats })
 	]);
 }

--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -2,6 +2,7 @@
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { fetchAllPaginatedRows } from '@/lib/supabase';
 import {
+	deriveFirstEverSpecies,
 	deriveSessionTotalRecords,
 	deriveSpeciesRecords,
 	sortHighlights,
@@ -73,6 +74,7 @@ export async function fetchSessionHighlights({
 	const stats = await fetchSessionStats(viewedGroupId);
 	return sortHighlights([
 		...deriveSessionTotalRecords({ date, stats }),
-		...deriveSpeciesRecords({ date, stats })
+		...deriveSpeciesRecords({ date, stats }),
+		...deriveFirstEverSpecies({ date, stats })
 	]);
 }

--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import { SessionHighlights } from '../SessionHighlights';
-import type { SessionHighlight } from '@/app/models/session-highlights';
+import type {
+	FirstEverSpeciesHighlight,
+	SessionHighlight
+} from '@/app/models/session-highlights';
 
 vi.mock('@/app/actions/session-highlights', () => ({
 	fetchSessionHighlights: vi.fn()
@@ -148,5 +151,24 @@ describe('SessionHighlights', () => {
 		expect(items[1].textContent).toBe(
 			'Record day for Reed Warbler — 12 caught, the most ever'
 		);
+	});
+
+	it('renders first-ever sentences', async () => {
+		const firstEverHighlight: FirstEverSpeciesHighlight = {
+			type: 'first-ever-species',
+			speciesName: 'Firecrest'
+		};
+		const { fetchSessionHighlights } =
+			await import('@/app/actions/session-highlights');
+		vi.mocked(fetchSessionHighlights).mockResolvedValue([firstEverHighlight]);
+		render(<SessionHighlights date="2024-09-15" viewedGroupId={1} />);
+		await waitFor(() => {
+			expect(screen.getByRole('heading', { name: 'Highlights' })).toBeDefined();
+		});
+		const items = screen
+			.getByTestId('session-highlights')
+			.querySelectorAll('li');
+		expect(items.length).toBe(1);
+		expect(items[0].textContent).toBe('First ever Firecrest for the group');
 	});
 });

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from 'vitest';
 import {
 	buildHighlightSentence,
 	deriveFirstEverSpecies,
+	deriveFirstOfYearSpecies,
 	deriveSessionTotalRecords,
 	deriveSpeciesRecords,
 	type FirstEverSpeciesHighlight,
+	type FirstOfYearSpeciesHighlight,
 	type SessionStatsData,
 	type SessionTotalRecordHighlight,
 	type SpeciesCountRecordHighlight
@@ -909,6 +911,84 @@ describe('deriveFirstEverSpecies', () => {
 	});
 });
 
+// ---- deriveFirstOfYearSpecies ----
+
+function deriveFirstOfYear(
+	rows: DaySpeciesMetricRow[],
+	{
+		sessionDates,
+		today = PAST_PERIOD_TODAY
+	}: { sessionDates?: string[]; today?: Date } = {}
+) {
+	const stats: SessionStatsData = {
+		daySpeciesCounts: rows,
+		sessionDates: sessionDates ?? [
+			...new Set(rows.map((row) => row.visit_date))
+		]
+	};
+	return deriveFirstOfYearSpecies({ date: SESSION_DATE, stats, today });
+}
+
+describe('deriveFirstOfYearSpecies', () => {
+	it('maps species first seen this year on the session date to first-of-year highlights', () => {
+		const highlights = deriveFirstOfYear([
+			speciesRow(SESSION_DATE, FIRECREST, 1),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, FIRECREST, 2),
+			speciesRow(SESSION_DATE, REED_WARBLER, 3),
+			speciesRow(PRIOR_SPRING_THIS_YEAR, REED_WARBLER, 2)
+		]);
+		// Firecrest was seen in a previous year but not yet this year
+		expect(highlights).toEqual([
+			{
+				type: 'first-of-year-species',
+				speciesName: FIRECREST,
+				year: 2024,
+				isCurrentYear: false
+			}
+		]);
+	});
+
+	it('excludes first-ever species — the first-ever highlight covers them', () => {
+		const highlights = deriveFirstOfYear([
+			speciesRow(SESSION_DATE, FIRECREST, 1),
+			speciesRow(PRIOR_SPRING_THIS_YEAR, REED_WARBLER, 2)
+		]);
+		expect(highlights).toEqual([]);
+	});
+
+	it('flags the current year when today is within the session year', () => {
+		const highlights = deriveFirstOfYear(
+			[
+				speciesRow(SESSION_DATE, FIRECREST, 1),
+				speciesRow(PRIOR_SPRING_OTHER_YEAR, FIRECREST, 2),
+				speciesRow(PRIOR_SPRING_THIS_YEAR, REED_WARBLER, 2)
+			],
+			{ today: new Date('2024-10-01') }
+		);
+		expect(highlights).toEqual([
+			expect.objectContaining({ speciesName: FIRECREST, isCurrentYear: true })
+		]);
+	});
+
+	it("returns empty for the group's first session of the year", () => {
+		// Prior sessions exist, but none this year — every species would be
+		// first of the year, so suppress all
+		const highlights = deriveFirstOfYear([
+			speciesRow(SESSION_DATE, FIRECREST, 1),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, FIRECREST, 2)
+		]);
+		expect(highlights).toEqual([]);
+	});
+
+	it('returns empty when every species was already seen this year', () => {
+		const highlights = deriveFirstOfYear([
+			speciesRow(SESSION_DATE, REED_WARBLER, 5),
+			speciesRow(PRIOR_SPRING_THIS_YEAR, REED_WARBLER, 3)
+		]);
+		expect(highlights).toEqual([]);
+	});
+});
+
 // ---- buildHighlightSentence — first-ever-species ----
 
 function makeFirstEverHighlight(
@@ -925,6 +1005,34 @@ describe('buildHighlightSentence — first-ever-species', () => {
 	it('renders first-ever copy', () => {
 		expect(buildHighlightSentence(makeFirstEverHighlight())).toBe(
 			'First ever Firecrest for the group'
+		);
+	});
+});
+
+// ---- buildHighlightSentence — first-of-year-species ----
+
+function makeFirstOfYearHighlight(
+	overrides: Partial<FirstOfYearSpeciesHighlight> = {}
+): FirstOfYearSpeciesHighlight {
+	return {
+		type: 'first-of-year-species',
+		speciesName: 'Firecrest',
+		year: 2024,
+		isCurrentYear: false,
+		...overrides
+	};
+}
+
+describe('buildHighlightSentence — first-of-year-species', () => {
+	it('renders "of the year" copy while the session year is current', () => {
+		expect(
+			buildHighlightSentence(makeFirstOfYearHighlight({ isCurrentYear: true }))
+		).toBe('First Firecrest of the year');
+	});
+
+	it('renders the absolute year once the session year has passed', () => {
+		expect(buildHighlightSentence(makeFirstOfYearHighlight())).toBe(
+			'First Firecrest of 2024'
 		);
 	});
 });

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
 	buildHighlightSentence,
+	deriveFirstEverSpecies,
 	deriveSessionTotalRecords,
 	deriveSpeciesRecords,
+	type FirstEverSpeciesHighlight,
 	type SessionStatsData,
 	type SessionTotalRecordHighlight,
 	type SpeciesCountRecordHighlight
@@ -855,5 +857,74 @@ describe('buildHighlightSentence — species-count-record', () => {
 				})
 			)
 		).toBe('Joint 3rd-best day for Reed Warbler ever — 8 birds');
+	});
+});
+
+// ---- deriveFirstEverSpecies ----
+
+const FIRECREST = 'Firecrest';
+
+function deriveFirstEver(rows: DaySpeciesMetricRow[], sessionDates?: string[]) {
+	const daySpeciesCounts = rows;
+	const stats: SessionStatsData = {
+		daySpeciesCounts,
+		sessionDates: sessionDates ?? [
+			...new Set(rows.map((row) => row.visit_date))
+		]
+	};
+	return deriveFirstEverSpecies({ date: SESSION_DATE, stats });
+}
+
+describe('deriveFirstEverSpecies', () => {
+	it('maps species whose earliest date is the session date to first-ever highlights', () => {
+		const highlights = deriveFirstEver([
+			speciesRow(SESSION_DATE, FIRECREST, 1),
+			speciesRow(SESSION_DATE, REED_WARBLER, 3),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 2)
+		]);
+		// Firecrest appears for the first time on the session date
+		expect(highlights).toContainEqual({
+			type: 'first-ever-species',
+			speciesName: FIRECREST
+		});
+		// Reed Warbler was seen before — not first-ever
+		expect(highlights.map((h) => h.speciesName)).not.toContain(REED_WARBLER);
+	});
+
+	it("returns empty for the group's first-ever session", () => {
+		// No prior session dates — every species would be first-ever, so suppress all
+		const highlights = deriveFirstEver(
+			[speciesRow(SESSION_DATE, FIRECREST, 1)],
+			[SESSION_DATE]
+		);
+		expect(highlights).toEqual([]);
+	});
+
+	it('returns empty when no species is new', () => {
+		const highlights = deriveFirstEver([
+			speciesRow(SESSION_DATE, REED_WARBLER, 5),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 3)
+		]);
+		expect(highlights).toEqual([]);
+	});
+});
+
+// ---- buildHighlightSentence — first-ever-species ----
+
+function makeFirstEverHighlight(
+	overrides: Partial<FirstEverSpeciesHighlight> = {}
+): FirstEverSpeciesHighlight {
+	return {
+		type: 'first-ever-species',
+		speciesName: 'Firecrest',
+		...overrides
+	};
+}
+
+describe('buildHighlightSentence — first-ever-species', () => {
+	it('renders first-ever copy', () => {
+		expect(buildHighlightSentence(makeFirstEverHighlight())).toBe(
+			'First ever Firecrest for the group'
+		);
 	});
 });

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -69,10 +69,20 @@ export type FirstEverSpeciesHighlight = {
 	speciesName: string;
 };
 
+export type FirstOfYearSpeciesHighlight = {
+	type: 'first-of-year-species';
+	speciesName: string;
+	year: number;
+	// 'of the year' copy is only correct while the session's year is current;
+	// otherwise the sentence uses the absolute year
+	isCurrentYear: boolean;
+};
+
 export type SessionHighlight =
 	| SessionTotalRecordHighlight
 	| SpeciesCountRecordHighlight
-	| FirstEverSpeciesHighlight;
+	| FirstEverSpeciesHighlight
+	| FirstOfYearSpeciesHighlight;
 
 type PeriodFields = {
 	scope: RecordScope;
@@ -394,10 +404,57 @@ export function deriveFirstEverSpecies({
 		}));
 }
 
+// Returns a highlight for each species seen for the first time this calendar
+// year on this session. First-ever species are excluded (the broader
+// first-ever highlight covers them), and the group's first session of the
+// year is suppressed entirely (every species would trivially be first of
+// the year).
+export function deriveFirstOfYearSpecies({
+	date,
+	stats,
+	today = new Date()
+}: {
+	date: string;
+	stats: SessionStatsData;
+	today?: Date;
+}): FirstOfYearSpeciesHighlight[] {
+	const sessionRows = stats.daySpeciesCounts.filter(
+		(row) => row.visit_date === date
+	);
+	if (sessionRows.length === 0) return [];
+	const yearPrefix = `${date.slice(0, 4)}-`;
+	// Suppress on the group's first session of the year
+	const priorSessionDatesThisYear = stats.sessionDates.filter(
+		(sessionDate) => sessionDate.startsWith(yearPrefix) && sessionDate < date
+	);
+	if (priorSessionDatesThisYear.length === 0) return [];
+	const year = Number(date.slice(0, 4));
+	return sessionRows
+		.map((row) => row.species_name)
+		.filter((speciesName) => {
+			const priorDates = stats.daySpeciesCounts
+				.filter(
+					(row) => row.species_name === speciesName && row.visit_date < date
+				)
+				.map((row) => row.visit_date);
+			return (
+				priorDates.length > 0 &&
+				!priorDates.some((priorDate) => priorDate.startsWith(yearPrefix))
+			);
+		})
+		.map((speciesName) => ({
+			type: 'first-of-year-species' as const,
+			speciesName,
+			year,
+			isCurrentYear: year === today.getFullYear()
+		}));
+}
+
 const HIGHLIGHT_TYPE_PRIORITY: SessionHighlight['type'][] = [
 	'session-total-record',
 	'species-count-record',
-	'first-ever-species'
+	'first-ever-species',
+	'first-of-year-species'
 ];
 
 export function sortHighlights(
@@ -474,5 +531,9 @@ export function buildHighlightSentence(highlight: SessionHighlight): string {
 			return buildSpeciesCountRecordSentence(highlight);
 		case 'first-ever-species':
 			return `First ever ${highlight.speciesName} for the group`;
+		case 'first-of-year-species':
+			return `First ${highlight.speciesName} ${
+				highlight.isCurrentYear ? 'of the year' : `of ${highlight.year}`
+			}`;
 	}
 }

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -64,9 +64,15 @@ export type SpeciesCountRecordHighlight = {
 	isJointPlacement?: boolean;
 };
 
+export type FirstEverSpeciesHighlight = {
+	type: 'first-ever-species';
+	speciesName: string;
+};
+
 export type SessionHighlight =
 	| SessionTotalRecordHighlight
-	| SpeciesCountRecordHighlight;
+	| SpeciesCountRecordHighlight
+	| FirstEverSpeciesHighlight;
 
 type PeriodFields = {
 	scope: RecordScope;
@@ -354,9 +360,44 @@ export function deriveSpeciesRecords({
 	return highlights;
 }
 
+// Returns a highlight for each species seen for the first time on this session.
+// Suppressed entirely for the group's first-ever session (every species would
+// be first, making the highlights uninformative).
+export function deriveFirstEverSpecies({
+	date,
+	stats
+}: {
+	date: string;
+	stats: SessionStatsData;
+}): FirstEverSpeciesHighlight[] {
+	const sessionRows = stats.daySpeciesCounts.filter(
+		(row) => row.visit_date === date
+	);
+	if (sessionRows.length === 0) return [];
+	// Suppress on the group's first-ever session
+	const priorSessionDates = stats.sessionDates.filter(
+		(sessionDate) => sessionDate < date
+	);
+	if (priorSessionDates.length === 0) return [];
+	// Find species with no appearance before this session
+	const speciesOnSession = sessionRows.map((row) => row.species_name);
+	return speciesOnSession
+		.filter(
+			(speciesName) =>
+				!stats.daySpeciesCounts.some(
+					(row) => row.species_name === speciesName && row.visit_date < date
+				)
+		)
+		.map((speciesName) => ({
+			type: 'first-ever-species' as const,
+			speciesName
+		}));
+}
+
 const HIGHLIGHT_TYPE_PRIORITY: SessionHighlight['type'][] = [
 	'session-total-record',
-	'species-count-record'
+	'species-count-record',
+	'first-ever-species'
 ];
 
 export function sortHighlights(
@@ -431,5 +472,7 @@ export function buildHighlightSentence(highlight: SessionHighlight): string {
 			return buildSessionTotalRecordSentence(highlight);
 		case 'species-count-record':
 			return buildSpeciesCountRecordSentence(highlight);
+		case 'first-ever-species':
+			return `First ever ${highlight.speciesName} for the group`;
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `FirstEverSpeciesHighlight` type (`type: 'first-ever-species'`) to the `SessionHighlight` discriminated union in `app/models/session-highlights.ts`
- Implements `deriveFirstEverSpecies` — finds species whose first appearance in the stats blob is on the session date; suppressed entirely on the group's first-ever session to avoid trivial noise
- Extends `buildHighlightSentence` with the `'first-ever-species'` case → "First ever Firecrest for the group"
- Adds `FirstOfYearSpeciesHighlight` type (`type: 'first-of-year-species'`) and `deriveFirstOfYearSpecies` — species seen in a previous year but not yet this calendar year. First-ever species are excluded (the broader highlight covers them), and the group's first session of the year is suppressed. Copy follows the current-period rule: "First Firecrest of the year" while the session year is current, else "First Firecrest of 2024"
- Adds `'first-ever-species'` then `'first-of-year-species'` after `'species-count-record'` in `sortHighlights` priority order
- Extends `fetchSessionHighlights` action to fan-in both derivations

Closes #317

## Test plan

- [x] `describe deriveFirstEverSpecies` — maps new species, returns empty for first-ever session, returns empty when no species is new
- [x] `describe deriveFirstOfYearSpecies` — maps species first seen this year, excludes first-ever species, flags current year, returns empty for first session of year / when nothing is new this year
- [x] `describe buildHighlightSentence — first-ever-species` — renders first-ever copy
- [x] `describe buildHighlightSentence — first-of-year-species` — current-year and absolute-year copy
- [x] `describe SessionHighlights` — renders first-ever sentences
- [x] All 323 app tests passing; lint and type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)