### PR TITLE
Session highlights: weight record-breaker highlights

### DIFF
--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -181,6 +181,43 @@ describe('fetchSessionHighlights', () => {
 		);
 	});
 
+	it('includes weight record highlights in the fan-out', async () => {
+		rpcPages = [
+			[
+				{
+					species_name: 'Blue Tit',
+					visit_date: SESSION_DATE,
+					encounter_count: 5,
+					weighed_birds_count: 5,
+					min_weight: 11,
+					max_weight: 13.1
+				},
+				{
+					species_name: 'Blue Tit',
+					visit_date: '2022-05-01',
+					encounter_count: 4,
+					weighed_birds_count: 4,
+					min_weight: 10.5,
+					max_weight: 13.0
+				}
+			]
+		];
+		const fetchSessionHighlights = await importFetchSessionHighlights();
+		const highlights = await fetchSessionHighlights({
+			date: SESSION_DATE,
+			viewedGroupId: GROUP_ID
+		});
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				type: 'weight-record',
+				speciesName: 'Blue Tit',
+				extreme: 'heaviest',
+				weight: 13.1,
+				previousRecord: 13.0
+			})
+		);
+	});
+
 	it('returns cached data within the TTL', async () => {
 		const fetchSessionHighlights = await importFetchSessionHighlights();
 		await fetchSessionHighlights({

--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -7,6 +7,7 @@ import {
 	deriveLongAbsenceRetraps,
 	deriveSessionTotalRecords,
 	deriveSpeciesRecords,
+	deriveWeightRecordBreakers,
 	sortHighlights,
 	type SessionHighlight,
 	type SessionStatsData
@@ -85,6 +86,7 @@ export async function fetchSessionHighlights({
 		...deriveSpeciesRecords({ date, stats }),
 		...deriveFirstEverSpecies({ date, stats }),
 		...deriveFirstOfYearSpecies({ date, stats }),
-		...deriveLongAbsenceRetraps(longAbsenceRetrapResults, date)
+		...deriveLongAbsenceRetraps(longAbsenceRetrapResults, date),
+		...deriveWeightRecordBreakers({ date, stats })
 	]);
 }

--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -4,7 +4,8 @@ import { SessionHighlights } from '../SessionHighlights';
 import type {
 	FirstEverSpeciesHighlight,
 	LongAbsenceRetrapHighlight,
-	SessionHighlight
+	SessionHighlight,
+	WeightRecordHighlight
 } from '@/app/models/session-highlights';
 
 vi.mock('@/app/actions/session-highlights', () => ({
@@ -197,6 +198,30 @@ describe('SessionHighlights', () => {
 		expect(items.length).toBe(1);
 		expect(items[0].textContent).toBe(
 			'Robin ARRETRAP recaught after 2 years, 10 months away (last seen 20 Jun 2021)'
+		);
+	});
+
+	it('renders weight record sentences', async () => {
+		const weightHighlight: WeightRecordHighlight = {
+			type: 'weight-record',
+			speciesName: 'Blue Tit',
+			extreme: 'heaviest',
+			weight: 13.1,
+			previousRecord: 13.0
+		};
+		const { fetchSessionHighlights } =
+			await import('@/app/actions/session-highlights');
+		vi.mocked(fetchSessionHighlights).mockResolvedValue([weightHighlight]);
+		render(<SessionHighlights date="2024-09-15" viewedGroupId={1} />);
+		await waitFor(() => {
+			expect(screen.getByRole('heading', { name: 'Highlights' })).toBeDefined();
+		});
+		const items = screen
+			.getByTestId('session-highlights')
+			.querySelectorAll('li');
+		expect(items.length).toBe(1);
+		expect(items[0].textContent).toBe(
+			'Heaviest Blue Tit ever weighed — 13.1g (previous record 13g)'
 		);
 	});
 });

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -6,12 +6,14 @@ import {
 	deriveFirstOfYearSpecies,
 	deriveSessionTotalRecords,
 	deriveSpeciesRecords,
+	deriveWeightRecordBreakers,
 	type FirstEverSpeciesHighlight,
 	type FirstOfYearSpeciesHighlight,
 	type LongAbsenceRetrapHighlight,
 	type SessionStatsData,
 	type SessionTotalRecordHighlight,
-	type SpeciesCountRecordHighlight
+	type SpeciesCountRecordHighlight,
+	type WeightRecordHighlight
 } from '../session-highlights';
 import type {
 	StatsPerDayAndSpeciesRow,
@@ -1270,5 +1272,199 @@ describe('buildHighlightSentence — long-absence-retrap', () => {
 		).toBe(
 			'Robin ARRETRAP recaught after 3 years away (last seen 20 Jun 2021)'
 		);
+	});
+});
+
+// ---- deriveWeightRecordBreakers ----
+
+const BLUE_TIT = 'Blue Tit';
+
+function weightRow(
+	date: string,
+	species: string,
+	{
+		weighedBirds = 1,
+		minWeight,
+		maxWeight
+	}: { weighedBirds?: number; minWeight: number; maxWeight: number }
+): StatsPerDayAndSpeciesRow {
+	return {
+		visit_date: date,
+		species_name: species,
+		encounter_count: weighedBirds,
+		weighed_birds_count: weighedBirds,
+		min_weight: minWeight,
+		max_weight: maxWeight
+	};
+}
+
+function deriveWeights(rows: StatsPerDayAndSpeciesRow[]) {
+	return deriveWeightRecordBreakers({
+		date: SESSION_DATE,
+		stats: statsFor(rows)
+	});
+}
+
+describe('deriveWeightRecordBreakers', () => {
+	it('returns a heaviest record beating the max across all other sessions', () => {
+		const highlights = deriveWeights([
+			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+				weighedBirds: 3,
+				minWeight: 10.5,
+				maxWeight: 13.0
+			})
+		]);
+		expect(highlights).toContainEqual({
+			type: 'weight-record',
+			speciesName: BLUE_TIT,
+			extreme: 'heaviest',
+			weight: 13.1,
+			previousRecord: 13.0
+		});
+	});
+
+	it('returns a lightest record beating the min across all other sessions', () => {
+		const highlights = deriveWeights([
+			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 9.8, maxWeight: 12 }),
+			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+				weighedBirds: 3,
+				minWeight: 10.2,
+				maxWeight: 13.0
+			})
+		]);
+		expect(highlights).toContainEqual({
+			type: 'weight-record',
+			speciesName: BLUE_TIT,
+			extreme: 'lightest',
+			weight: 9.8,
+			previousRecord: 10.2
+		});
+	});
+
+	it('suppresses a would-be record beaten by a later session', () => {
+		const highlights = deriveWeights([
+			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+				weighedBirds: 3,
+				minWeight: 10.5,
+				maxWeight: 12.5
+			}),
+			weightRow(LATER_DAY, BLUE_TIT, { minWeight: 10.9, maxWeight: 14.0 })
+		]);
+		expect(highlights.map((h) => h.extreme)).not.toContain('heaviest');
+	});
+
+	it('requires at least 3 weighed encounters on other days', () => {
+		const highlights = deriveWeights([
+			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+				weighedBirds: 2,
+				minWeight: 10.5,
+				maxWeight: 13.0
+			})
+		]);
+		expect(highlights).toEqual([]);
+	});
+
+	it('reports a prior tie older than a year as a for-N-years record', () => {
+		const highlights = deriveWeights([
+			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+			weightRow(PRIOR_AUTUMN_OTHER_YEAR, BLUE_TIT, {
+				weighedBirds: 3,
+				minWeight: 10.5,
+				maxWeight: 13.1
+			})
+		]);
+		expect(highlights).toContainEqual({
+			type: 'weight-record',
+			speciesName: BLUE_TIT,
+			extreme: 'heaviest',
+			weight: 13.1,
+			previousRecord: 13.1,
+			recordEqualledYearsAgo: 3
+		});
+	});
+
+	it('ignores ties under a year old', () => {
+		const highlights = deriveWeights([
+			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+			weightRow(PRIOR_SPRING_THIS_YEAR, BLUE_TIT, {
+				weighedBirds: 3,
+				minWeight: 10.5,
+				maxWeight: 13.1
+			})
+		]);
+		expect(highlights.map((h) => h.extreme)).not.toContain('heaviest');
+	});
+
+	it('ignores ties held only by a later session', () => {
+		const highlights = deriveWeights([
+			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+				weighedBirds: 3,
+				minWeight: 10.5,
+				maxWeight: 12.0
+			}),
+			weightRow(LATER_DAY, BLUE_TIT, { minWeight: 11.5, maxWeight: 13.1 })
+		]);
+		expect(highlights.map((h) => h.extreme)).not.toContain('heaviest');
+	});
+
+	it('ignores species with no weighed encounter in the session', () => {
+		const highlights = deriveWeights([
+			weightRow(SESSION_DATE, BLUE_TIT, {
+				weighedBirds: 0,
+				minWeight: 0,
+				maxWeight: 0
+			}),
+			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+				weighedBirds: 3,
+				minWeight: 10.5,
+				maxWeight: 13.0
+			})
+		]);
+		expect(highlights).toEqual([]);
+	});
+});
+
+// ---- buildHighlightSentence — weight-record ----
+
+function makeWeightHighlight(
+	overrides: Partial<WeightRecordHighlight> = {}
+): WeightRecordHighlight {
+	return {
+		type: 'weight-record',
+		speciesName: BLUE_TIT,
+		extreme: 'heaviest',
+		weight: 13.1,
+		previousRecord: 13.0,
+		...overrides
+	};
+}
+
+describe('buildHighlightSentence — weight-record', () => {
+	it('renders heaviest copy with previous record', () => {
+		expect(buildHighlightSentence(makeWeightHighlight())).toBe(
+			'Heaviest Blue Tit ever weighed — 13.1g (previous record 13g)'
+		);
+	});
+
+	it('renders lightest copy with previous record', () => {
+		expect(
+			buildHighlightSentence(
+				makeWeightHighlight({
+					extreme: 'lightest',
+					weight: 9.8,
+					previousRecord: 10.2
+				})
+			)
+		).toBe('Lightest Blue Tit ever weighed — 9.8g (previous record 10.2g)');
+	});
+
+	it('renders heaviest-for-N-years copy for a tie', () => {
+		expect(
+			buildHighlightSentence(makeWeightHighlight({ recordEqualledYearsAgo: 4 }))
+		).toBe('Heaviest Blue Tit for 4 years — 13.1g');
 	});
 });

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -107,12 +107,30 @@ export type LongAbsenceRetrapHighlight = {
 	gapMonths: number;
 };
 
