### PR TITLE
refactor: fetch session stats via stats_per_day_and_species

### DIFF
--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { TopMetricsFilterParams } from '@/app/models/db';
+import type { StatsPerDayAndSpeciesRow } from '@/app/models/db';
 
 const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
 	mockGetAuthenticatedSupabaseClient: vi.fn()
@@ -15,12 +15,23 @@ const PAGE_SIZE = 1000;
 
 // Queries are paginated (PostgREST caps responses at 1000 rows), so the
 // mock builders serve rows page by page from these arrays
-let rpcPages: {
-	species_name: string;
-	visit_date: string;
-	metric_value: number;
-}[][];
+let rpcPages: StatsPerDayAndSpeciesRow[][];
 let sessionPages: { visit_date: string }[][];
+
+function statsRow(
+	species_name: string,
+	visit_date: string,
+	encounter_count: number
+): StatsPerDayAndSpeciesRow {
+	return {
+		species_name,
+		visit_date,
+		encounter_count,
+		weighed_birds_count: 0,
+		min_weight: 0,
+		max_weight: 0
+	};
+}
 
 function pageForRange(pages: unknown[][], fromRow: number) {
 	return Promise.resolve({
@@ -31,7 +42,7 @@ function pageForRange(pages: unknown[][], fromRow: number) {
 
 const mockRpcOrder = vi.fn();
 const mockRpcRange = vi.fn();
-// The paginated rpc (metrics_by_period_and_species) returns a query builder;
+// The paginated rpc (stats_per_day_and_species) returns a query builder;
 // the non-paginated rpc (long_absence_retraps) returns a thenable.
 const paginatedRpcQueryBuilder = { order: mockRpcOrder, range: mockRpcRange };
 const mockLongAbsenceRpcResult = Promise.resolve({ data: [], error: null });
@@ -59,9 +70,9 @@ beforeEach(() => {
 	vi.clearAllMocks();
 	rpcPages = [
 		[
-			{ species_name: 'Robin', visit_date: SESSION_DATE, metric_value: 74 },
-			{ species_name: 'Robin', visit_date: '2022-05-01', metric_value: 30 },
-			{ species_name: 'Wren', visit_date: '2022-05-01', metric_value: 30 }
+			statsRow('Robin', SESSION_DATE, 74),
+			statsRow('Robin', '2022-05-01', 30),
+			statsRow('Wren', '2022-05-01', 30)
 		]
 	];
 	sessionPages = [[{ visit_date: '2022-05-01' }, { visit_date: SESSION_DATE }]];
@@ -94,28 +105,18 @@ describe('fetchSessionHighlights', () => {
 			date: SESSION_DATE,
 			viewedGroupId: GROUP_ID
 		});
-		// Two rpc calls: metrics_by_period_and_species (paginated) and
+		// Two rpc calls: stats_per_day_and_species (paginated) and
 		// long_absence_retraps (non-paginated)
 		expect(mockRpc).toHaveBeenCalledTimes(2);
 		const rpcFunctionNames = mockRpc.mock.calls.map(
 			(call) => (call as [string, unknown])[0]
 		);
-		expect(rpcFunctionNames).toContain('metrics_by_period_and_species');
+		expect(rpcFunctionNames).toContain('stats_per_day_and_species');
 		expect(rpcFunctionNames).toContain('long_absence_retraps');
-		const [, metricsArgs] = mockRpc.mock.calls.find(
-			(call) =>
-				(call as [string, unknown])[0] === 'metrics_by_period_and_species'
-		) as [
-			string,
-			{
-				temporal_unit: string;
-				metric_name: string;
-				filters: TopMetricsFilterParams;
-			}
-		];
-		expect(metricsArgs.temporal_unit).toBe('day');
-		expect(metricsArgs.metric_name).toBe('encounters');
-		expect(metricsArgs.filters.ringing_group_filter).toBe(GROUP_ID);
+		const [, statsArgs] = mockRpc.mock.calls.find(
+			(call) => (call as [string, unknown])[0] === 'stats_per_day_and_species'
+		) as [string, { ringing_group_filter: number }];
+		expect(statsArgs.ringing_group_filter).toBe(GROUP_ID);
 		expect(highlights).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
@@ -154,18 +155,10 @@ describe('fetchSessionHighlights', () => {
 
 	it('derives highlights from rows beyond the first page', async () => {
 		rpcPages = [
-			Array.from({ length: PAGE_SIZE }, (_, index) => ({
-				species_name: `Species ${index}`,
-				visit_date: '2022-05-01',
-				metric_value: 1
-			})),
-			[
-				{
-					species_name: 'Robin',
-					visit_date: SESSION_DATE,
-					metric_value: 2000
-				}
-			]
+			Array.from({ length: PAGE_SIZE }, (_, index) =>
+				statsRow(`Species ${index}`, '2022-05-01', 1)
+			),
+			[statsRow('Robin', SESSION_DATE, 2000)]
 		];
 		const fetchSessionHighlights = await importFetchSessionHighlights();
 		const highlights = await fetchSessionHighlights({
@@ -198,10 +191,10 @@ describe('fetchSessionHighlights', () => {
 			date: '2022-05-01',
 			viewedGroupId: GROUP_ID
 		});
-		// metrics_by_period_and_species is cached (called once), but
+		// stats_per_day_and_species is cached (called once), but
 		// long_absence_retraps is per-session (called twice)
 		const metricsCalls = mockRpc.mock.calls.filter(
-			(call) => (call as [string])[0] === 'metrics_by_period_and_species'
+			(call) => (call as [string])[0] === 'stats_per_day_and_species'
 		);
 		expect(metricsCalls).toHaveLength(1);
 		expect(mockEq).toHaveBeenCalledTimes(1);

--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -12,9 +12,8 @@ import {
 	type SessionStatsData
 } from '@/app/models/session-highlights';
 import type {
-	DaySpeciesMetricRow,
 	LongAbsenceRetrapsResult,
-	TopMetricsFilterParams
+	StatsPerDayAndSpeciesRow
 } from '@/app/models/db';
 
 // The stats blob only changes when new data is imported, so cache it
@@ -33,15 +32,11 @@ async function fetchSessionStats(
 		return cached.stats;
 	}
 	const supabase = await getAuthenticatedSupabaseClient();
-	const [daySpeciesCounts, sessionRows] = await Promise.all([
-		fetchAllPaginatedRows<DaySpeciesMetricRow>((fromRow, toRow) =>
+	const [daySpeciesStats, sessionRows] = await Promise.all([
+		fetchAllPaginatedRows<StatsPerDayAndSpeciesRow>((fromRow, toRow) =>
 			supabase
-				.rpc('metrics_by_period_and_species', {
-					temporal_unit: 'day',
-					metric_name: 'encounters',
-					filters: {
-						ringing_group_filter: viewedGroupId
-					} as TopMetricsFilterParams
+				.rpc('stats_per_day_and_species', {
+					ringing_group_filter: viewedGroupId
 				})
 				.order('visit_date')
 				.order('species_name')
@@ -57,7 +52,7 @@ async function fetchSessionStats(
 		)
 	]);
 	const stats: SessionStatsData = {
-		daySpeciesCounts,
+		daySpeciesStats,
 		sessionDates: sessionRows.map((row) => row.visit_date)
 	};
 	sessionStatsCache.set(viewedGroupId, {

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -14,7 +14,7 @@ import {
 	type SpeciesCountRecordHighlight
 } from '../session-highlights';
 import type {
-	DaySpeciesMetricRow,
+	StatsPerDayAndSpeciesRow,
 	LongAbsenceRetrapsResult
 } from '@/app/models/db';
 
@@ -40,22 +40,27 @@ const PRIOR_SPRING_YEAR_THREE = '2023-05-01';
 function dayRows(
 	date: string,
 	speciesCounts: Record<string, number>
-): DaySpeciesMetricRow[] {
-	return Object.entries(speciesCounts).map(([species_name, metric_value]) => ({
-		species_name,
-		visit_date: date,
-		metric_value
-	}));
+): StatsPerDayAndSpeciesRow[] {
+	return Object.entries(speciesCounts).map(
+		([species_name, encounter_count]) => ({
+			species_name,
+			visit_date: date,
+			encounter_count,
+			weighed_birds_count: 0,
+			min_weight: 0,
+			max_weight: 0
+		})
+	);
 }
 
-function statsFor(rows: DaySpeciesMetricRow[]): SessionStatsData {
+function statsFor(rows: StatsPerDayAndSpeciesRow[]): SessionStatsData {
 	return {
-		daySpeciesCounts: rows,
+		daySpeciesStats: rows,
 		sessionDates: [...new Set(rows.map((row) => row.visit_date))]
 	};
 }
 
-function derive(rows: DaySpeciesMetricRow[], today = PAST_PERIOD_TODAY) {
+function derive(rows: StatsPerDayAndSpeciesRow[], today = PAST_PERIOD_TODAY) {
 	return deriveSessionTotalRecords({
 		date: SESSION_DATE,
 		stats: statsFor(rows),
@@ -277,7 +282,7 @@ describe('deriveSessionTotalRecords', () => {
 
 	it('counts zero-encounter sessions as comparison sessions in scope', () => {
 		const stats: SessionStatsData = {
-			daySpeciesCounts: dayRows(SESSION_DATE, { Robin: 74 }),
+			daySpeciesStats: dayRows(SESSION_DATE, { Robin: 74 }),
 			sessionDates: [PRIOR_SPRING_OTHER_YEAR, SESSION_DATE]
 		};
 		const highlights = deriveSessionTotalRecords({
@@ -386,18 +391,28 @@ function speciesRow(
 	date: string,
 	species: string,
 	count: number
-): DaySpeciesMetricRow {
-	return { visit_date: date, species_name: species, metric_value: count };
+): StatsPerDayAndSpeciesRow {
+	return {
+		visit_date: date,
+		species_name: species,
+		encounter_count: count,
+		weighed_birds_count: 0,
+		min_weight: 0,
+		max_weight: 0
+	};
 }
 
-function statsForSpecies(rows: DaySpeciesMetricRow[]): SessionStatsData {
+function statsForSpecies(rows: StatsPerDayAndSpeciesRow[]): SessionStatsData {
 	return {
-		daySpeciesCounts: rows,
+		daySpeciesStats: rows,
 		sessionDates: [...new Set(rows.map((row) => row.visit_date))]
 	};
 }
 
-function deriveSpecies(rows: DaySpeciesMetricRow[], today = PAST_PERIOD_TODAY) {
+function deriveSpecies(
+	rows: StatsPerDayAndSpeciesRow[],
+	today = PAST_PERIOD_TODAY
+) {
 	return deriveSpeciesRecords({
 		date: SESSION_DATE,
 		stats: statsForSpecies(rows),
@@ -871,10 +886,13 @@ describe('buildHighlightSentence — species-count-record', () => {
 
 const FIRECREST = 'Firecrest';
 
-function deriveFirstEver(rows: DaySpeciesMetricRow[], sessionDates?: string[]) {
-	const daySpeciesCounts = rows;
+function deriveFirstEver(
+	rows: StatsPerDayAndSpeciesRow[],
+	sessionDates?: string[]
+) {
+	const daySpeciesStats = rows;
 	const stats: SessionStatsData = {
-		daySpeciesCounts,
+		daySpeciesStats,
 		sessionDates: sessionDates ?? [
 			...new Set(rows.map((row) => row.visit_date))
 		]
@@ -953,14 +971,14 @@ describe('deriveFirstEverSpecies', () => {
 // ---- deriveFirstOfYearSpecies ----
 
 function deriveFirstOfYear(
-	rows: DaySpeciesMetricRow[],
+	rows: StatsPerDayAndSpeciesRow[],
 	{
 		sessionDates,
 		today = PAST_PERIOD_TODAY
 	}: { sessionDates?: string[]; today?: Date } = {}
 ) {
 	const stats: SessionStatsData = {
-		daySpeciesCounts: rows,
+		daySpeciesStats: rows,
 		sessionDates: sessionDates ?? [
 			...new Set(rows.map((row) => row.visit_date))
 		]

--- a/app/models/db.ts
+++ b/app/models/db.ts
@@ -19,8 +19,6 @@ export type TopSpeciesArgs =
 
 export type TopMetricsFilterParams =
 	Database['public']['CompositeTypes']['top_metrics_filter_params'];
-export type DaySpeciesMetricRow =
-	Database['public']['Functions']['metrics_by_period_and_species']['Returns'][number];
 export type AggregateStatsRow =
 	Database['public']['Functions']['aggregate_stats']['Returns'][number];
 

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -10,7 +10,7 @@ import {
 	isCurrentSeasonPeriod
 } from '@/app/models/seasons';
 import type {
-	DaySpeciesMetricRow,
+	StatsPerDayAndSpeciesRow,
 	LongAbsenceRetrapsResult
 } from '@/app/models/db';
 
@@ -27,10 +27,11 @@ export const RECORD_SCOPES = [
 export type RecordScope = (typeof RECORD_SCOPES)[number];
 
 // Everything needed to compare a session against the group's history,
-// fetched once per group: per-day-per-species encounter counts plus the
-// full list of session dates (so zero-encounter sessions still count)
+// fetched once per group: per-day-per-species stats (encounter counts,
+// weighed-bird counts, weight extremes) plus the full list of session
+// dates (so zero-encounter sessions still count)
 export type SessionStatsData = {
-	daySpeciesCounts: DaySpeciesMetricRow[];
+	daySpeciesStats: StatsPerDayAndSpeciesRow[];
 	sessionDates: string[];
 };
 
@@ -155,20 +156,20 @@ type DayTotals = {
 // Highlights compare the session against every other session in scope,
 // whenever it happened — later data can erase or demote a record
 export function buildDayTotals({
-	daySpeciesCounts,
+	daySpeciesStats,
 	sessionDates
 }: SessionStatsData): DayTotals[] {
 	const totalsByDate = new Map<string, DayTotals>();
 	for (const date of sessionDates) {
 		totalsByDate.set(date, { date, encounters: 0, species: 0 });
 	}
-	for (const row of daySpeciesCounts) {
+	for (const row of daySpeciesStats) {
 		const dayTotals = totalsByDate.get(row.visit_date) ?? {
 			date: row.visit_date,
 			encounters: 0,
 			species: 0
 		};
-		dayTotals.encounters += row.metric_value;
+		dayTotals.encounters += row.encounter_count;
 		dayTotals.species += 1;
 		totalsByDate.set(row.visit_date, dayTotals);
 	}
@@ -314,7 +315,7 @@ export function deriveSpeciesRecords({
 	today?: Date;
 }): SpeciesCountRecordHighlight[] {
 	const sessionDate = new Date(date);
-	const sessionRows = stats.daySpeciesCounts.filter(
+	const sessionRows = stats.daySpeciesStats.filter(
 		(row) => row.visit_date === date
 	);
 	if (sessionRows.length === 0) return [];
@@ -329,13 +330,13 @@ export function deriveSpeciesRecords({
 
 	const highlights: SpeciesCountRecordHighlight[] = [];
 	for (const sessionRow of sessionRows) {
-		const { species_name: speciesName, metric_value: sessionValue } =
+		const { species_name: speciesName, encounter_count: sessionValue } =
 			sessionRow;
 		// A single bird is never a notable count, whatever the history says
 		if (sessionValue === 1) continue;
 		for (const scope of RECORD_SCOPES) {
 			const scopeMatcher = getScopeMatcher(scope, sessionDate);
-			const otherRowsInScope = stats.daySpeciesCounts.filter(
+			const otherRowsInScope = stats.daySpeciesStats.filter(
 				(row) =>
 					row.species_name === speciesName &&
 					row.visit_date !== date &&
@@ -345,7 +346,7 @@ export function deriveSpeciesRecords({
 			// in scope (otherwise it's first-ever territory, covered by #317)
 			if (otherRowsInScope.length === 0) continue;
 			const bestOtherValue = Math.max(
-				...otherRowsInScope.map((row) => row.metric_value)
+				...otherRowsInScope.map((row) => row.encounter_count)
 			);
 			const baseHighlight: SpeciesCountRecordHighlight = {
 				type: 'species-count-record',
@@ -365,7 +366,7 @@ export function deriveSpeciesRecords({
 				const mostRecentPriorTieDate = otherRowsInScope
 					.filter(
 						(row) =>
-							row.metric_value === bestOtherValue && row.visit_date < date
+							row.encounter_count === bestOtherValue && row.visit_date < date
 					)
 					.map((row) => row.visit_date)
 					.sort()
@@ -384,7 +385,7 @@ export function deriveSpeciesRecords({
 			if (scope === 'all-time') {
 				const placement = deriveAllTimePlacement(
 					sessionValue,
-					otherRowsInScope.map((row) => row.metric_value)
+					otherRowsInScope.map((row) => row.encounter_count)
 				);
 				if (placement) {
 					highlights.push({ ...baseHighlight, ...placement });
@@ -409,7 +410,7 @@ export function deriveFirstEverSpecies({
 	date: string;
 	stats: SessionStatsData;
 }): FirstEverSpeciesHighlight[] {
-	const sessionRows = stats.daySpeciesCounts.filter(
+	const sessionRows = stats.daySpeciesStats.filter(
 		(row) => row.visit_date === date
 	);
 	if (sessionRows.length === 0) return [];
@@ -422,7 +423,7 @@ export function deriveFirstEverSpecies({
 	return sessionRows
 		.filter(
 			(sessionRow) =>
-				!stats.daySpeciesCounts.some(
+				!stats.daySpeciesStats.some(
 					(row) =>
 						row.species_name === sessionRow.species_name &&
 						row.visit_date < date
@@ -431,10 +432,10 @@ export function deriveFirstEverSpecies({
 		.map((sessionRow) => ({
 			type: 'first-ever-species' as const,
 			speciesName: sessionRow.species_name,
-			multipleIndividualsRecorded: sessionRow.metric_value > 1,
+			multipleIndividualsRecorded: sessionRow.encounter_count > 1,
 			// The species' only records ever — later days revoke this, so a
 			// "first ever" can lose its "only" copy as more data arrives
-			isOnlyRecord: !stats.daySpeciesCounts.some(
+			isOnlyRecord: !stats.daySpeciesStats.some(
 				(row) =>
 					row.species_name === sessionRow.species_name &&
 					row.visit_date !== date
@@ -456,7 +457,7 @@ export function deriveFirstOfYearSpecies({
 	stats: SessionStatsData;
 	today?: Date;
 }): FirstOfYearSpeciesHighlight[] {
-	const sessionRows = stats.daySpeciesCounts.filter(
+	const sessionRows = stats.daySpeciesStats.filter(
 		(row) => row.visit_date === date
 	);
 	if (sessionRows.length === 0) return [];
@@ -469,7 +470,7 @@ export function deriveFirstOfYearSpecies({
 	const year = Number(date.slice(0, 4));
 	return sessionRows
 		.filter((sessionRow) => {
-			const priorDates = stats.daySpeciesCounts
+			const priorDates = stats.daySpeciesStats
 				.filter(
 					(row) =>
 						row.species_name === sessionRow.species_name &&
@@ -486,11 +487,11 @@ export function deriveFirstOfYearSpecies({
 			speciesName: sessionRow.species_name,
 			year,
 			isCurrentYear: year === today.getFullYear(),
-			multipleIndividualsRecorded: sessionRow.metric_value > 1,
+			multipleIndividualsRecorded: sessionRow.encounter_count > 1,
 			// The species' only records this calendar year — a later day in the
 			// same year revokes this; prior-year records don't (they're what
 			// makes it first-of-year rather than first-ever)
-			isOnlyRecord: !stats.daySpeciesCounts.some(
+			isOnlyRecord: !stats.daySpeciesStats.some(
 				(row) =>
 					row.species_name === sessionRow.species_name &&
 					row.visit_date !== date &&


### PR DESCRIPTION
## What this covers

Stacked on #347. Migrates `fetchSessionStats` (`app/actions/session-highlights.ts`) from `metrics_by_period_and_species` to the new `stats_per_day_and_species` RPC — one paginated, group-scoped call feeding the 1-hour memoised stats blob.

**Changes:**
- `SessionStatsData.daySpeciesCounts` → `daySpeciesStats`: rows are now `StatsPerDayAndSpeciesRow` (`encounter_count`, `weighed_birds_count`, `min_weight`, `max_weight`) instead of `DaySpeciesMetricRow` (`metric_value`). All derivations read `encounter_count`; weight fields are carried but unused until #321 derives weight records from the same blob.
- Removed the now-unused `DaySpeciesMetricRow` re-export from `app/models/db.ts`. (`metrics_by_period_and_species` itself stays in the schema — no other app callers, but dropping it is out of scope here.)
- Test fixtures updated to the new row shape (`statsRow` helper in the action tests; model-test builders fill the weight fields with zeros).

No behaviour change: identical highlights derived from identical encounter counts.

## Tests

Existing suites cover the migration: action tests assert the new RPC name/args, pagination, ordering, and caching; model tests exercise all derivations against the new row shape. Full `npm run qa` (lint + type-check + 340 app tests) and all 78 DB integration tests pass.

Part of #219. Stacked on #347 — merge that first, then rebase this onto `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)