### PR TITLE
feat: stats_per_day_and_species RPC (Session highlights 8, reworked)

### DIFF
--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { TopMetricsFilterParams } from '@/app/models/db';
+import type { StatsPerDayAndSpeciesRow } from '@/app/models/db';
 
 const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
 	mockGetAuthenticatedSupabaseClient: vi.fn()
@@ -15,12 +15,23 @@ const PAGE_SIZE = 1000;
 
 // Queries are paginated (PostgREST caps responses at 1000 rows), so the
 // mock builders serve rows page by page from these arrays
-let rpcPages: {
-	species_name: string;
-	visit_date: string;
-	metric_value: number;
-}[][];
+let rpcPages: StatsPerDayAndSpeciesRow[][];
 let sessionPages: { visit_date: string }[][];
+
+function statsRow(
+	species_name: string,
+	visit_date: string,
+	encounter_count: number
+): StatsPerDayAndSpeciesRow {
+	return {
+		species_name,
+		visit_date,
+		encounter_count,
+		weighed_birds_count: 0,
+		min_weight: 0,
+		max_weight: 0
+	};
+}
 
 function pageForRange(pages: unknown[][], fromRow: number) {
 	return Promise.resolve({
@@ -31,7 +42,7 @@ function pageForRange(pages: unknown[][], fromRow: number) {
 
 const mockRpcOrder = vi.fn();
 const mockRpcRange = vi.fn();
-// The paginated rpc (metrics_by_period_and_species) returns a query builder;
+// The paginated rpc (stats_per_day_and_species) returns a query builder;
 // the non-paginated rpc (long_absence_retraps) returns a thenable.
 const paginatedRpcQueryBuilder = { order: mockRpcOrder, range: mockRpcRange };
 const mockLongAbsenceRpcResult = Promise.resolve({ data: [], error: null });
@@ -59,9 +70,9 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	rpcPages = [
 		[
-			{ species_name: 'Robin', visit_date: SESSION_DATE, metric_value: 74 },
-			{ species_name: 'Robin', visit_date: '2022-05-01', metric_value: 30 },
-			{ species_name: 'Wren', visit_date: '2022-05-01', metric_value: 30 }
+			statsRow('Robin', SESSION_DATE, 74),
+			statsRow('Robin', '2022-05-01', 30),
+			statsRow('Wren', '2022-05-01', 30)
 		]
 	];
 	sessionPages = [[{ visit_date: '2022-05-01' }, { visit_date: SESSION_DATE }]];
@@ -94,28 +105,18 @@ describe('fetchSessionHighlights', () => {
 			date: SESSION_DATE,
 			viewedGroupId: GROUP_ID
 		});
-		// Two rpc calls: metrics_by_period_and_species (paginated) and
+		// Two rpc calls: stats_per_day_and_species (paginated) and
 		// long_absence_retraps (non-paginated)
 		expect(mockRpc).toHaveBeenCalledTimes(2);
 		const rpcFunctionNames = mockRpc.mock.calls.map(
 			(call) => (call as [string, unknown])[0]
 		);
-		expect(rpcFunctionNames).toContain('metrics_by_period_and_species');
+		expect(rpcFunctionNames).toContain('stats_per_day_and_species');
 		expect(rpcFunctionNames).toContain('long_absence_retraps');
-		const [, metricsArgs] = mockRpc.mock.calls.find(
-			(call) =>
-				(call as [string, unknown])[0] === 'metrics_by_period_and_species'
-		) as [
-			string,
-			{
-				temporal_unit: string;
-				metric_name: string;
-				filters: TopMetricsFilterParams;
-			}
-		];
-		expect(metricsArgs.temporal_unit).toBe('day');
-		expect(metricsArgs.metric_name).toBe('encounters');
-		expect(metricsArgs.filters.ringing_group_filter).toBe(GROUP_ID);
+		const [, statsArgs] = mockRpc.mock.calls.find(
+			(call) => (call as [string, unknown])[0] === 'stats_per_day_and_species'
+		) as [string, { ringing_group_filter: number }];
+		expect(statsArgs.ringing_group_filter).toBe(GROUP_ID);
 		expect(highlights).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
@@ -154,18 +155,10 @@ describe('fetchSessionHighlights', () => {
 
 	it('derives highlights from rows beyond the first page', async () => {
 		rpcPages = [
-			Array.from({ length: PAGE_SIZE }, (_, index) => ({
-				species_name: `Species ${index}`,
-				visit_date: '2022-05-01',
-				metric_value: 1
-			})),
-			[
-				{
-					species_name: 'Robin',
-					visit_date: SESSION_DATE,
-					metric_value: 2000
-				}
-			]
+			Array.from({ length: PAGE_SIZE }, (_, index) =>
+				statsRow(`Species ${index}`, '2022-05-01', 1)
+			),
+			[statsRow('Robin', SESSION_DATE, 2000)]
 		];
 		const fetchSessionHighlights = await importFetchSessionHighlights();
 		const highlights = await fetchSessionHighlights({
@@ -198,10 +191,10 @@ describe('fetchSessionHighlights', () => {
 			date: '2022-05-01',
 			viewedGroupId: GROUP_ID
 		});
-		// metrics_by_period_and_species is cached (called once), but
+		// stats_per_day_and_species is cached (called once), but
 		// long_absence_retraps is per-session (called twice)
 		const metricsCalls = mockRpc.mock.calls.filter(
-			(call) => (call as [string])[0] === 'metrics_by_period_and_species'
+			(call) => (call as [string])[0] === 'stats_per_day_and_species'
 		);
 		expect(metricsCalls).toHaveLength(1);
 		expect(mockEq).toHaveBeenCalledTimes(1);

--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -12,9 +12,8 @@ import {
 	type SessionStatsData
 } from '@/app/models/session-highlights';
 import type {
-	DaySpeciesMetricRow,
 	LongAbsenceRetrapsResult,
-	TopMetricsFilterParams
+	StatsPerDayAndSpeciesRow
 } from '@/app/models/db';
 
 // The stats blob only changes when new data is imported, so cache it
@@ -33,15 +32,11 @@ async function fetchSessionStats(
 		return cached.stats;
 	}
 	const supabase = await getAuthenticatedSupabaseClient();
-	const [daySpeciesCounts, sessionRows] = await Promise.all([
-		fetchAllPaginatedRows<DaySpeciesMetricRow>((fromRow, toRow) =>
+	const [daySpeciesStats, sessionRows] = await Promise.all([
+		fetchAllPaginatedRows<StatsPerDayAndSpeciesRow>((fromRow, toRow) =>
 			supabase
-				.rpc('metrics_by_period_and_species', {
-					temporal_unit: 'day',
-					metric_name: 'encounters',
-					filters: {
-						ringing_group_filter: viewedGroupId
-					} as TopMetricsFilterParams
+				.rpc('stats_per_day_and_species', {
+					ringing_group_filter: viewedGroupId
 				})
 				.order('visit_date')
 				.order('species_name')
@@ -57,7 +52,7 @@ async function fetchSessionStats(
 		)
 	]);
 	const stats: SessionStatsData = {
-		daySpeciesCounts,
+		daySpeciesStats,
 		sessionDates: sessionRows.map((row) => row.visit_date)
 	};
 	sessionStatsCache.set(viewedGroupId, {

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -14,7 +14,7 @@ import {
 	type SpeciesCountRecordHighlight
 } from '../session-highlights';
 import type {
-	DaySpeciesMetricRow,
+	StatsPerDayAndSpeciesRow,
 	LongAbsenceRetrapsResult
 } from '@/app/models/db';
 
@@ -40,22 +40,27 @@ const PRIOR_SPRING_YEAR_THREE = '2023-05-01';
 function dayRows(
 	date: string,
 	speciesCounts: Record<string, number>
-): DaySpeciesMetricRow[] {
-	return Object.entries(speciesCounts).map(([species_name, metric_value]) => ({
-		species_name,
-		visit_date: date,
-		metric_value
-	}));
+): StatsPerDayAndSpeciesRow[] {
+	return Object.entries(speciesCounts).map(
+		([species_name, encounter_count]) => ({
+			species_name,
+			visit_date: date,
+			encounter_count,
+			weighed_birds_count: 0,
+			min_weight: 0,
+			max_weight: 0
+		})
+	);
 }
 
-function statsFor(rows: DaySpeciesMetricRow[]): SessionStatsData {
+function statsFor(rows: StatsPerDayAndSpeciesRow[]): SessionStatsData {
 	return {
-		daySpeciesCounts: rows,
+		daySpeciesStats: rows,
 		sessionDates: [...new Set(rows.map((row) => row.visit_date))]
 	};
 }
 
-function derive(rows: DaySpeciesMetricRow[], today = PAST_PERIOD_TODAY) {
+function derive(rows: StatsPerDayAndSpeciesRow[], today = PAST_PERIOD_TODAY) {
 	return deriveSessionTotalRecords({
 		date: SESSION_DATE,
 		stats: statsFor(rows),
@@ -277,7 +282,7 @@ describe('deriveSessionTotalRecords', () => {
 
 	it('counts zero-encounter sessions as comparison sessions in scope', () => {
 		const stats: SessionStatsData = {
-			daySpeciesCounts: dayRows(SESSION_DATE, { Robin: 74 }),
+			daySpeciesStats: dayRows(SESSION_DATE, { Robin: 74 }),
 			sessionDates: [PRIOR_SPRING_OTHER_YEAR, SESSION_DATE]
 		};
 		const highlights = deriveSessionTotalRecords({
@@ -386,18 +391,28 @@ function speciesRow(
 	date: string,
 	species: string,
 	count: number
-): DaySpeciesMetricRow {
-	return { visit_date: date, species_name: species, metric_value: count };
+): StatsPerDayAndSpeciesRow {
+	return {
+		visit_date: date,
+		species_name: species,
+		encounter_count: count,
+		weighed_birds_count: 0,
+		min_weight: 0,
+		max_weight: 0
+	};
 }
 
-function statsForSpecies(rows: DaySpeciesMetricRow[]): SessionStatsData {
+function statsForSpecies(rows: StatsPerDayAndSpeciesRow[]): SessionStatsData {
 	return {
-		daySpeciesCounts: rows,
+		daySpeciesStats: rows,
 		sessionDates: [...new Set(rows.map((row) => row.visit_date))]
 	};
 }
 
-function deriveSpecies(rows: DaySpeciesMetricRow[], today = PAST_PERIOD_TODAY) {
+function deriveSpecies(
+	rows: StatsPerDayAndSpeciesRow[],
+	today = PAST_PERIOD_TODAY
+) {
 	return deriveSpeciesRecords({
 		date: SESSION_DATE,
 		stats: statsForSpecies(rows),
@@ -871,10 +886,13 @@ describe('buildHighlightSentence — species-count-record', () => {
 
 const FIRECREST = 'Firecrest';
 
-function deriveFirstEver(rows: DaySpeciesMetricRow[], sessionDates?: string[]) {
-	const daySpeciesCounts = rows;
+function deriveFirstEver(
+	rows: StatsPerDayAndSpeciesRow[],
+	sessionDates?: string[]
+) {
+	const daySpeciesStats = rows;
 	const stats: SessionStatsData = {
-		daySpeciesCounts,
+		daySpeciesStats,
 		sessionDates: sessionDates ?? [
 			...new Set(rows.map((row) => row.visit_date))
 		]
@@ -953,14 +971,14 @@ describe('deriveFirstEverSpecies', () => {
 // ---- deriveFirstOfYearSpecies ----
 
 function deriveFirstOfYear(
-	rows: DaySpeciesMetricRow[],
+	rows: StatsPerDayAndSpeciesRow[],
 	{
 		sessionDates,
 		today = PAST_PERIOD_TODAY
 	}: { sessionDates?: string[]; today?: Date } = {}
 ) {
 	const stats: SessionStatsData = {
-		daySpeciesCounts: rows,
+		daySpeciesStats: rows,
 		sessionDates: sessionDates ?? [
 			...new Set(rows.map((row) => row.visit_date))
 		]

--- a/app/models/db.ts
+++ b/app/models/db.ts
@@ -30,3 +30,5 @@ export type NotableRetrapsResult =
 	Database['public']['Functions']['notable_retraps']['Returns'][number];
 export type LongAbsenceRetrapsResult =
 	Database['public']['Functions']['long_absence_retraps']['Returns'][number];
+export type StatsPerDayAndSpeciesRow =
+	Database['public']['Functions']['stats_per_day_and_species']['Returns'][number];

--- a/app/models/db.ts
+++ b/app/models/db.ts
@@ -19,8 +19,6 @@ export type TopSpeciesArgs =
 
 export type TopMetricsFilterParams =
 	Database['public']['CompositeTypes']['top_metrics_filter_params'];
-export type DaySpeciesMetricRow =
-	Database['public']['Functions']['metrics_by_period_and_species']['Returns'][number];
 export type AggregateStatsRow =
 	Database['public']['Functions']['aggregate_stats']['Returns'][number];
 

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -10,7 +10,7 @@ import {
 	isCurrentSeasonPeriod
 } from '@/app/models/seasons';
 import type {
-	DaySpeciesMetricRow,
+	StatsPerDayAndSpeciesRow,
 	LongAbsenceRetrapsResult
 } from '@/app/models/db';
 
@@ -27,10 +27,11 @@ export const RECORD_SCOPES = [
 export type RecordScope = (typeof RECORD_SCOPES)[number];
 
 // Everything needed to compare a session against the group's history,
-// fetched once per group: per-day-per-species encounter counts plus the
-// full list of session dates (so zero-encounter sessions still count)
+// fetched once per group: per-day-per-species stats (encounter counts,
+// weighed-bird counts, weight extremes) plus the full list of session
+// dates (so zero-encounter sessions still count)
 export type SessionStatsData = {
-	daySpeciesCounts: DaySpeciesMetricRow[];
+	daySpeciesStats: StatsPerDayAndSpeciesRow[];
 	sessionDates: string[];
 };
 
@@ -155,20 +156,20 @@ type DayTotals = {
 // Highlights compare the session against every other session in scope,
 // whenever it happened — later data can erase or demote a record
 export function buildDayTotals({
-	daySpeciesCounts,
+	daySpeciesStats,
 	sessionDates
 }: SessionStatsData): DayTotals[] {
 	const totalsByDate = new Map<string, DayTotals>();
 	for (const date of sessionDates) {
 		totalsByDate.set(date, { date, encounters: 0, species: 0 });
 	}
-	for (const row of daySpeciesCounts) {
+	for (const row of daySpeciesStats) {
 		const dayTotals = totalsByDate.get(row.visit_date) ?? {
 			date: row.visit_date,
 			encounters: 0,
 			species: 0
 		};
-		dayTotals.encounters += row.metric_value;
+		dayTotals.encounters += row.encounter_count;
 		dayTotals.species += 1;
 		totalsByDate.set(row.visit_date, dayTotals);
 	}
@@ -314,7 +315,7 @@ export function deriveSpeciesRecords({
 	today?: Date;
 }): SpeciesCountRecordHighlight[] {
 	const sessionDate = new Date(date);
-	const sessionRows = stats.daySpeciesCounts.filter(
+	const sessionRows = stats.daySpeciesStats.filter(
 		(row) => row.visit_date === date
 	);
 	if (sessionRows.length === 0) return [];
@@ -329,13 +330,13 @@ export function deriveSpeciesRecords({
 
 	const highlights: SpeciesCountRecordHighlight[] = [];
 	for (const sessionRow of sessionRows) {
-		const { species_name: speciesName, metric_value: sessionValue } =
+		const { species_name: speciesName, encounter_count: sessionValue } =
 			sessionRow;
 		// A single bird is never a notable count, whatever the history says
 		if (sessionValue === 1) continue;
 		for (const scope of RECORD_SCOPES) {
 			const scopeMatcher = getScopeMatcher(scope, sessionDate);
-			const otherRowsInScope = stats.daySpeciesCounts.filter(
+			const otherRowsInScope = stats.daySpeciesStats.filter(
 				(row) =>
 					row.species_name === speciesName &&
 					row.visit_date !== date &&
@@ -345,7 +346,7 @@ export function deriveSpeciesRecords({
 			// in scope (otherwise it's first-ever territory, covered by #317)
 			if (otherRowsInScope.length === 0) continue;
 			const bestOtherValue = Math.max(
-				...otherRowsInScope.map((row) => row.metric_value)
+				...otherRowsInScope.map((row) => row.encounter_count)
 			);
 			const baseHighlight: SpeciesCountRecordHighlight = {
 				type: 'species-count-record',
@@ -365,7 +366,7 @@ export function deriveSpeciesRecords({
 				const mostRecentPriorTieDate = otherRowsInScope
 					.filter(
 						(row) =>
-							row.metric_value === bestOtherValue && row.visit_date < date
+							row.encounter_count === bestOtherValue && row.visit_date < date
 					)
 					.map((row) => row.visit_date)
 					.sort()
@@ -384,7 +385,7 @@ export function deriveSpeciesRecords({
 			if (scope === 'all-time') {
 				const placement = deriveAllTimePlacement(
 					sessionValue,
-					otherRowsInScope.map((row) => row.metric_value)
+					otherRowsInScope.map((row) => row.encounter_count)
 				);
 				if (placement) {
 					highlights.push({ ...baseHighlight, ...placement });
@@ -409,7 +410,7 @@ export function deriveFirstEverSpecies({
 	date: string;
 	stats: SessionStatsData;
 }): FirstEverSpeciesHighlight[] {
-	const sessionRows = stats.daySpeciesCounts.filter(
+	const sessionRows = stats.daySpeciesStats.filter(
 		(row) => row.visit_date === date
 	);
 	if (sessionRows.length === 0) return [];
@@ -422,7 +423,7 @@ export function deriveFirstEverSpecies({
 	return sessionRows
 		.filter(
 			(sessionRow) =>
-				!stats.daySpeciesCounts.some(
+				!stats.daySpeciesStats.some(
 					(row) =>
 						row.species_name === sessionRow.species_name &&
 						row.visit_date < date
@@ -431,10 +432,10 @@ export function deriveFirstEverSpecies({
 		.map((sessionRow) => ({
 			type: 'first-ever-species' as const,
 			speciesName: sessionRow.species_name,
-			multipleIndividualsRecorded: sessionRow.metric_value > 1,
+			multipleIndividualsRecorded: sessionRow.encounter_count > 1,
 			// The species' only records ever — later days revoke this, so a
 			// "first ever" can lose its "only" copy as more data arrives
-			isOnlyRecord: !stats.daySpeciesCounts.some(
+			isOnlyRecord: !stats.daySpeciesStats.some(
 				(row) =>
 					row.species_name === sessionRow.species_name &&
 					row.visit_date !== date
@@ -456,7 +457,7 @@ export function deriveFirstOfYearSpecies({
 	stats: SessionStatsData;
 	today?: Date;
 }): FirstOfYearSpeciesHighlight[] {
-	const sessionRows = stats.daySpeciesCounts.filter(
+	const sessionRows = stats.daySpeciesStats.filter(
 		(row) => row.visit_date === date
 	);
 	if (sessionRows.length === 0) return [];
@@ -469,7 +470,7 @@ export function deriveFirstOfYearSpecies({
 	const year = Number(date.slice(0, 4));
 	return sessionRows
 		.filter((sessionRow) => {
-			const priorDates = stats.daySpeciesCounts
+			const priorDates = stats.daySpeciesStats
 				.filter(
 					(row) =>
 						row.species_name === sessionRow.species_name &&
@@ -486,11 +487,11 @@ export function deriveFirstOfYearSpecies({
 			speciesName: sessionRow.species_name,
 			year,
 			isCurrentYear: year === today.getFullYear(),
-			multipleIndividualsRecorded: sessionRow.metric_value > 1,
+			multipleIndividualsRecorded: sessionRow.encounter_count > 1,
 			// The species' only records this calendar year — a later day in the
 			// same year revokes this; prior-year records don't (they're what
 			// makes it first-of-year rather than first-ever)
-			isOnlyRecord: !stats.daySpeciesCounts.some(
+			isOnlyRecord: !stats.daySpeciesStats.some(
 				(row) =>
 					row.species_name === sessionRow.species_name &&
 					row.visit_date !== date &&

--- a/supabase/__tests__/rpc-functions.test.ts
+++ b/supabase/__tests__/rpc-functions.test.ts
@@ -8,7 +8,8 @@
  * Run with: npm run test:integration
  */
 
-import { describe, it, beforeAll, expect } from 'vitest';
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import { execSync } from 'child_process';
 import { getAuthenticatedSupabaseClientForGroup } from '../../lib/group-auth';
 import { supabase } from '../../lib/supabase';
 import type { SupabaseClient } from '@supabase/supabase-js';
@@ -50,16 +51,20 @@ const ARRETRAP_PROVEN_AGE = 3;
 describe('Postgres RPC integration tests', () => {
 	let alphaId: number;
 	let betaId: number;
+	let gammaId: number;
 	let alphaClient: SupabaseClient;
 	let betaClient: SupabaseClient;
+	let gammaClient: SupabaseClient;
 
 	beforeAll(async () => {
 		alphaId = await getGroupIdByName('Alpha');
 		betaId = await getGroupIdByName('Beta');
+		gammaId = await getGroupIdByName('Gamma');
 
-		[alphaClient, betaClient] = await Promise.all([
+		[alphaClient, betaClient, gammaClient] = await Promise.all([
 			getAuthenticatedSupabaseClientForGroup(alphaId),
 			getAuthenticatedSupabaseClientForGroup(betaId),
+			getAuthenticatedSupabaseClientForGroup(gammaId),
 		]);
 	});
 
@@ -638,6 +643,210 @@ describe('Postgres RPC integration tests', () => {
 			});
 			expect(error).toBeNull();
 			expect(data).toHaveLength(0);
+		});
+	});
+
+	describe('stats_per_day_and_species', () => {
+		it('returns encounter count, weighted birds count and weight extremes per day and species', async () => {
+			// Seed 2021-06-20: ARRETRAP (Robin, 18.5) and AWREN001 (Wren, 9.0).
+			const { data, error } = await alphaClient.rpc('stats_per_day_and_species', {
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			const dayRows = data!.filter((row) => row.visit_date === '2021-06-20');
+			expect(dayRows).toHaveLength(2);
+			expect(dayRows).toContainEqual({
+				species_name: 'Robin',
+				visit_date: '2021-06-20',
+				encounter_count: 1,
+				weighted_birds_count: 1,
+				min_weight: 18.5,
+				max_weight: 18.5,
+			});
+			expect(dayRows).toContainEqual({
+				species_name: 'Wren',
+				visit_date: '2021-06-20',
+				encounter_count: 1,
+				weighted_birds_count: 1,
+				min_weight: 9,
+				max_weight: 9,
+			});
+		});
+
+		it('aggregates multiple weighted encounters on one day into a single row', async () => {
+			// Seed 2022-06-15 Robins: 19.0, 17.2, 16.5, 20.5, 19.5, 17.0 — six encounters.
+			const { data, error } = await alphaClient.rpc('stats_per_day_and_species', {
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			const robinRow = data!.find(
+				(row) => row.visit_date === '2022-06-15' && row.species_name === 'Robin'
+			);
+			expect(robinRow).toEqual({
+				species_name: 'Robin',
+				visit_date: '2022-06-15',
+				encounter_count: 6,
+				weighted_birds_count: 6,
+				min_weight: 16.5,
+				max_weight: 20.5,
+			});
+		});
+
+		it("excludes other groups' data", async () => {
+			// Beta's only session is 2023-06-01 (two Chaffinches + its own SHARED01
+			// Robin encounter). None of Alpha's sessions appear despite Alpha→Beta
+			// sharing, because both Encounters and Sessions are group-filtered.
+			const { data, error } = await betaClient.rpc('stats_per_day_and_species', {
+				ringing_group_filter: betaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(2);
+			expect(data).toContainEqual({
+				species_name: 'Chaffinch',
+				visit_date: '2023-06-01',
+				encounter_count: 2,
+				weighted_birds_count: 2,
+				min_weight: 18.5,
+				max_weight: 20,
+			});
+			expect(data).toContainEqual({
+				species_name: 'Robin',
+				visit_date: '2023-06-01',
+				encounter_count: 1,
+				weighted_birds_count: 1,
+				min_weight: 18.5,
+				max_weight: 18.5,
+			});
+		});
+
+		it('returns no rows for a group with no encounters', async () => {
+			const { data, error } = await gammaClient.rpc('stats_per_day_and_species', {
+				ringing_group_filter: gammaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toHaveLength(0);
+		});
+
+		describe('unweighted encounters', () => {
+			// Seed encounters all carry a weight, so insert Delta-group encounters
+			// (one weighted, two unweighted) across two sessions and clean up after.
+			let deltaId: number;
+			let deltaClient: SupabaseClient;
+			let locationId: number;
+			let sessionIds: number[];
+			let birdIds: number[];
+
+			beforeAll(async () => {
+				deltaId = await getGroupIdByName('Delta');
+				deltaClient = await getAuthenticatedSupabaseClientForGroup(deltaId);
+
+				const { data: species } = await supabase
+					.from('Species')
+					.select('id')
+					.eq('species_name', 'Robin')
+					.single();
+
+				const { data: location, error: locationError } = await deltaClient
+					.from('Locations')
+					.insert({
+						location_name: 'Stats Per Day Test Location',
+						ringing_group_id: deltaId,
+					})
+					.select('id')
+					.single();
+				if (locationError) throw locationError;
+				locationId = location!.id;
+
+				const sessions = await Promise.all(
+					['2098-06-01', '2098-06-02'].map((visitDate) =>
+						deltaClient
+							.from('Sessions')
+							.insert({ visit_date: visitDate, location_id: locationId })
+							.select('id')
+							.single()
+					)
+				);
+				sessions.forEach(({ error }) => {
+					if (error) throw error;
+				});
+				sessionIds = sessions.map(({ data }) => data!.id);
+
+				const birds = await Promise.all(
+					['STATSTEST1', 'STATSTEST2', 'STATSTEST3'].map((ringNo) =>
+						deltaClient
+							.from('Birds')
+							.insert({ ring_no: ringNo, species_id: species!.id })
+							.select('id')
+							.single()
+					)
+				);
+				birds.forEach(({ error }) => {
+					if (error) throw error;
+				});
+				birdIds = birds.map(({ data }) => data!.id);
+
+				const baseEncounter = {
+					capture_time: '10:00:00',
+					scheme: 'BTO',
+					sex: 'M',
+					age_code: 1,
+					record_type: 'N',
+				};
+				const { error: encountersError } = await deltaClient
+					.from('Encounters')
+					.insert([
+						// 2098-06-01: one weighted + one unweighted encounter
+						{ ...baseEncounter, bird_id: birdIds[0], session_id: sessionIds[0], weight: 15 },
+						{ ...baseEncounter, bird_id: birdIds[1], session_id: sessionIds[0] },
+						// 2098-06-02: only an unweighted encounter
+						{ ...baseEncounter, bird_id: birdIds[2], session_id: sessionIds[1] },
+					]);
+				if (encountersError) throw encountersError;
+			});
+
+			afterAll(() => {
+				execSync(
+					`psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -c '` +
+						`DELETE FROM "Encounters" WHERE bird_id IN (${birdIds.join(', ')});` +
+						`DELETE FROM "Birds" WHERE id IN (${birdIds.join(', ')});` +
+						`DELETE FROM "Sessions" WHERE id IN (${sessionIds.join(', ')});` +
+						`DELETE FROM "Locations" WHERE id = ${locationId};'`
+				);
+			});
+
+			it('counts unweighted encounters in encounter_count but not weighted_birds_count', async () => {
+				const { data, error } = await deltaClient.rpc('stats_per_day_and_species', {
+					ringing_group_filter: deltaId,
+				});
+				expect(error).toBeNull();
+				expect(
+					data!.find((row) => row.visit_date === '2098-06-01')
+				).toEqual({
+					species_name: 'Robin',
+					visit_date: '2098-06-01',
+					encounter_count: 2,
+					weighted_birds_count: 1,
+					min_weight: 15,
+					max_weight: 15,
+				});
+			});
+
+			it('returns null weight extremes and zero weighted_birds_count for a day with only unweighted encounters', async () => {
+				const { data, error } = await deltaClient.rpc('stats_per_day_and_species', {
+					ringing_group_filter: deltaId,
+				});
+				expect(error).toBeNull();
+				expect(
+					data!.find((row) => row.visit_date === '2098-06-02')
+				).toEqual({
+					species_name: 'Robin',
+					visit_date: '2098-06-02',
+					encounter_count: 1,
+					weighted_birds_count: 0,
+					min_weight: null,
+					max_weight: null,
+				});
+			});
 		});
 	});
 });

--- a/supabase/__tests__/rpc-functions.test.ts
+++ b/supabase/__tests__/rpc-functions.test.ts
@@ -647,7 +647,7 @@ describe('Postgres RPC integration tests', () => {
 	});
 
 	describe('stats_per_day_and_species', () => {
-		it('returns encounter count, weighted birds count and weight extremes per day and species', async () => {
+		it('returns encounter count, weighed birds count and weight extremes per day and species', async () => {
 			// Seed 2021-06-20: ARRETRAP (Robin, 18.5) and AWREN001 (Wren, 9.0).
 			const { data, error } = await alphaClient.rpc('stats_per_day_and_species', {
 				ringing_group_filter: alphaId,
@@ -659,7 +659,7 @@ describe('Postgres RPC integration tests', () => {
 				species_name: 'Robin',
 				visit_date: '2021-06-20',
 				encounter_count: 1,
-				weighted_birds_count: 1,
+				weighed_birds_count: 1,
 				min_weight: 18.5,
 				max_weight: 18.5,
 			});
@@ -667,13 +667,13 @@ describe('Postgres RPC integration tests', () => {
 				species_name: 'Wren',
 				visit_date: '2021-06-20',
 				encounter_count: 1,
-				weighted_birds_count: 1,
+				weighed_birds_count: 1,
 				min_weight: 9,
 				max_weight: 9,
 			});
 		});
 
-		it('aggregates multiple weighted encounters on one day into a single row', async () => {
+		it('aggregates multiple weighed encounters on one day into a single row', async () => {
 			// Seed 2022-06-15 Robins: 19.0, 17.2, 16.5, 20.5, 19.5, 17.0 — six encounters.
 			const { data, error } = await alphaClient.rpc('stats_per_day_and_species', {
 				ringing_group_filter: alphaId,
@@ -686,7 +686,7 @@ describe('Postgres RPC integration tests', () => {
 				species_name: 'Robin',
 				visit_date: '2022-06-15',
 				encounter_count: 6,
-				weighted_birds_count: 6,
+				weighed_birds_count: 6,
 				min_weight: 16.5,
 				max_weight: 20.5,
 			});
@@ -705,7 +705,7 @@ describe('Postgres RPC integration tests', () => {
 				species_name: 'Chaffinch',
 				visit_date: '2023-06-01',
 				encounter_count: 2,
-				weighted_birds_count: 2,
+				weighed_birds_count: 2,
 				min_weight: 18.5,
 				max_weight: 20,
 			});
@@ -713,7 +713,7 @@ describe('Postgres RPC integration tests', () => {
 				species_name: 'Robin',
 				visit_date: '2023-06-01',
 				encounter_count: 1,
-				weighted_birds_count: 1,
+				weighed_birds_count: 1,
 				min_weight: 18.5,
 				max_weight: 18.5,
 			});
@@ -727,9 +727,9 @@ describe('Postgres RPC integration tests', () => {
 			expect(data).toHaveLength(0);
 		});
 
-		describe('unweighted encounters', () => {
+		describe('unweighed encounters', () => {
 			// Seed encounters all carry a weight, so insert Delta-group encounters
-			// (one weighted, two unweighted) across two sessions and clean up after.
+			// (one weighed, two unweighed) across two sessions and clean up after.
 			let deltaId: number;
 			let deltaClient: SupabaseClient;
 			let locationId: number;
@@ -795,10 +795,10 @@ describe('Postgres RPC integration tests', () => {
 				const { error: encountersError } = await deltaClient
 					.from('Encounters')
 					.insert([
-						// 2098-06-01: one weighted + one unweighted encounter
+						// 2098-06-01: one weighed + one unweighed encounter
 						{ ...baseEncounter, bird_id: birdIds[0], session_id: sessionIds[0], weight: 15 },
 						{ ...baseEncounter, bird_id: birdIds[1], session_id: sessionIds[0] },
-						// 2098-06-02: only an unweighted encounter
+						// 2098-06-02: only an unweighed encounter
 						{ ...baseEncounter, bird_id: birdIds[2], session_id: sessionIds[1] },
 					]);
 				if (encountersError) throw encountersError;
@@ -814,7 +814,7 @@ describe('Postgres RPC integration tests', () => {
 				);
 			});
 
-			it('counts unweighted encounters in encounter_count but not weighted_birds_count', async () => {
+			it('counts unweighed encounters in encounter_count but not weighed_birds_count', async () => {
 				const { data, error } = await deltaClient.rpc('stats_per_day_and_species', {
 					ringing_group_filter: deltaId,
 				});
@@ -825,13 +825,13 @@ describe('Postgres RPC integration tests', () => {
 					species_name: 'Robin',
 					visit_date: '2098-06-01',
 					encounter_count: 2,
-					weighted_birds_count: 1,
+					weighed_birds_count: 1,
 					min_weight: 15,
 					max_weight: 15,
 				});
 			});
 
-			it('returns null weight extremes and zero weighted_birds_count for a day with only unweighted encounters', async () => {
+			it('returns null weight extremes and zero weighed_birds_count for a day with only unweighed encounters', async () => {
 				const { data, error } = await deltaClient.rpc('stats_per_day_and_species', {
 					ringing_group_filter: deltaId,
 				});
@@ -842,7 +842,7 @@ describe('Postgres RPC integration tests', () => {
 					species_name: 'Robin',
 					visit_date: '2098-06-02',
 					encounter_count: 1,
-					weighted_birds_count: 0,
+					weighed_birds_count: 0,
 					min_weight: null,
 					max_weight: null,
 				});

--- a/supabase/schema/schemas/public/functions/stats_per_day_and_species.sql
+++ b/supabase/schema/schemas/public/functions/stats_per_day_and_species.sql
@@ -2,7 +2,7 @@ CREATE FUNCTION public.stats_per_day_and_species (ringing_group_filter bigint) R
 	species_name text,
 	visit_date date,
 	encounter_count bigint,
-	weighted_birds_count bigint,
+	weighed_birds_count bigint,
 	min_weight numeric,
 	max_weight numeric
 ) LANGUAGE plpgsql STABLE
@@ -15,7 +15,7 @@ BEGIN
     sp.species_name AS species_name,
     sess.visit_date AS visit_date,
     COUNT(e.*) AS encounter_count,
-    COUNT(e.*) FILTER (WHERE e.weight IS NOT NULL) AS weighted_birds_count,
+    COUNT(e.*) FILTER (WHERE e.weight IS NOT NULL) AS weighed_birds_count,
     MIN(e.weight::numeric) AS min_weight,
     MAX(e.weight::numeric) AS max_weight
   FROM

--- a/supabase/schema/schemas/public/functions/stats_per_day_and_species.sql
+++ b/supabase/schema/schemas/public/functions/stats_per_day_and_species.sql
@@ -1,0 +1,39 @@
+CREATE FUNCTION public.stats_per_day_and_species (ringing_group_filter bigint) RETURNS TABLE (
+	species_name text,
+	visit_date date,
+	encounter_count bigint,
+	weighted_birds_count bigint,
+	min_weight numeric,
+	max_weight numeric
+) LANGUAGE plpgsql STABLE
+SET
+	search_path TO 'public',
+	'pg_catalog' AS $function$
+BEGIN
+  RETURN QUERY
+  SELECT
+    sp.species_name AS species_name,
+    sess.visit_date AS visit_date,
+    COUNT(e.*) AS encounter_count,
+    COUNT(e.*) FILTER (WHERE e.weight IS NOT NULL) AS weighted_birds_count,
+    MIN(e.weight::numeric) AS min_weight,
+    MAX(e.weight::numeric) AS max_weight
+  FROM
+    public."Birds" b
+    LEFT JOIN public."Encounters" e ON b.id = e.bird_id
+    LEFT JOIN public."Sessions" sess ON e.session_id = sess.id
+    LEFT JOIN public."Species" sp ON b.species_id = sp.id
+  WHERE
+    sess.visit_date IS NOT NULL
+    AND e.ringing_group_id = ringing_group_filter
+    AND sess.ringing_group_id = ringing_group_filter
+  GROUP BY
+    sess.visit_date, sp.species_name;
+END;
+$function$;
+
+GRANT ALL ON FUNCTION public.stats_per_day_and_species (bigint) TO anon;
+
+GRANT ALL ON FUNCTION public.stats_per_day_and_species (bigint) TO authenticated;
+
+GRANT ALL ON FUNCTION public.stats_per_day_and_species (bigint) TO service_role;

--- a/types/supabase.types.ts
+++ b/types/supabase.types.ts
@@ -425,7 +425,7 @@ export type Database = {
           min_weight: number
           species_name: string
           visit_date: string
-          weighted_birds_count: number
+          weighed_birds_count: number
         }[]
       }
       text_soundex: { Args: { "": string }; Returns: string }

--- a/types/supabase.types.ts
+++ b/types/supabase.types.ts
@@ -417,6 +417,17 @@ export type Database = {
         }[]
       }
       soundex: { Args: { "": string }; Returns: string }
+      stats_per_day_and_species: {
+        Args: { ringing_group_filter: number }
+        Returns: {
+          encounter_count: number
+          max_weight: number
+          min_weight: number
+          species_name: string
+          visit_date: string
+          weighted_birds_count: number
+        }[]
+      }
       text_soundex: { Args: { "": string }; Returns: string }
       top_metrics_by_period: {
         Args: {


### PR DESCRIPTION
## What this covers

Adds the `stats_per_day_and_species` RPC — one row per (day, species), one column per stat needed to derive session highlights. Replaces the per-session-RPC approach of #345 with the `deriveSessionTotalRecords` pattern: fetch the whole per-group series once, memoise it (the existing 1-hour `sessionStatsCache`), and derive records in the app model layer. Record comparisons, tie rules, and the `min_prior_weighed` threshold stay in testable TypeScript, not SQL.

**Signature:** `stats_per_day_and_species(ringing_group_filter bigint)` → `TABLE (species_name text, visit_date date, encounter_count bigint, weighed_birds_count bigint, min_weight numeric, max_weight numeric)`

**Behaviour:**
- One row per (day, species) with at least one encounter; days with no weighed encounters still get a row (`weighed_birds_count = 0`, NULL extremes) so encounter-count derivations keep working.
- Dual group filter on both `Encounters.ringing_group_id` and `Sessions.ringing_group_id` (design decision #4), matching `metrics_by_period_and_species`.
- `weight::numeric` cast (column is `real`); PostgREST serialises as JS numbers.
- Deliberately excluded: record/tie/threshold logic (model-layer concerns) and stats no highlight needs yet (distinct individuals, wing, age) — additive migrations later if wanted.

Includes the schema SQL, regenerated `types/supabase.types.ts`, the `StatsPerDayAndSpeciesRow` re-export in `app/models/db.ts`, and DB integration tests.

## Tests

Six integration tests in `supabase/__tests__/rpc-functions.test.ts` (`describe stats_per_day_and_species`). Seed encounters all carry weights, so the two unweighed-encounter cases insert Delta-group data (mirroring the `triggers.test.ts` pattern) and clean up after. All 78 integration tests and full `npm run qa` (lint + type-check + 340 app tests) pass.

## Follow-ups (not this PR)

1. Rework #321: derive weight record-breaker highlights in `app/models/session-highlights.ts` from this series.
2. Migrate `fetchSessionStats`'s `daySpeciesCounts` from `metrics_by_period_and_species` to this RPC.

Migration is generated locally but not committed (gitignored); deploy via `npm run db:migration:push`.

Part of #219. Supersedes #345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