+// Which end of the weight range broke a record this session
+export const WEIGHT_RECORD_EXTREMES = ['heaviest', 'lightest'] as const;
+export type WeightRecordExtreme = (typeof WEIGHT_RECORD_EXTREMES)[number];
+
+export type WeightRecordHighlight = {
+	type: 'weight-record';
+	speciesName: string;
+	extreme: WeightRecordExtreme;
+	// The session's record-breaking weight, in grams
+	weight: number;
+	// The extreme across all other sessions (may postdate the session)
+	previousRecord: number;
+	// Set only for ties where the equalled record is over a year old — the
+	// number of full years the record has stood
+	recordEqualledYearsAgo?: number;
+};
+
 export type SessionHighlight =
 	| SessionTotalRecordHighlight
 	| SpeciesCountRecordHighlight
 	| FirstEverSpeciesHighlight
 	| FirstOfYearSpeciesHighlight
-	| LongAbsenceRetrapHighlight;
+	| LongAbsenceRetrapHighlight
+	| WeightRecordHighlight;
 
 type PeriodFields = {
 	scope: RecordScope;
@@ -528,12 +546,102 @@ export function deriveLongAbsenceRetraps(
 	});
 }
 
+// Minimum number of weighed encounters across other days for a species
+// before a weight record is worth reporting
+const MIN_WEIGHED_ENCOUNTERS_FOR_RECORD = 3;
+
+// Weight records are inherently all-time — a species' heaviest/lightest bird
+// this session is compared against every other day it was weighed, including
+// later days (which can erase a highlight). A record needs the species to have
+// been weighed at least three times across those other days.
+export function deriveWeightRecordBreakers({
+	date,
+	stats
+}: {
+	date: string;
+	stats: SessionStatsData;
+}): WeightRecordHighlight[] {
+	const sessionDate = new Date(date);
+	const sessionRows = stats.daySpeciesStats.filter(
+		(row) => row.visit_date === date && row.weighed_birds_count > 0
+	);
+	if (sessionRows.length === 0) return [];
+
+	const highlights: WeightRecordHighlight[] = [];
+	for (const sessionRow of sessionRows) {
+		const otherWeighedRows = stats.daySpeciesStats.filter(
+			(row) =>
+				row.species_name === sessionRow.species_name &&
+				row.visit_date !== date &&
+				row.weighed_birds_count > 0
+		);
+		const otherWeighedEncounters = otherWeighedRows.reduce(
+			(total, row) => total + row.weighed_birds_count,
+			0
+		);
+		if (otherWeighedEncounters < MIN_WEIGHED_ENCOUNTERS_FOR_RECORD) continue;
+
+		for (const extreme of WEIGHT_RECORD_EXTREMES) {
+			const isHeaviest = extreme === 'heaviest';
+			const sessionWeight = isHeaviest
+				? sessionRow.max_weight
+				: sessionRow.min_weight;
+			const otherWeights = otherWeighedRows.map((row) =>
+				isHeaviest ? row.max_weight : row.min_weight
+			);
+			// The record to beat: the biggest max (heaviest) / smallest min (lightest)
+			const previousRecord = isHeaviest
+				? Math.max(...otherWeights)
+				: Math.min(...otherWeights);
+			const beatsRecord = isHeaviest
+				? sessionWeight > previousRecord
+				: sessionWeight < previousRecord;
+			const baseHighlight: WeightRecordHighlight = {
+				type: 'weight-record',
+				speciesName: sessionRow.species_name,
+				extreme,
+				weight: sessionWeight,
+				previousRecord
+			};
+			if (beatsRecord) {
+				highlights.push(baseHighlight);
+				continue;
+			}
+			if (sessionWeight === previousRecord) {
+				// The for-N-years copy describes how long the record has stood, so
+				// only a prior day holding the extreme value counts — a tie held
+				// only by a later session is unreportable
+				const mostRecentPriorTieDate = otherWeighedRows
+					.filter(
+						(row) =>
+							(isHeaviest ? row.max_weight : row.min_weight) ===
+								previousRecord && row.visit_date < date
+					)
+					.map((row) => row.visit_date)
+					.sort()
+					.at(-1);
+				if (mostRecentPriorTieDate !== undefined) {
+					const recordEqualledYearsAgo = differenceInYears(
+						sessionDate,
+						new Date(mostRecentPriorTieDate)
+					);
+					if (recordEqualledYearsAgo >= 1) {
+						highlights.push({ ...baseHighlight, recordEqualledYearsAgo });
+					}
+				}
+			}
+		}
+	}
+	return highlights;
+}
+
 const HIGHLIGHT_TYPE_PRIORITY: SessionHighlight['type'][] = [
 	'session-total-record',
 	'species-count-record',
 	'first-ever-species',
 	'first-of-year-species',
-	'long-absence-retrap'
+	'long-absence-retrap',
+	'weight-record'
 ];
 
 export function sortHighlights(
@@ -608,6 +716,20 @@ function buildSpeciesRecordsPhrase(
 	return `${highlight.speciesName} record${highlight.multipleIndividualsRecorded ? 's' : ''}`;
 }
 
+const WEIGHT_RECORD_DESCRIPTOR: Record<WeightRecordExtreme, string> = {
+	heaviest: 'Heaviest',
+	lightest: 'Lightest'
+};
+
+function buildWeightRecordSentence(highlight: WeightRecordHighlight): string {
+	const { speciesName, extreme, weight } = highlight;
+	const descriptor = WEIGHT_RECORD_DESCRIPTOR[extreme];
+	if (highlight.recordEqualledYearsAgo !== undefined) {
+		return `${descriptor} ${speciesName} for ${buildYearsAgoCopy(highlight.recordEqualledYearsAgo)} — ${weight}g`;
+	}
+	return `${descriptor} ${speciesName} ever weighed — ${weight}g (previous record ${highlight.previousRecord}g)`;
+}
+
 export function buildHighlightSentence(highlight: SessionHighlight): string {
 	switch (highlight.type) {
 		case 'session-total-record':
@@ -638,5 +760,7 @@ export function buildHighlightSentence(highlight: SessionHighlight): string {
 			);
 			return `${speciesName} ${ringNo} recaught after ${gapPhrase} away (last seen ${formattedPreviousDate})`;
 		}
+		case 'weight-record':
+			return buildWeightRecordSentence(highlight);
 	}
 }


