### PR TITLE
feat: session_weight_record_breakers RPC (Session highlights 8)

### DIFF
--- a/app/models/db.ts
+++ b/app/models/db.ts
@@ -30,3 +30,5 @@ export type NotableRetrapsResult =
 	Database['public']['Functions']['notable_retraps']['Returns'][number];
 export type LongAbsenceRetrapsResult =
 	Database['public']['Functions']['long_absence_retraps']['Returns'][number];
+export type SessionWeightExtremesResult =
+	Database['public']['Functions']['session_weight_extremes']['Returns'][number];

--- a/app/models/db.ts
+++ b/app/models/db.ts
@@ -30,5 +30,5 @@ export type NotableRetrapsResult =
 	Database['public']['Functions']['notable_retraps']['Returns'][number];
 export type LongAbsenceRetrapsResult =
 	Database['public']['Functions']['long_absence_retraps']['Returns'][number];
-export type SessionWeightExtremesResult =
-	Database['public']['Functions']['session_weight_extremes']['Returns'][number];
+export type SessionWeightRecordBreakersResult =
+	Database['public']['Functions']['session_weight_record_breakers']['Returns'][number];

--- a/supabase/__tests__/rpc-functions.test.ts
+++ b/supabase/__tests__/rpc-functions.test.ts
@@ -641,7 +641,7 @@ describe('Postgres RPC integration tests', () => {
 		});
 	});
 
