### PR TITLE
feat: report "Only X record(s)" when a first is also the only record

### DIFF
--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -156,7 +156,9 @@ describe('SessionHighlights', () => {
 	it('renders first-ever sentences', async () => {
 		const firstEverHighlight: FirstEverSpeciesHighlight = {
 			type: 'first-ever-species',
-			speciesName: 'Firecrest'
+			speciesName: 'Firecrest',
+			multipleIndividualsRecorded: false,
+			isOnlyRecord: false
 		};
 		const { fetchSessionHighlights } =
 			await import('@/app/actions/session-highlights');
@@ -169,6 +171,6 @@ describe('SessionHighlights', () => {
 			.getByTestId('session-highlights')
 			.querySelectorAll('li');
 		expect(items.length).toBe(1);
-		expect(items[0].textContent).toBe('First ever Firecrest for the group');
+		expect(items[0].textContent).toBe('First ever Firecrest record');
 	});
 });

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -888,13 +888,15 @@ describe('deriveFirstEverSpecies', () => {
 		// Firecrest appears for the first time on the session date
 		expect(highlights).toContainEqual({
 			type: 'first-ever-species',
-			speciesName: FIRECREST
+			speciesName: FIRECREST,
+			multipleIndividualsRecorded: false,
+			isOnlyRecord: false
 		});
 		// Reed Warbler was seen before — not first-ever
 		expect(highlights.map((h) => h.speciesName)).not.toContain(REED_WARBLER);
 	});
 
-	it('sets onlyRecordCount when the species appears on no other day', () => {
+	it('flags isOnlyRecord when the species appears on no other day', () => {
 		const highlights = deriveFirstEver([
 			speciesRow(SESSION_DATE, FIRECREST, 3),
 			speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 2)
@@ -903,19 +905,25 @@ describe('deriveFirstEverSpecies', () => {
 			{
 				type: 'first-ever-species',
 				speciesName: FIRECREST,
-				onlyRecordCount: 3
+				multipleIndividualsRecorded: true,
+				isOnlyRecord: true
 			}
 		]);
 	});
 
-	it('does not set onlyRecordCount when the species appears on a later day', () => {
+	it('does not flag isOnlyRecord when the species appears on a later day', () => {
 		const highlights = deriveFirstEver([
 			speciesRow(SESSION_DATE, FIRECREST, 3),
 			speciesRow(LATER_DAY, FIRECREST, 1),
 			speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 2)
 		]);
 		expect(highlights).toEqual([
-			{ type: 'first-ever-species', speciesName: FIRECREST }
+			{
+				type: 'first-ever-species',
+				speciesName: FIRECREST,
+				multipleIndividualsRecorded: true,
+				isOnlyRecord: false
+			}
 		]);
 	});
 
@@ -970,12 +978,14 @@ describe('deriveFirstOfYearSpecies', () => {
 				type: 'first-of-year-species',
 				speciesName: FIRECREST,
 				year: 2024,
-				isCurrentYear: false
+				isCurrentYear: false,
+				multipleIndividualsRecorded: false,
+				isOnlyRecord: false
 			}
 		]);
 	});
 
-	it('sets onlyRecordCount when the species appears on no other day this year', () => {
+	it('flags isOnlyRecord when the species appears on no other day this year', () => {
 		// Prior-year records are what make it first-of-year — they don't
 		// revoke the "only" copy
 		const highlights = deriveFirstOfYear([
@@ -989,12 +999,13 @@ describe('deriveFirstOfYearSpecies', () => {
 				speciesName: FIRECREST,
 				year: 2024,
 				isCurrentYear: false,
-				onlyRecordCount: 2
+				multipleIndividualsRecorded: true,
+				isOnlyRecord: true
 			}
 		]);
 	});
 
-	it('does not set onlyRecordCount when the species appears later in the same year', () => {
+	it('does not flag isOnlyRecord when the species appears later in the same year', () => {
 		const highlights = deriveFirstOfYear([
 			speciesRow(SESSION_DATE, FIRECREST, 2),
 			speciesRow(LATER_DAY, FIRECREST, 1),
@@ -1006,7 +1017,9 @@ describe('deriveFirstOfYearSpecies', () => {
 				type: 'first-of-year-species',
 				speciesName: FIRECREST,
 				year: 2024,
-				isCurrentYear: false
+				isCurrentYear: false,
+				multipleIndividualsRecorded: true,
+				isOnlyRecord: false
 			}
 		]);
 	});
@@ -1060,6 +1073,8 @@ function makeFirstEverHighlight(
 	return {
 		type: 'first-ever-species',
 		speciesName: 'Firecrest',
+		multipleIndividualsRecorded: false,
+		isOnlyRecord: false,
 		...overrides
 	};
 }
@@ -1067,19 +1082,32 @@ function makeFirstEverHighlight(
 describe('buildHighlightSentence — first-ever-species', () => {
 	it('renders first-ever copy', () => {
 		expect(buildHighlightSentence(makeFirstEverHighlight())).toBe(
-			'First ever Firecrest for the group'
+			'First ever Firecrest record'
 		);
+	});
+
+	it('renders plural first-ever copy for multiple individuals', () => {
+		expect(
+			buildHighlightSentence(
+				makeFirstEverHighlight({ multipleIndividualsRecorded: true })
+			)
+		).toBe('First ever Firecrest records');
 	});
 
 	it('renders only-record copy when the session holds the only record', () => {
 		expect(
-			buildHighlightSentence(makeFirstEverHighlight({ onlyRecordCount: 1 }))
+			buildHighlightSentence(makeFirstEverHighlight({ isOnlyRecord: true }))
 		).toBe('Only Firecrest record ever');
 	});
 
-	it('renders plural only-record copy for multiple encounters', () => {
+	it('renders plural only-record copy for multiple individuals', () => {
 		expect(
-			buildHighlightSentence(makeFirstEverHighlight({ onlyRecordCount: 3 }))
+			buildHighlightSentence(
+				makeFirstEverHighlight({
+					isOnlyRecord: true,
+					multipleIndividualsRecorded: true
+				})
+			)
 		).toBe('Only Firecrest records ever');
 	});
 });
@@ -1094,6 +1122,8 @@ function makeFirstOfYearHighlight(
 		speciesName: 'Firecrest',
 		year: 2024,
 		isCurrentYear: false,
+		multipleIndividualsRecorded: false,
+		isOnlyRecord: false,
 		...overrides
 	};
 }
@@ -1102,26 +1132,39 @@ describe('buildHighlightSentence — first-of-year-species', () => {
 	it('renders "of the year" copy while the session year is current', () => {
 		expect(
 			buildHighlightSentence(makeFirstOfYearHighlight({ isCurrentYear: true }))
-		).toBe('First Firecrest of the year');
+		).toBe('First Firecrest record of the year');
 	});
 
 	it('renders the absolute year once the session year has passed', () => {
 		expect(buildHighlightSentence(makeFirstOfYearHighlight())).toBe(
-			'First Firecrest of 2024'
+			'First Firecrest record of 2024'
 		);
+	});
+
+	it('renders plural first-of-year copy for multiple individuals', () => {
+		expect(
+			buildHighlightSentence(
+				makeFirstOfYearHighlight({ multipleIndividualsRecorded: true })
+			)
+		).toBe('First Firecrest records of 2024');
 	});
 
 	it('renders only-record copy while the session year is current', () => {
 		expect(
 			buildHighlightSentence(
-				makeFirstOfYearHighlight({ isCurrentYear: true, onlyRecordCount: 1 })
+				makeFirstOfYearHighlight({ isCurrentYear: true, isOnlyRecord: true })
 			)
 		).toBe('Only Firecrest record of the year');
 	});
 
 	it('renders plural only-record copy once the session year has passed', () => {
 		expect(
-			buildHighlightSentence(makeFirstOfYearHighlight({ onlyRecordCount: 3 }))
+			buildHighlightSentence(
+				makeFirstOfYearHighlight({
+					isOnlyRecord: true,
+					multipleIndividualsRecorded: true
+				})
+			)
 		).toBe('Only Firecrest records of 2024');
 	});
 });

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -881,6 +881,7 @@ describe('deriveFirstEverSpecies', () => {
 	it('maps species whose earliest date is the session date to first-ever highlights', () => {
 		const highlights = deriveFirstEver([
 			speciesRow(SESSION_DATE, FIRECREST, 1),
+			speciesRow(LATER_DAY, FIRECREST, 2),
 			speciesRow(SESSION_DATE, REED_WARBLER, 3),
 			speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 2)
 		]);
@@ -891,6 +892,31 @@ describe('deriveFirstEverSpecies', () => {
 		});
 		// Reed Warbler was seen before — not first-ever
 		expect(highlights.map((h) => h.speciesName)).not.toContain(REED_WARBLER);
+	});
+
+	it('sets onlyRecordCount when the species appears on no other day', () => {
+		const highlights = deriveFirstEver([
+			speciesRow(SESSION_DATE, FIRECREST, 3),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 2)
+		]);
+		expect(highlights).toEqual([
+			{
+				type: 'first-ever-species',
+				speciesName: FIRECREST,
+				onlyRecordCount: 3
+			}
+		]);
+	});
+
+	it('does not set onlyRecordCount when the species appears on a later day', () => {
+		const highlights = deriveFirstEver([
+			speciesRow(SESSION_DATE, FIRECREST, 3),
+			speciesRow(LATER_DAY, FIRECREST, 1),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, REED_WARBLER, 2)
+		]);
+		expect(highlights).toEqual([
+			{ type: 'first-ever-species', speciesName: FIRECREST }
+		]);
 	});
 
 	it("returns empty for the group's first-ever session", () => {
@@ -933,11 +959,48 @@ describe('deriveFirstOfYearSpecies', () => {
 	it('maps species first seen this year on the session date to first-of-year highlights', () => {
 		const highlights = deriveFirstOfYear([
 			speciesRow(SESSION_DATE, FIRECREST, 1),
+			speciesRow(LATER_DAY, FIRECREST, 2),
 			speciesRow(PRIOR_SPRING_OTHER_YEAR, FIRECREST, 2),
 			speciesRow(SESSION_DATE, REED_WARBLER, 3),
 			speciesRow(PRIOR_SPRING_THIS_YEAR, REED_WARBLER, 2)
 		]);
 		// Firecrest was seen in a previous year but not yet this year
+		expect(highlights).toEqual([
+			{
+				type: 'first-of-year-species',
+				speciesName: FIRECREST,
+				year: 2024,
+				isCurrentYear: false
+			}
+		]);
+	});
+
+	it('sets onlyRecordCount when the species appears on no other day this year', () => {
+		// Prior-year records are what make it first-of-year — they don't
+		// revoke the "only" copy
+		const highlights = deriveFirstOfYear([
+			speciesRow(SESSION_DATE, FIRECREST, 2),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, FIRECREST, 4),
+			speciesRow(PRIOR_SPRING_THIS_YEAR, REED_WARBLER, 2)
+		]);
+		expect(highlights).toEqual([
+			{
+				type: 'first-of-year-species',
+				speciesName: FIRECREST,
+				year: 2024,
+				isCurrentYear: false,
+				onlyRecordCount: 2
+			}
+		]);
+	});
+
+	it('does not set onlyRecordCount when the species appears later in the same year', () => {
+		const highlights = deriveFirstOfYear([
+			speciesRow(SESSION_DATE, FIRECREST, 2),
+			speciesRow(LATER_DAY, FIRECREST, 1),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, FIRECREST, 4),
+			speciesRow(PRIOR_SPRING_THIS_YEAR, REED_WARBLER, 2)
+		]);
 		expect(highlights).toEqual([
 			{
 				type: 'first-of-year-species',
@@ -1007,6 +1070,18 @@ describe('buildHighlightSentence — first-ever-species', () => {
 			'First ever Firecrest for the group'
 		);
 	});
+
+	it('renders only-record copy when the session holds the only record', () => {
+		expect(
+			buildHighlightSentence(makeFirstEverHighlight({ onlyRecordCount: 1 }))
+		).toBe('Only Firecrest record ever');
+	});
+
+	it('renders plural only-record copy for multiple encounters', () => {
+		expect(
+			buildHighlightSentence(makeFirstEverHighlight({ onlyRecordCount: 3 }))
+		).toBe('Only Firecrest records ever');
+	});
 });
 
 // ---- buildHighlightSentence — first-of-year-species ----
@@ -1034,5 +1109,19 @@ describe('buildHighlightSentence — first-of-year-species', () => {
 		expect(buildHighlightSentence(makeFirstOfYearHighlight())).toBe(
 			'First Firecrest of 2024'
 		);
+	});
+
+	it('renders only-record copy while the session year is current', () => {
+		expect(
+			buildHighlightSentence(
+				makeFirstOfYearHighlight({ isCurrentYear: true, onlyRecordCount: 1 })
+			)
+		).toBe('Only Firecrest record of the year');
+	});
+
+	it('renders plural only-record copy once the session year has passed', () => {
+		expect(
+			buildHighlightSentence(makeFirstOfYearHighlight({ onlyRecordCount: 3 }))
+		).toBe('Only Firecrest records of 2024');
 	});
 });

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -67,6 +67,9 @@ export type SpeciesCountRecordHighlight = {
 export type FirstEverSpeciesHighlight = {
 	type: 'first-ever-species';
 	speciesName: string;
+	// Set only when the session holds the species' only records ever
+	// (no other day in the data, before or after); drives pluralisation
+	onlyRecordCount?: number;
 };
 
 export type FirstOfYearSpeciesHighlight = {
@@ -76,6 +79,9 @@ export type FirstOfYearSpeciesHighlight = {
 	// 'of the year' copy is only correct while the session's year is current;
 	// otherwise the sentence uses the absolute year
 	isCurrentYear: boolean;
+	// Set only when the session holds the species' only records this calendar
+	// year (no other day in the year, before or after); drives pluralisation
+	onlyRecordCount?: number;
 };
 
 export type SessionHighlight =
@@ -390,18 +396,29 @@ export function deriveFirstEverSpecies({
 	);
 	if (priorSessionDates.length === 0) return [];
 	// Find species with no appearance before this session
-	const speciesOnSession = sessionRows.map((row) => row.species_name);
-	return speciesOnSession
+	return sessionRows
 		.filter(
-			(speciesName) =>
+			(sessionRow) =>
 				!stats.daySpeciesCounts.some(
-					(row) => row.species_name === speciesName && row.visit_date < date
+					(row) =>
+						row.species_name === sessionRow.species_name &&
+						row.visit_date < date
 				)
 		)
-		.map((speciesName) => ({
-			type: 'first-ever-species' as const,
-			speciesName
-		}));
+		.map((sessionRow) => {
+			// The species' only records ever — later days revoke this, so a
+			// "first ever" can lose its "only" copy as more data arrives
+			const isOnlyRecord = !stats.daySpeciesCounts.some(
+				(row) =>
+					row.species_name === sessionRow.species_name &&
+					row.visit_date !== date
+			);
+			return {
+				type: 'first-ever-species' as const,
+				speciesName: sessionRow.species_name,
+				...(isOnlyRecord ? { onlyRecordCount: sessionRow.metric_value } : {})
+			};
+		});
 }
 
 // Returns a highlight for each species seen for the first time this calendar
@@ -430,11 +447,12 @@ export function deriveFirstOfYearSpecies({
 	if (priorSessionDatesThisYear.length === 0) return [];
 	const year = Number(date.slice(0, 4));
 	return sessionRows
-		.map((row) => row.species_name)
-		.filter((speciesName) => {
+		.filter((sessionRow) => {
 			const priorDates = stats.daySpeciesCounts
 				.filter(
-					(row) => row.species_name === speciesName && row.visit_date < date
+					(row) =>
+						row.species_name === sessionRow.species_name &&
+						row.visit_date < date
 				)
 				.map((row) => row.visit_date);
 			return (
@@ -442,12 +460,26 @@ export function deriveFirstOfYearSpecies({
 				!priorDates.some((priorDate) => priorDate.startsWith(yearPrefix))
 			);
 		})
-		.map((speciesName) => ({
-			type: 'first-of-year-species' as const,
-			speciesName,
-			year,
-			isCurrentYear: year === today.getFullYear()
-		}));
+		.map((sessionRow) => {
+			// The species' only records this calendar year — a later day in the
+			// same year revokes this; prior-year records don't (they're what
+			// makes it first-of-year rather than first-ever)
+			const isOnlyRecordThisYear = !stats.daySpeciesCounts.some(
+				(row) =>
+					row.species_name === sessionRow.species_name &&
+					row.visit_date !== date &&
+					row.visit_date.startsWith(yearPrefix)
+			);
+			return {
+				type: 'first-of-year-species' as const,
+				speciesName: sessionRow.species_name,
+				year,
+				isCurrentYear: year === today.getFullYear(),
+				...(isOnlyRecordThisYear
+					? { onlyRecordCount: sessionRow.metric_value }
+					: {})
+			};
+		});
 }
 
 const HIGHLIGHT_TYPE_PRIORITY: SessionHighlight['type'][] = [
@@ -523,6 +555,10 @@ function buildSpeciesCountRecordSentence(
 	return `Record day for ${speciesName} — ${valueCopy}, ${mostPhrase}`;
 }
 
+function buildOnlyRecordPhrase(speciesName: string, count: number): string {
+	return `Only ${speciesName} record${count > 1 ? 's' : ''}`;
+}
+
 export function buildHighlightSentence(highlight: SessionHighlight): string {
 	switch (highlight.type) {
 		case 'session-total-record':
@@ -530,10 +566,16 @@ export function buildHighlightSentence(highlight: SessionHighlight): string {
 		case 'species-count-record':
 			return buildSpeciesCountRecordSentence(highlight);
 		case 'first-ever-species':
-			return `First ever ${highlight.speciesName} for the group`;
-		case 'first-of-year-species':
-			return `First ${highlight.speciesName} ${
-				highlight.isCurrentYear ? 'of the year' : `of ${highlight.year}`
-			}`;
+			return highlight.onlyRecordCount !== undefined
+				? `${buildOnlyRecordPhrase(highlight.speciesName, highlight.onlyRecordCount)} ever`
+				: `First ever ${highlight.speciesName} for the group`;
+		case 'first-of-year-species': {
+			const yearPhrase = highlight.isCurrentYear
+				? 'of the year'
+				: `of ${highlight.year}`;
+			return highlight.onlyRecordCount !== undefined
+				? `${buildOnlyRecordPhrase(highlight.speciesName, highlight.onlyRecordCount)} ${yearPhrase}`
+				: `First ${highlight.speciesName} ${yearPhrase}`;
+		}
 	}
 }

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -67,9 +67,11 @@ export type SpeciesCountRecordHighlight = {
 export type FirstEverSpeciesHighlight = {
 	type: 'first-ever-species';
 	speciesName: string;
-	// Set only when the session holds the species' only records ever
-	// (no other day in the data, before or after); drives pluralisation
-	onlyRecordCount?: number;
+	// More than one encounter of the species this session — 'record' vs 'records'
+	multipleIndividualsRecorded: boolean;
+	// The session holds the species' only records ever (no other day in the
+	// data, before or after) — 'Only' copy instead of 'First'
+	isOnlyRecord: boolean;
 };
 
 export type FirstOfYearSpeciesHighlight = {
@@ -79,9 +81,11 @@ export type FirstOfYearSpeciesHighlight = {
 	// 'of the year' copy is only correct while the session's year is current;
 	// otherwise the sentence uses the absolute year
 	isCurrentYear: boolean;
-	// Set only when the session holds the species' only records this calendar
-	// year (no other day in the year, before or after); drives pluralisation
-	onlyRecordCount?: number;
+	// More than one encounter of the species this session — 'record' vs 'records'
+	multipleIndividualsRecorded: boolean;
+	// The session holds the species' only records this calendar year (no other
+	// day in the year, before or after) — 'Only' copy instead of 'First'
+	isOnlyRecord: boolean;
 };
 
 export type SessionHighlight =
@@ -405,20 +409,18 @@ export function deriveFirstEverSpecies({
 						row.visit_date < date
 				)
 		)
-		.map((sessionRow) => {
+		.map((sessionRow) => ({
+			type: 'first-ever-species' as const,
+			speciesName: sessionRow.species_name,
+			multipleIndividualsRecorded: sessionRow.metric_value > 1,
 			// The species' only records ever — later days revoke this, so a
 			// "first ever" can lose its "only" copy as more data arrives
-			const isOnlyRecord = !stats.daySpeciesCounts.some(
+			isOnlyRecord: !stats.daySpeciesCounts.some(
 				(row) =>
 					row.species_name === sessionRow.species_name &&
 					row.visit_date !== date
-			);
-			return {
-				type: 'first-ever-species' as const,
-				speciesName: sessionRow.species_name,
-				...(isOnlyRecord ? { onlyRecordCount: sessionRow.metric_value } : {})
-			};
-		});
+			)
+		}));
 }
 
 // Returns a highlight for each species seen for the first time this calendar
@@ -460,26 +462,22 @@ export function deriveFirstOfYearSpecies({
 				!priorDates.some((priorDate) => priorDate.startsWith(yearPrefix))
 			);
 		})
-		.map((sessionRow) => {
+		.map((sessionRow) => ({
+			type: 'first-of-year-species' as const,
+			speciesName: sessionRow.species_name,
+			year,
+			isCurrentYear: year === today.getFullYear(),
+			multipleIndividualsRecorded: sessionRow.metric_value > 1,
 			// The species' only records this calendar year — a later day in the
 			// same year revokes this; prior-year records don't (they're what
 			// makes it first-of-year rather than first-ever)
-			const isOnlyRecordThisYear = !stats.daySpeciesCounts.some(
+			isOnlyRecord: !stats.daySpeciesCounts.some(
 				(row) =>
 					row.species_name === sessionRow.species_name &&
 					row.visit_date !== date &&
 					row.visit_date.startsWith(yearPrefix)
-			);
-			return {
-				type: 'first-of-year-species' as const,
-				speciesName: sessionRow.species_name,
-				year,
-				isCurrentYear: year === today.getFullYear(),
-				...(isOnlyRecordThisYear
-					? { onlyRecordCount: sessionRow.metric_value }
-					: {})
-			};
-		});
+			)
+		}));
 }
 
 const HIGHLIGHT_TYPE_PRIORITY: SessionHighlight['type'][] = [
@@ -555,8 +553,10 @@ function buildSpeciesCountRecordSentence(
 	return `Record day for ${speciesName} — ${valueCopy}, ${mostPhrase}`;
 }
 
-function buildOnlyRecordPhrase(speciesName: string, count: number): string {
-	return `Only ${speciesName} record${count > 1 ? 's' : ''}`;
+function buildSpeciesRecordsPhrase(
+	highlight: FirstEverSpeciesHighlight | FirstOfYearSpeciesHighlight
+): string {
+	return `${highlight.speciesName} record${highlight.multipleIndividualsRecorded ? 's' : ''}`;
 }
 
 export function buildHighlightSentence(highlight: SessionHighlight): string {
@@ -566,16 +566,14 @@ export function buildHighlightSentence(highlight: SessionHighlight): string {
 		case 'species-count-record':
 			return buildSpeciesCountRecordSentence(highlight);
 		case 'first-ever-species':
-			return highlight.onlyRecordCount !== undefined
-				? `${buildOnlyRecordPhrase(highlight.speciesName, highlight.onlyRecordCount)} ever`
-				: `First ever ${highlight.speciesName} for the group`;
+			return highlight.isOnlyRecord
+				? `Only ${buildSpeciesRecordsPhrase(highlight)} ever`
+				: `First ever ${buildSpeciesRecordsPhrase(highlight)}`;
 		case 'first-of-year-species': {
 			const yearPhrase = highlight.isCurrentYear
 				? 'of the year'
 				: `of ${highlight.year}`;
-			return highlight.onlyRecordCount !== undefined
-				? `${buildOnlyRecordPhrase(highlight.speciesName, highlight.onlyRecordCount)} ${yearPhrase}`
-				: `First ${highlight.speciesName} ${yearPhrase}`;
+			return `${highlight.isOnlyRecord ? 'Only' : 'First'} ${buildSpeciesRecordsPhrase(highlight)} ${yearPhrase}`;
 		}
 	}
 }


### PR DESCRIPTION
Implements #338.

When a first-ever or first-of-year species highlight is also the **only** record of that species in scope, the sentence becomes the "Only" variant instead:

- `Only Wren record ever` / `Only Wren records ever` (first-ever, no other day with the species anywhere)
- `Only Wren record of the year` / `Only Wren records of 2024` (first-of-year, no other day with the species in the session's calendar year; prior-year records don't revoke it — they are what makes it first-of-year)

## Decisions (agreed with user)

- **Copy**: pluralised by the session's encounter count for the species, no numeral shown.
- **"Only" semantics**: all-sessions — later records revoke the "Only" copy (the plain first-ever/first-of-year sentence stays).
- Same highlight, different copy — not an additional highlight. No season variant.

## Implementation

- `app/models/session-highlights.ts`: optional `onlyRecordCount` on `FirstEverSpeciesHighlight` / `FirstOfYearSpeciesHighlight` (mirrors the `recordEqualledYearsAgo?` conditional-field convention); derive functions set it; `buildHighlightSentence` branches on it.
- No action/component/DB changes — the sentence builder already feeds the UI.
- 8 new model tests; two existing derive tests gained a later-day row so they keep exercising the plain (non-only) copy.

## Testing

- `npm run qa` — 331 app tests pass
- Pre-push hook — app + DB integration + e2e suites pass

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)