### PR DESCRIPTION
Part of #219 · Closes #321

## What this covers

Adds "record breaker" weight highlights to the session page — heaviest and lightest bird weighed for a species on a session, judged against the group's whole history.

- New `WeightRecordHighlight` type and `deriveWeightRecordBreakers` in `app/models/session-highlights.ts`, derived purely from the memoised `stats_per_day_and_species` blob (`SessionStatsData.daySpeciesStats`) — no new RPC or action fetch, mirroring `deriveSessionTotalRecords` / `deriveSpeciesRecords`.
- Wired into the `fetchSessionHighlights` fan-out, `sortHighlights` priority list, and `buildHighlightSentence`. The generic `SessionHighlights` component needed no change.

## Semantics (all-time, mirrors session-total records)

- For the session date D, each species with a weighed encounter (`weighed_birds_count > 0`) has its `max_weight` (heaviest) and `min_weight` (lightest) compared against every other day the species was weighed — including later days, which can erase a highlight.
- Threshold: the species must have ≥3 weighed encounters across those other days, else no highlight.
- Strict beat → "Heaviest Blue Tit ever weighed — 13.1g (previous record 13g)" / lightest equivalent.
- Tie → reported only when the most recent *prior* day holding that extreme is >1 year before D → "Heaviest Blue Tit for 4 years — 13.1g" (full years, via `differenceInYears`, consistent with `recordEqualledYearsAgo`). Ties held only by a later day, or prior ties ≤1 year old, are suppressed.
- Weights rendered in grams as the raw numeric value (e.g. `13.1g`).

## Tests

- `deriveWeightRecordBreakers` — heaviest/lightest records, later-session suppression, ≥3-encounter threshold, prior tie >1 year, tie <1 year ignored, later-only tie ignored, no weighed encounter ignored.
- `buildHighlightSentence — weight-record` — heaviest/lightest copy with previous record, heaviest-for-N-years tie copy.
- `SessionHighlights` — renders weight record sentences.
- `fetchSessionHighlights` — asserts weight records appear in the fan-out.

`npm run qa` (lint + type-check + app tests, 353), `npm run test:integration` (78), and the full pre-push suite including Playwright e2e (98) all pass.

## Assumptions

- Terminology follows the owner's "record breakers" preference (type `weight-record`, `deriveWeightRecordBreakers`), superseding the stale ticket body's `session_weight_extremes` RPC / `deriveWeightExtremes` naming.
- Weights formatted with the raw numeric value, so a whole-gram previous record of `13.0` renders as `13g` (JS number formatting).
- Does NOT close #219 — the tracking issue stays open (#323 remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)