-	describe('session_weight_extremes', () => {
+	describe('session_weight_record_breakers', () => {
 		// Seed Alpha weights (weighed encounters, per species and date):
 		//   Robin — prior to 2023-05-12 the heaviest was 20.5 (AR0008, 2022-06-15);
 		//     on 2023-05-12 AR0018 = 21.0 beats it, and 21 prior weighed encounters
@@ -650,7 +650,7 @@ describe('Postgres RPC integration tests', () => {
 		//     (2022-06-15) over 4 weighed encounters; on 2022-08-10 ARWRBL006 = 11.0
 		//     ties the lightest and ARWRBL007 = 12.1 beats the heaviest.
 		it('returns a heaviest record beating the prior max with enough prior weights', async () => {
-			const { data, error } = await alphaClient.rpc('session_weight_extremes', {
+			const { data, error } = await alphaClient.rpc('session_weight_record_breakers', {
 				session_date: '2023-05-12',
 				ringing_group_filter: alphaId,
 			});
@@ -660,9 +660,9 @@ describe('Postgres RPC integration tests', () => {
 					species_name: 'Robin',
 					ring_no: 'AR0018',
 					weight: 21,
-					extreme_type: 'heaviest',
-					previous_extreme: 20.5,
-					previous_extreme_date: '2022-06-15',
+					record_type: 'heaviest',
+					previous_record: 20.5,
+					previous_record_date: '2022-06-15',
 				},
 			]);
 		});
@@ -671,7 +671,7 @@ describe('Postgres RPC integration tests', () => {
 			// On 2022-04-30 the only prior weighed encounter is ARRETRAP (Robin, 18.5,
 			// 2021-06-20) — a single prior weight, below the default min of 3 — so no
 			// species qualifies for a comparison.
-			const { data, error } = await alphaClient.rpc('session_weight_extremes', {
+			const { data, error } = await alphaClient.rpc('session_weight_record_breakers', {
 				session_date: '2022-04-30',
 				ringing_group_filter: alphaId,
 			});
@@ -679,8 +679,8 @@ describe('Postgres RPC integration tests', () => {
 			expect(data).toHaveLength(0);
 		});
 
-		it('returns ties with previous_extreme and previous_extreme_date populated', async () => {
-			const { data, error } = await alphaClient.rpc('session_weight_extremes', {
+		it('returns ties with previous_record and previous_record_date populated', async () => {
+			const { data, error } = await alphaClient.rpc('session_weight_record_breakers', {
 				session_date: '2022-08-10',
 				ringing_group_filter: alphaId,
 			});
@@ -690,26 +690,26 @@ describe('Postgres RPC integration tests', () => {
 					species_name: 'Reed Warbler',
 					ring_no: 'ARWRBL007',
 					weight: 12.1,
-					extreme_type: 'heaviest',
-					previous_extreme: 12,
-					previous_extreme_date: '2022-06-15',
+					record_type: 'heaviest',
+					previous_record: 12,
+					previous_record_date: '2022-06-15',
 				},
 				{
 					species_name: 'Reed Warbler',
 					ring_no: 'ARWRBL006',
 					weight: 11,
-					extreme_type: 'lightest',
-					previous_extreme: 11,
-					previous_extreme_date: '2022-06-15',
+					record_type: 'lightest',
+					previous_record: 11,
+					previous_record_date: '2022-06-15',
 				},
 			]);
 		});
 
-		it('returns lightest extreme and one row per species when min_prior_weighed=1', async () => {
+		it('returns lightest record and one row per species when min_prior_weighed=1', async () => {
 			// On 2022-04-30 the sole prior weight is ARRETRAP (Robin, 18.5, 2021-06-20).
 			// With min_prior_weighed=1 the Robins beat it both ways: AR0003 (20.0) is the
-			// heaviest and AR0002 (16.8) the lightest — one row per (species, extreme).
-			const { data, error } = await alphaClient.rpc('session_weight_extremes', {
+			// heaviest and AR0002 (16.8) the lightest — one row per (species, record type).
+			const { data, error } = await alphaClient.rpc('session_weight_record_breakers', {
 				session_date: '2022-04-30',
 				ringing_group_filter: alphaId,
 				min_prior_weighed: 1,
@@ -720,23 +720,23 @@ describe('Postgres RPC integration tests', () => {
 					species_name: 'Robin',
 					ring_no: 'AR0003',
 					weight: 20,
-					extreme_type: 'heaviest',
-					previous_extreme: 18.5,
-					previous_extreme_date: '2021-06-20',
+					record_type: 'heaviest',
+					previous_record: 18.5,
+					previous_record_date: '2021-06-20',
 				},
 				{
 					species_name: 'Robin',
 					ring_no: 'AR0002',
 					weight: 16.8,
-					extreme_type: 'lightest',
-					previous_extreme: 18.5,
-					previous_extreme_date: '2021-06-20',
+					record_type: 'lightest',
+					previous_record: 18.5,
+					previous_record_date: '2021-06-20',
 				},
 			]);
 		});
 
 		it('returns empty for a date with no session', async () => {
-			const { data, error } = await alphaClient.rpc('session_weight_extremes', {
+			const { data, error } = await alphaClient.rpc('session_weight_record_breakers', {
 				session_date: '2099-01-01',
 				ringing_group_filter: alphaId,
 			});

--- a/supabase/__tests__/rpc-functions.test.ts
+++ b/supabase/__tests__/rpc-functions.test.ts
@@ -640,4 +640,108 @@ describe('Postgres RPC integration tests', () => {
 			expect(data).toHaveLength(0);
 		});
 	});
+
+	describe('session_weight_extremes', () => {
+		// Seed Alpha weights (weighed encounters, per species and date):
+		//   Robin — prior to 2023-05-12 the heaviest was 20.5 (AR0008, 2022-06-15);
+		//     on 2023-05-12 AR0018 = 21.0 beats it, and 21 prior weighed encounters
+		//     comfortably clear the default min_prior_weighed of 3.
+		//   Reed Warbler — prior to 2022-08-10 min 11.0 (2022-06-15) / max 12.0
+		//     (2022-06-15) over 4 weighed encounters; on 2022-08-10 ARWRBL006 = 11.0
+		//     ties the lightest and ARWRBL007 = 12.1 beats the heaviest.
+		it('returns a heaviest record beating the prior max with enough prior weights', async () => {
+			const { data, error } = await alphaClient.rpc('session_weight_extremes', {
+				session_date: '2023-05-12',
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toEqual([
+				{
+					species_name: 'Robin',
+					ring_no: 'AR0018',
+					weight: 21,
+					extreme_type: 'heaviest',
+					previous_extreme: 20.5,
+					previous_extreme_date: '2022-06-15',
+				},
+			]);
+		});
+
+		it('excludes species with fewer than min_prior_weighed prior weighed encounters', async () => {
+			// On 2022-04-30 the only prior weighed encounter is ARRETRAP (Robin, 18.5,
+			// 2021-06-20) — a single prior weight, below the default min of 3 — so no
+			// species qualifies for a comparison.
+			const { data, error } = await alphaClient.rpc('session_weight_extremes', {
+				session_date: '2022-04-30',
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(0);
+		});
+
+		it('returns ties with previous_extreme and previous_extreme_date populated', async () => {
+			const { data, error } = await alphaClient.rpc('session_weight_extremes', {
+				session_date: '2022-08-10',
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toEqual([
+				{
+					species_name: 'Reed Warbler',
+					ring_no: 'ARWRBL007',
+					weight: 12.1,
+					extreme_type: 'heaviest',
+					previous_extreme: 12,
+					previous_extreme_date: '2022-06-15',
+				},
+				{
+					species_name: 'Reed Warbler',
+					ring_no: 'ARWRBL006',
+					weight: 11,
+					extreme_type: 'lightest',
+					previous_extreme: 11,
+					previous_extreme_date: '2022-06-15',
+				},
+			]);
+		});
+
+		it('returns lightest extreme and one row per species when min_prior_weighed=1', async () => {
+			// On 2022-04-30 the sole prior weight is ARRETRAP (Robin, 18.5, 2021-06-20).
+			// With min_prior_weighed=1 the Robins beat it both ways: AR0003 (20.0) is the
+			// heaviest and AR0002 (16.8) the lightest — one row per (species, extreme).
+			const { data, error } = await alphaClient.rpc('session_weight_extremes', {
+				session_date: '2022-04-30',
+				ringing_group_filter: alphaId,
+				min_prior_weighed: 1,
+			});
+			expect(error).toBeNull();
+			expect(data).toEqual([
+				{
+					species_name: 'Robin',
+					ring_no: 'AR0003',
+					weight: 20,
+					extreme_type: 'heaviest',
+					previous_extreme: 18.5,
+					previous_extreme_date: '2021-06-20',
+				},
+				{
+					species_name: 'Robin',
+					ring_no: 'AR0002',
+					weight: 16.8,
+					extreme_type: 'lightest',
+					previous_extreme: 18.5,
+					previous_extreme_date: '2021-06-20',
+				},
+			]);
+		});
+
+		it('returns empty for a date with no session', async () => {
+			const { data, error } = await alphaClient.rpc('session_weight_extremes', {
+				session_date: '2099-01-01',
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(0);
+		});
+	});
 });

--- a/supabase/schema/schemas/public/functions/session_weight_extremes.sql
+++ b/supabase/schema/schemas/public/functions/session_weight_extremes.sql
@@ -1,0 +1,110 @@
+CREATE FUNCTION public.session_weight_extremes (
+	session_date date,
+	ringing_group_filter bigint,
+	min_prior_weighed integer DEFAULT 3
+) RETURNS TABLE (
+	species_name text,
+	ring_no text,
+	weight numeric,
+	extreme_type text,
+	previous_extreme numeric,
+	previous_extreme_date date
+) LANGUAGE plpgsql STABLE
+SET
+	search_path TO 'public',
+	'pg_catalog' AS $function$
+BEGIN
+  RETURN QUERY
+  WITH todays_weighed AS (
+    SELECT
+      sp.species_name AS species_name,
+      b.ring_no AS ring_no,
+      e.weight::numeric AS weight
+    FROM public."Encounters" e
+      JOIN public."Sessions" sess ON e.session_id = sess.id
+      JOIN public."Birds" b ON e.bird_id = b.id
+      LEFT JOIN public."Species" sp ON b.species_id = sp.id
+    WHERE sess.visit_date = session_date
+      AND sess.ringing_group_id = ringing_group_filter
+      AND e.ringing_group_id = ringing_group_filter
+      AND e.weight IS NOT NULL
+  ),
+  prior_weighed AS (
+    SELECT
+      sp.species_name AS species_name,
+      e.weight::numeric AS weight,
+      sess.visit_date AS visit_date
+    FROM public."Encounters" e
+      JOIN public."Sessions" sess ON e.session_id = sess.id
+      JOIN public."Birds" b ON e.bird_id = b.id
+      LEFT JOIN public."Species" sp ON b.species_id = sp.id
+    WHERE sess.visit_date < session_date
+      AND sess.ringing_group_id = ringing_group_filter
+      AND e.ringing_group_id = ringing_group_filter
+      AND e.weight IS NOT NULL
+  ),
+  prior_extremes AS (
+    SELECT
+      pw.species_name AS species_name,
+      MIN(pw.weight) AS min_weight,
+      MAX(pw.weight) AS max_weight,
+      COUNT(*) AS weighed_count
+    FROM prior_weighed pw
+    GROUP BY pw.species_name
+    HAVING COUNT(*) >= min_prior_weighed
+  )
+  SELECT extremes.species_name, extremes.ring_no, extremes.weight,
+    extremes.extreme_type, extremes.previous_extreme, extremes.previous_extreme_date
+  FROM (
+    -- Heaviest: today's birds equalling or beating the prior maximum.
+    (
+      SELECT DISTINCT ON (tw.species_name)
+        tw.species_name,
+        tw.ring_no,
+        tw.weight,
+        'heaviest'::text AS extreme_type,
+        pe.max_weight AS previous_extreme,
+        (
+          SELECT MAX(pw.visit_date)
+          FROM prior_weighed pw
+          WHERE pw.species_name = pe.species_name
+            AND pw.weight = pe.max_weight
+        ) AS previous_extreme_date
+      FROM todays_weighed tw
+        JOIN prior_extremes pe ON tw.species_name = pe.species_name
+      WHERE tw.weight >= pe.max_weight
+      ORDER BY tw.species_name, tw.weight DESC
+    )
+
+    UNION ALL
+
+    -- Lightest: today's birds equalling or undercutting the prior minimum.
+    (
+      SELECT DISTINCT ON (tw.species_name)
+        tw.species_name,
+        tw.ring_no,
+        tw.weight,
+        'lightest'::text AS extreme_type,
+        pe.min_weight AS previous_extreme,
+        (
+          SELECT MAX(pw.visit_date)
+          FROM prior_weighed pw
+          WHERE pw.species_name = pe.species_name
+            AND pw.weight = pe.min_weight
+        ) AS previous_extreme_date
+      FROM todays_weighed tw
+        JOIN prior_extremes pe ON tw.species_name = pe.species_name
+      WHERE tw.weight <= pe.min_weight
+      ORDER BY tw.species_name, tw.weight ASC
+    )
+  ) AS extremes
+  -- 'heaviest' sorts before 'lightest' so each species' heaviest row comes first.
+  ORDER BY extremes.species_name, extremes.extreme_type;
+END;
+$function$;
+
+GRANT ALL ON FUNCTION public.session_weight_extremes (date, bigint, integer) TO anon;
+
+GRANT ALL ON FUNCTION public.session_weight_extremes (date, bigint, integer) TO authenticated;
+
+GRANT ALL ON FUNCTION public.session_weight_extremes (date, bigint, integer) TO service_role;

--- a/supabase/schema/schemas/public/functions/session_weight_record_breakers.sql
+++ b/supabase/schema/schemas/public/functions/session_weight_record_breakers.sql
@@ -1,4 +1,4 @@
-CREATE FUNCTION public.session_weight_extremes (
+CREATE FUNCTION public.session_weight_record_breakers (
 	session_date date,
 	ringing_group_filter bigint,
 	min_prior_weighed integer DEFAULT 3
@@ -6,9 +6,9 @@ CREATE FUNCTION public.session_weight_extremes (
 	species_name text,
 	ring_no text,
 	weight numeric,
-	extreme_type text,
-	previous_extreme numeric,
-	previous_extreme_date date
+	record_type text,
+	previous_record numeric,
+	previous_record_date date
 ) LANGUAGE plpgsql STABLE
 SET
 	search_path TO 'public',
@@ -43,7 +43,7 @@ BEGIN
       AND e.ringing_group_id = ringing_group_filter
       AND e.weight IS NOT NULL
   ),
-  prior_extremes AS (
+  prior_records AS (
     SELECT
       pw.species_name AS species_name,
       MIN(pw.weight) AS min_weight,
@@ -53,8 +53,8 @@ BEGIN
     GROUP BY pw.species_name
     HAVING COUNT(*) >= min_prior_weighed
   )
-  SELECT extremes.species_name, extremes.ring_no, extremes.weight,
-    extremes.extreme_type, extremes.previous_extreme, extremes.previous_extreme_date
+  SELECT record_breakers.species_name, record_breakers.ring_no, record_breakers.weight,
+    record_breakers.record_type, record_breakers.previous_record, record_breakers.previous_record_date
   FROM (
     -- Heaviest: today's birds equalling or beating the prior maximum.
     (
@@ -62,17 +62,17 @@ BEGIN
         tw.species_name,
         tw.ring_no,
         tw.weight,
-        'heaviest'::text AS extreme_type,
-        pe.max_weight AS previous_extreme,
+        'heaviest'::text AS record_type,
+        pr.max_weight AS previous_record,
         (
           SELECT MAX(pw.visit_date)
           FROM prior_weighed pw
-          WHERE pw.species_name = pe.species_name
-            AND pw.weight = pe.max_weight
-        ) AS previous_extreme_date
+          WHERE pw.species_name = pr.species_name
+            AND pw.weight = pr.max_weight
+        ) AS previous_record_date
       FROM todays_weighed tw
-        JOIN prior_extremes pe ON tw.species_name = pe.species_name
-      WHERE tw.weight >= pe.max_weight
+        JOIN prior_records pr ON tw.species_name = pr.species_name
+      WHERE tw.weight >= pr.max_weight
       ORDER BY tw.species_name, tw.weight DESC
     )
 
@@ -84,27 +84,27 @@ BEGIN
         tw.species_name,
         tw.ring_no,
         tw.weight,
-        'lightest'::text AS extreme_type,
-        pe.min_weight AS previous_extreme,
+        'lightest'::text AS record_type,
+        pr.min_weight AS previous_record,
         (
           SELECT MAX(pw.visit_date)
           FROM prior_weighed pw
-          WHERE pw.species_name = pe.species_name
-            AND pw.weight = pe.min_weight
-        ) AS previous_extreme_date
+          WHERE pw.species_name = pr.species_name
+            AND pw.weight = pr.min_weight
+        ) AS previous_record_date
       FROM todays_weighed tw
-        JOIN prior_extremes pe ON tw.species_name = pe.species_name
-      WHERE tw.weight <= pe.min_weight
+        JOIN prior_records pr ON tw.species_name = pr.species_name
+      WHERE tw.weight <= pr.min_weight
       ORDER BY tw.species_name, tw.weight ASC
     )
-  ) AS extremes
+  ) AS record_breakers
   -- 'heaviest' sorts before 'lightest' so each species' heaviest row comes first.
-  ORDER BY extremes.species_name, extremes.extreme_type;
+  ORDER BY record_breakers.species_name, record_breakers.record_type;
 END;
 $function$;
 
-GRANT ALL ON FUNCTION public.session_weight_extremes (date, bigint, integer) TO anon;
+GRANT ALL ON FUNCTION public.session_weight_record_breakers (date, bigint, integer) TO anon;
 
-GRANT ALL ON FUNCTION public.session_weight_extremes (date, bigint, integer) TO authenticated;
+GRANT ALL ON FUNCTION public.session_weight_record_breakers (date, bigint, integer) TO authenticated;
 
-GRANT ALL ON FUNCTION public.session_weight_extremes (date, bigint, integer) TO service_role;
+GRANT ALL ON FUNCTION public.session_weight_record_breakers (date, bigint, integer) TO service_role;

--- a/types/supabase.types.ts
+++ b/types/supabase.types.ts
@@ -416,6 +416,21 @@ export type Database = {
           sequence_prefix: string
         }[]
       }
+      session_weight_extremes: {
+        Args: {
+          min_prior_weighed?: number
+          ringing_group_filter: number
+          session_date: string
+        }
+        Returns: {
+          extreme_type: string
+          previous_extreme: number
+          previous_extreme_date: string
+          ring_no: string
+          species_name: string
+          weight: number
+        }[]
+      }
       soundex: { Args: { "": string }; Returns: string }
       text_soundex: { Args: { "": string }; Returns: string }
       top_metrics_by_period: {

--- a/types/supabase.types.ts
+++ b/types/supabase.types.ts
@@ -416,16 +416,16 @@ export type Database = {
           sequence_prefix: string
         }[]
       }
-      session_weight_extremes: {
+      session_weight_record_breakers: {
         Args: {
           min_prior_weighed?: number
           ringing_group_filter: number
           session_date: string
         }
         Returns: {
-          extreme_type: string
-          previous_extreme: number
-          previous_extreme_date: string
+          previous_record: number
+          previous_record_date: string
+          record_type: string
           ring_no: string
           species_name: string
           weight: number


### PR DESCRIPTION
## What this covers

Adds the `session_weight_record_breakers` RPC — the DB layer for the weight record-breakers session highlight (part of #219).

**Signature:** `session_weight_record_breakers(session_date date, ringing_group_filter bigint, min_prior_weighed integer DEFAULT 3)` → `TABLE (species_name text, ring_no text, weight numeric, record_type text, previous_record numeric, previous_record_date date)`

**Behaviour:**
- Compares today's weighed encounters (both sides `weight IS NOT NULL`) against each species' prior MIN/MAX weight, over sessions strictly before `session_date`.
- Only species with `>= min_prior_weighed` prior weighed encounters qualify.
- `>=` (heaviest) / `<=` (lightest) comparisons so ties are returned.
- `DISTINCT ON (species)` picks one bird per species per record type; `UNION ALL` combines lightest + heaviest.
- Returns `previous_record` and the most recent `previous_record_date` on which that prior record was set, so the model layer can apply the all-time tie rule.
- Dual group filter on both `Encounters.ringing_group_id` and `Sessions.ringing_group_id` per design decision #4, keeping shared (GroupDataSharing) data out of comparisons.

Includes the schema SQL file, regenerated `types/supabase.types.ts`, the `SessionWeightRecordBreakersResult` type re-export in `app/models/db.ts`, and DB integration tests.

## Tests

Five integration tests in `supabase/__tests__/rpc-functions.test.ts` (`describe session_weight_record_breakers`), matching the ticket's enumerated titles. All 48 RPC integration tests pass; full `npm run qa` (lint + type-check + 340 app tests) passes.

## Assumptions

- **Migration not committed:** `supabase/migrations` is gitignored (per commit "stop committing supabase migrations"); the declarative schema file is the source of truth and the human deploys via `npm run db:migration:push`. Only the schema SQL, types, and tests are committed.
- **Deterministic ordering:** added an outer `ORDER BY species_name, record_type` (heaviest sorts before lightest) so results are stable rather than relying on `UNION ALL` ordering — makes the test expectations robust.
- **numeric → JS number:** PostgREST serialises the `numeric` columns as JS numbers, which the tests assert against.

## Note

This is the DB increment of #219's weight record-breakers highlight. It does **not** close #219 — the UI counterpart (#321) consumes this RPC, and #219 stays open until its final child.

Part of #219.

🤖 Generated with [Claude Code](https://claude.com/claude-code)