### PR TITLE
feat: show proven age on session page records (#220)

### DIFF
--- a/app/components/SingleSessionTable.tsx
+++ b/app/components/SingleSessionTable.tsx
@@ -44,6 +44,7 @@ function SpeciesDetailsTable({
 					<th>Ring No</th>
 					<th>Type</th>
 					<th>Age</th>
+					<th>Proven Age</th>
 					<th>Sex</th>
 					<th>Sexing Method</th>
 					<th>Breeding Condition</th>
@@ -66,6 +67,7 @@ function SpeciesDetailsTable({
 						</td>
 						<td>{encounter.record_type}</td>
 						<td>{encounter.age_code}</td>
+						<td>{encounter.bird.proven_age}</td>
 						<td>{encounter.sex}</td>
 						<td>{encounter.sexing_method}</td>
 						<td>{encounter.breeding_condition}</td>
@@ -87,6 +89,7 @@ type RowModel = {
 	adults: number;
 	juvs: number;
 	unknownAge: number;
+	maxProvenAge: number;
 };
 
 function rowDataTransform(data: SpeciesWithEncounters): RowModel {
@@ -104,7 +107,10 @@ function rowDataTransform(data: SpeciesWithEncounters): RowModel {
 			[1, 3].includes(encounter.age_code)
 		).length,
 		unknownAge: data.encounters.filter((encounter) => encounter.age_code === 2)
-			.length
+			.length,
+		maxProvenAge: Math.max(
+			...data.encounters.map((encounter) => encounter.bird.proven_age)
+		)
 	};
 }
 
@@ -130,6 +136,9 @@ const columnConfigs = {
 	},
 	unknownAge: {
 		label: 'Unknown Age'
+	},
+	maxProvenAge: {
+		label: 'Max Proven Age'
 	}
 } as Record<keyof RowModel, ColumnConfig>;
 
@@ -152,7 +161,7 @@ function SessionTableBody({
 		<AccordionTableBody<RowModelWithRawData<SpeciesWithEncounters, RowModel>>
 			data={data}
 			getKey={(speciesWithEncounters) => speciesWithEncounters.species}
-			columnCount={5}
+			columnCount={6}
 			FirstColumnComponent={SpeciesNameCell}
 			RestColumnsComponent={SpeciesRow}
 			ExpandedContentComponent={SpeciesDetailsTable}
@@ -175,6 +184,7 @@ function EncounterRow({ encounter }: { encounter: SessionEncounter }) {
 			<td>{encounter.bird.species.species_name}</td>
 			<td>{encounter.record_type}</td>
 			<td>{encounter.age_code}</td>
+			<td>{encounter.bird.proven_age}</td>
 			<td>{encounter.sex}</td>
 			<td>{encounter.sexing_method}</td>
 			<td>{encounter.breeding_condition}</td>
@@ -201,6 +211,7 @@ function ChronologicalView({ netRounds }: { netRounds: NetRound[] }) {
 								<th>Species</th>
 								<th>Type</th>
 								<th>Age</th>
+								<th>Proven Age</th>
 								<th>Sex</th>
 								<th>Sexing Method</th>
 								<th>Breeding Condition</th>

--- a/app/components/__tests__/SingleSessionTable.test.tsx
+++ b/app/components/__tests__/SingleSessionTable.test.tsx
@@ -8,7 +8,8 @@ import type { SessionEncounter } from '@/app/models/session';
 function makeEncounter(
 	id: number,
 	species: string,
-	capture_time: string
+	capture_time: string,
+	proven_age = 0
 ): SessionEncounter {
 	return {
 		id,
@@ -25,16 +26,18 @@ function makeEncounter(
 		wing_length: null,
 		bird: {
 			ring_no: `RING${id}`,
+			proven_age,
 			species: { id: 1, species_name: species }
 		}
 	} as unknown as SessionEncounter;
 }
 
-const robinEncounter = makeEncounter(1, 'Robin', '09:00:00');
+const robinEncounter = makeEncounter(1, 'Robin', '09:00:00', 3);
+const olderRobinEncounter = makeEncounter(3, 'Robin', '09:15:00', 7);
 const titmouseEncounter = makeEncounter(2, 'Blue Tit', '09:30:00');
 
 const speciesList: SpeciesWithEncounters[] = [
-	{ species: 'Robin', encounters: [robinEncounter] },
+	{ species: 'Robin', encounters: [robinEncounter, olderRobinEncounter] },
 	{ species: 'Blue Tit', encounters: [titmouseEncounter] }
 ];
 
@@ -61,6 +64,20 @@ describe('SessionTabs', () => {
 	it('shows species table by default', () => {
 		render(<SessionTabs speciesList={speciesList} netRounds={netRounds} />);
 		expect(screen.getByTestId('session-table')).not.toBeNull();
+	});
+
+	it('shows the max proven age per species row', () => {
+		render(<SessionTabs speciesList={speciesList} netRounds={netRounds} />);
+		const robinRow = screen.getByText('Robin').closest('tr') as HTMLElement;
+		expect(robinRow.textContent).toContain('7');
+	});
+
+	it('shows proven age per encounter in the by-time view', () => {
+		render(<SessionTabs speciesList={speciesList} netRounds={netRounds} />);
+		fireEvent.click(screen.getByRole('button', { name: 'By time' }));
+		expect(
+			screen.getAllByRole('columnheader').map((c) => c.textContent)
+		).toContain('Proven Age');
 	});
 
 	it('shows chronological view when By time tab clicked', () => {

--- a/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
@@ -48,7 +48,11 @@ const mockEncounters = [
 		sexing_method: null,
 		weight: 18.5,
 		wing_length: 75,
-		bird: { ring_no: 'ABC001', species: { id: 1, species_name: 'Robin' } }
+		bird: {
+			ring_no: 'ABC001',
+			proven_age: 5,
+			species: { id: 1, species_name: 'Robin' }
+		}
 	},
 	{
 		id: 2,
@@ -63,7 +67,11 @@ const mockEncounters = [
 		sexing_method: null,
 		weight: null,
 		wing_length: null,
-		bird: { ring_no: 'XYZ002', species: { id: 1, species_name: 'Robin' } }
+		bird: {
+			ring_no: 'XYZ002',
+			proven_age: 2,
+			species: { id: 1, species_name: 'Robin' }
+		}
 	},
 	{
 		id: 3,
@@ -78,7 +86,11 @@ const mockEncounters = [
 		sexing_method: null,
 		weight: 11.0,
 		wing_length: 55,
-		bird: { ring_no: 'DEF003', species: { id: 2, species_name: 'Blue Tit' } }
+		bird: {
+			ring_no: 'DEF003',
+			proven_age: 0,
+			species: { id: 2, species_name: 'Blue Tit' }
+		}
 	}
 ];
 
@@ -140,6 +152,12 @@ describe('session detail page', () => {
 		expect(stats.textContent).toContain('End: 08:30');
 		expect(stats.textContent).toContain('Duration: 30m');
 		expect(stats.textContent).toContain('Net rounds: 3');
+	});
+
+	it('renders the oldest-bird pill with proven age, species and ring number', async () => {
+		render(await renderPage());
+		const stats = await screen.findByTestId('session-stats');
+		expect(stats.textContent).toContain('Oldest: 5 years — Robin (ABC001)');
 	});
 
 	it('renders one table row per species', async () => {

--- a/app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx
@@ -49,7 +49,11 @@ const mockEncounters = [
 		sexing_method: null,
 		weight: 18.5,
 		wing_length: 75,
-		bird: { ring_no: 'ABC001', species: { id: 1, species_name: 'Robin' } }
+		bird: {
+			ring_no: 'ABC001',
+			proven_age: 4,
+			species: { id: 1, species_name: 'Robin' }
+		}
 	}
 ];
 

--- a/app/group/[groupId]/session/_shared.tsx
+++ b/app/group/[groupId]/session/_shared.tsx
@@ -74,6 +74,7 @@ export async function fetchSessionData({
 			wing_length,
 			bird:Birds (
 				ring_no,
+				proven_age,
 				species:Species (
 					id,
 					species_name
@@ -111,6 +112,17 @@ function groupBySpecies(
 			}
 			return a.encounters.length < b.encounters.length ? 1 : -1;
 		});
+}
+
+function findOldestEncounter(
+	encounters: SessionEncounter[]
+): SessionEncounter | null {
+	return encounters.reduce<SessionEncounter | null>((oldest, encounter) => {
+		if (!oldest || encounter.bird.proven_age > oldest.bird.proven_age) {
+			return encounter;
+		}
+		return oldest;
+	}, null);
 }
 
 function Locations({
@@ -171,6 +183,7 @@ export function SessionSummary({
 }) {
 	const speciesList = groupBySpecies(dayData.encounters);
 	const chronology = calculateSessionChronology(dayData.encounters);
+	const oldestEncounter = findOldestEncounter(dayData.encounters);
 
 	if (dayData.locations.length === 0) {
 		return (
@@ -197,19 +210,24 @@ export function SessionSummary({
 			</PrimaryHeading>
 			<BadgeList
 				testId="session-stats"
-				items={[
-					`${dayData.encounters.length} birds`,
-					`${speciesList.length} species`,
-					`${dayData.encounters.filter((encounter) => encounter.record_type === 'N').length} new`,
-					`${dayData.encounters.filter((encounter) => encounter.record_type === 'S').length} retraps`,
-					`${dayData.encounters.filter((encounter) => encounter.age_code > 3).length} adults`,
-					`${dayData.encounters.filter((encounter) => [1, 3].includes(encounter.age_code)).length} juvs`,
-					`${dayData.encounters.filter((encounter) => encounter.age_code === 2).length} unknown age`,
-					`Start: ${chronology.startTime ? chronology.startTime.slice(0, 5) : '–'}`,
-					`End: ${chronology.endTime ? chronology.endTime.slice(0, 5) : '–'}`,
-					`Duration: ${chronology.durationMinutes !== null ? formatMinutesForDisplay(chronology.durationMinutes) : '–'}`,
-					`Net rounds: ${chronology.netRounds.length}`
-				]}
+				items={
+					[
+						`${dayData.encounters.length} birds`,
+						`${speciesList.length} species`,
+						`${dayData.encounters.filter((encounter) => encounter.record_type === 'N').length} new`,
+						`${dayData.encounters.filter((encounter) => encounter.record_type === 'S').length} retraps`,
+						`${dayData.encounters.filter((encounter) => encounter.age_code > 3).length} adults`,
+						`${dayData.encounters.filter((encounter) => [1, 3].includes(encounter.age_code)).length} juvs`,
+						`${dayData.encounters.filter((encounter) => encounter.age_code === 2).length} unknown age`,
+						`Start: ${chronology.startTime ? chronology.startTime.slice(0, 5) : '–'}`,
+						`End: ${chronology.endTime ? chronology.endTime.slice(0, 5) : '–'}`,
+						`Duration: ${chronology.durationMinutes !== null ? formatMinutesForDisplay(chronology.durationMinutes) : '–'}`,
+						`Net rounds: ${chronology.netRounds.length}`,
+						oldestEncounter && oldestEncounter.bird.proven_age > 0
+							? `Oldest: ${oldestEncounter.bird.proven_age} years — ${oldestEncounter.bird.species.species_name} (${oldestEncounter.bird.ring_no})`
+							: null
+					].filter(Boolean) as string[]
+				}
 			/>
 			{locationId ? null : (
 				<SessionHighlights date={date} viewedGroupId={viewedGroupId} />


### PR DESCRIPTION
## What this covers

Implements all three parts of #220 — proven age shown throughout the session page:

1. **Per-encounter proven age** — a "Proven Age" column added to the by-species nested (expanded) rows and to the by-time (chronological) view.
2. **Max proven age per species** — a "Max Proven Age" column added to the species summary rows.
3. **Oldest-bird pill** — the session summary badge list now includes `Oldest: N years — Species (ring)` for the encounter with the greatest proven age.

Data-wise, `fetchSessionData` now selects `proven_age` alongside the encounter's bird (a UI/read-only change — no schema change; `proven_age` already exists on the `Birds` table).

## Assumptions made (subagent mode)

- **Copy for the pill**: `Oldest: N years — Species (ring)`, matching the existing badge-list style (`Proven Age: N` on the bird page, "N years old" in SpStats).
- **Zero proven age**: the oldest pill is only shown when the greatest proven age is `> 0`, so sessions where no bird has a proven age don't get a meaningless "Oldest: 0 years" badge.
- **Max proven age column** is shown as a raw number (0 when none proven), consistent with the other numeric species columns.
- Added the proven-age column to the by-time view too (not strictly named in the ticket) for consistency with the by-species nested rows.

## Tests

- `npm run qa` — lint, type-check, and all 336 app tests pass.
- New coverage: oldest-bird pill (page test), max-proven-age species row and per-encounter proven age column (SingleSessionTable test). Existing session/site page mocks updated to carry `proven_age`.

Closes #220