### PR TITLE
feat: session highlights 11 — busiest/quietest-since (final)

### DIFF
--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -6,6 +6,7 @@ import {
 	deriveFirstOfYearSpecies,
 	deriveLongAbsenceRetraps,
 	deriveSessionTotalRecords,
+	deriveSinceHighlights,
 	deriveSpeciesRecords,
 	deriveWeightRecordBreakers,
 	sortHighlights,
@@ -83,6 +84,7 @@ export async function fetchSessionHighlights({
 	]);
 	return sortHighlights([
 		...deriveSessionTotalRecords({ date, stats }),
+		...deriveSinceHighlights({ date, stats }),
 		...deriveSpeciesRecords({ date, stats }),
 		...deriveFirstEverSpecies({ date, stats }),
 		...deriveFirstOfYearSpecies({ date, stats }),

--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -201,6 +201,80 @@ describe('SessionHighlights', () => {
 		);
 	});
 
+	it('renders a full mixed set of highlights in priority order', async () => {
+		// One highlight from every family, already in priority order (the action
+		// sorts before returning); the component renders them as given
+		const mixedHighlights: SessionHighlight[] = [
+			{
+				type: 'session-total-record',
+				metric: 'encounters',
+				scope: 'all-time',
+				value: 74,
+				seasonName: 'autumn',
+				year: 2024,
+				isCurrentYear: false,
+				isCurrentSeason: false,
+				seasonPeriodLabel: 'autumn 2024'
+			},
+			{
+				type: 'since-comparison',
+				kind: 'quietest',
+				value: 3,
+				sinceDate: '2023-09-14'
+			},
+			{
+				type: 'species-count-record',
+				speciesName: 'Reed Warbler',
+				scope: 'all-time',
+				value: 12,
+				seasonName: 'autumn',
+				year: 2024,
+				isCurrentYear: false,
+				isCurrentSeason: false,
+				seasonPeriodLabel: 'autumn 2024'
+			},
+			{
+				type: 'first-ever-species',
+				speciesName: 'Firecrest',
+				multipleIndividualsRecorded: false,
+				isOnlyRecord: false
+			},
+			{
+				type: 'long-absence-retrap',
+				ringNo: 'ARRETRAP',
+				speciesName: 'Robin',
+				previousDate: '2021-06-20',
+				gapYears: 2,
+				gapMonths: 10
+			},
+			{
+				type: 'weight-record',
+				speciesName: 'Blue Tit',
+				extreme: 'heaviest',
+				weight: 13.1,
+				previousRecord: 13.0
+			}
+		];
+		const { fetchSessionHighlights } =
+			await import('@/app/actions/session-highlights');
+		vi.mocked(fetchSessionHighlights).mockResolvedValue(mixedHighlights);
+		render(<SessionHighlights date="2024-09-15" viewedGroupId={1} />);
+		await waitFor(() => {
+			expect(screen.getByRole('heading', { name: 'Highlights' })).toBeDefined();
+		});
+		const items = screen
+			.getByTestId('session-highlights')
+			.querySelectorAll('li');
+		expect([...items].map((item) => item.textContent)).toEqual([
+			'Busiest session ever — 74 birds',
+			'Quietest session since 14 Sep 2023 — 3 birds',
+			'Record day for Reed Warbler — 12 caught, the most ever',
+			'First ever Firecrest record',
+			'Robin ARRETRAP recaught after 2 years, 10 months away (last seen 20 Jun 2021)',
+			'Heaviest Blue Tit ever weighed — 13.1g (previous record 13g)'
+		]);
+	});
+
 	it('renders weight record sentences', async () => {
 		const weightHighlight: WeightRecordHighlight = {
 			type: 'weight-record',

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -5,13 +5,16 @@ import {
 	deriveFirstEverSpecies,
 	deriveFirstOfYearSpecies,
 	deriveSessionTotalRecords,
+	deriveSinceHighlights,
 	deriveSpeciesRecords,
 	deriveWeightRecordBreakers,
+	sortHighlights,
 	type FirstEverSpeciesHighlight,
 	type FirstOfYearSpeciesHighlight,
 	type LongAbsenceRetrapHighlight,
 	type SessionStatsData,
 	type SessionTotalRecordHighlight,
+	type SinceComparisonHighlight,
 	type SpeciesCountRecordHighlight,
 	type WeightRecordHighlight
 } from '../session-highlights';
@@ -298,6 +301,141 @@ describe('deriveSessionTotalRecords', () => {
 				value: 74
 			})
 		);
+	});
+});
+
+// ---- deriveSinceHighlights ----
+
+// A day within a month of SESSION_DATE (2024-09-15) — since dates this recent
+// are not editorial-worthy
+const WITHIN_A_MONTH = '2024-08-20';
+
+function deriveSince(
+	rows: StatsPerDayAndSpeciesRow[],
+	sessionDates?: string[]
+) {
+	const stats: SessionStatsData = {
+		daySpeciesStats: rows,
+		sessionDates: sessionDates ?? [
+			...new Set(rows.map((row) => row.visit_date))
+		]
+	};
+	return deriveSinceHighlights({ date: SESSION_DATE, stats });
+}
+
+describe('deriveSinceHighlights', () => {
+	it('returns busiest-since using the most recent prior session day with an equal-or-higher total', () => {
+		// two prior days at/above the session total; the more recent one
+		// (PRIOR_SPRING_THIS_YEAR) is the since date. A newer, quieter day gives
+		// quietest-since a later since date, so busiest wins the earlier-date
+		// tie-break and is the only highlight.
+		const highlights = deriveSince([
+			...dayRows(SESSION_DATE, { Robin: 41 }),
+			...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 50 }),
+			...dayRows(PRIOR_SPRING_THIS_YEAR, { Robin: 45 }),
+			...dayRows('2024-07-01', { Robin: 10 })
+		]);
+		expect(highlights).toEqual([
+			{
+				type: 'since-comparison',
+				kind: 'busiest',
+				value: 41,
+				sinceDate: PRIOR_SPRING_THIS_YEAR
+			}
+		]);
+	});
+
+	it('returns quietest-since using the most recent prior session day with an equal-or-lower total', () => {
+		const highlights = deriveSince([
+			...dayRows(SESSION_DATE, { Robin: 3 }),
+			...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 1 }),
+			...dayRows(PRIOR_SPRING_THIS_YEAR, { Robin: 2 }),
+			...dayRows(WITHIN_A_MONTH, { Robin: 40 })
+		]);
+		expect(highlights).toContainEqual({
+			type: 'since-comparison',
+			kind: 'quietest',
+			value: 3,
+			sinceDate: PRIOR_SPRING_THIS_YEAR
+		});
+	});
+
+	it('counts zero-encounter session days in quietest comparisons', () => {
+		// PRIOR_SPRING_THIS_YEAR is a zero-encounter session day (no rows) — it
+		// undershoots the session and, being the most recent qualifying day, is
+		// the quietest-since date. No prior day reaches the session total, so
+		// busiest is suppressed and only the zero-day-driven quietest is left.
+		const highlights = deriveSince(
+			[
+				...dayRows(SESSION_DATE, { Robin: 5 }),
+				...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 3 })
+			],
+			[PRIOR_SPRING_OTHER_YEAR, PRIOR_SPRING_THIS_YEAR, SESSION_DATE]
+		);
+		expect(highlights).toEqual([
+			{
+				type: 'since-comparison',
+				kind: 'quietest',
+				value: 5,
+				sinceDate: PRIOR_SPRING_THIS_YEAR
+			}
+		]);
+	});
+
+	it('suppresses busiest when no prior day qualifies (duplicate of all-time record)', () => {
+		const highlights = deriveSince([
+			...dayRows(SESSION_DATE, { Robin: 100 }),
+			...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 40 })
+		]);
+		expect(highlights.map((highlight) => highlight.kind)).not.toContain(
+			'busiest'
+		);
+	});
+
+	it('reports quietest-ever when no prior day qualifies and prior sessions exist', () => {
+		const highlights = deriveSince([
+			...dayRows(SESSION_DATE, { Robin: 3 }),
+			...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 40 })
+		]);
+		expect(highlights).toContainEqual({
+			type: 'since-comparison',
+			kind: 'quietest',
+			value: 3
+		});
+	});
+
+	it("suppresses quietest-ever for the group's first session", () => {
+		expect(deriveSince(dayRows(SESSION_DATE, { Robin: 3 }))).toEqual([]);
+	});
+
+	it('suppresses comparisons whose since date is within one month of the session', () => {
+		// The only prior day equals the session total, qualifying for both
+		// busiest-since and quietest-since — but it sits within a month of the
+		// session, so both are suppressed (and it isn't a quietest-ever case
+		// because a qualifying prior day does exist)
+		const highlights = deriveSince([
+			...dayRows(SESSION_DATE, { Robin: 20 }),
+			...dayRows(WITHIN_A_MONTH, { Robin: 20 })
+		]);
+		expect(highlights).toEqual([]);
+	});
+
+	it('reports only the comparison with the earlier since date when both qualify', () => {
+		// busiest-since reaches back to the older spring day; quietest-since only
+		// to the more recent one — busiest wins
+		const highlights = deriveSince([
+			...dayRows(SESSION_DATE, { Robin: 20 }),
+			...dayRows(PRIOR_SPRING_OTHER_YEAR, { Robin: 30 }),
+			...dayRows(PRIOR_SPRING_THIS_YEAR, { Robin: 10 })
+		]);
+		expect(highlights).toEqual([
+			{
+				type: 'since-comparison',
+				kind: 'busiest',
+				value: 20,
+				sinceDate: PRIOR_SPRING_OTHER_YEAR
+			}
+		]);
 	});
 });
 
@@ -1466,5 +1604,80 @@ describe('buildHighlightSentence — weight-record', () => {
 		expect(
 			buildHighlightSentence(makeWeightHighlight({ recordEqualledYearsAgo: 4 }))
 		).toBe('Heaviest Blue Tit for 4 years — 13.1g');
+	});
+});
+
+// ---- buildHighlightSentence — since ----
+
+function makeSinceHighlight(
+	overrides: Partial<SinceComparisonHighlight> = {}
+): SinceComparisonHighlight {
+	return {
+		type: 'since-comparison',
+		kind: 'busiest',
+		value: 41,
+		sinceDate: '2023-05-12',
+		...overrides
+	};
+}
+
+describe('buildHighlightSentence — since', () => {
+	it('renders busiest-since copy', () => {
+		expect(buildHighlightSentence(makeSinceHighlight())).toBe(
+			'Busiest session since 12 May 2023 — 41 birds'
+		);
+	});
+
+	it('renders quietest-since copy', () => {
+		expect(
+			buildHighlightSentence(
+				makeSinceHighlight({
+					kind: 'quietest',
+					value: 3,
+					sinceDate: '2023-09-14'
+				})
+			)
+		).toBe('Quietest session since 14 Sep 2023 — 3 birds');
+	});
+
+	it('renders quietest-ever copy', () => {
+		expect(
+			buildHighlightSentence(
+				makeSinceHighlight({ kind: 'quietest', value: 3, sinceDate: undefined })
+			)
+		).toBe('Quietest session ever — 3 birds');
+	});
+});
+
+// ---- sortHighlights ----
+
+describe('sortHighlights', () => {
+	it('orders highlights by fixed family priority', () => {
+		const weight: WeightRecordHighlight = makeWeightHighlight();
+		const longAbsence: LongAbsenceRetrapHighlight = makeLongAbsenceHighlight();
+		const firstOfYear: FirstOfYearSpeciesHighlight = makeFirstOfYearHighlight();
+		const firstEver: FirstEverSpeciesHighlight = makeFirstEverHighlight();
+		const speciesRecord: SpeciesCountRecordHighlight = makeSpeciesHighlight({});
+		const since: SinceComparisonHighlight = makeSinceHighlight();
+		const total: SessionTotalRecordHighlight = makeHighlight({});
+		// Deliberately unsorted input
+		const sorted = sortHighlights([
+			weight,
+			longAbsence,
+			firstOfYear,
+			firstEver,
+			speciesRecord,
+			since,
+			total
+		]);
+		expect(sorted.map((highlight) => highlight.type)).toEqual([
+			'session-total-record',
+			'since-comparison',
+			'species-count-record',
+			'first-ever-species',
+			'first-of-year-species',
+			'long-absence-retrap',
+			'weight-record'
+		]);
 	});
 });

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -1,7 +1,9 @@
 import {
 	differenceInYears,
 	format as formatDate,
-	intervalToDuration
+	intervalToDuration,
+	isBefore,
+	subMonths
 } from 'date-fns';
 import {
 	getSeasonMonths,
@@ -107,6 +109,23 @@ export type LongAbsenceRetrapHighlight = {
 	gapMonths: number;
 };
 
+// A busiest/quietest comparison against the most recent prior session day
+// that equalled or exceeded (busiest) / equalled or undershot (quietest) the
+// session's encounter total — "Busiest session since 12 May 2023"
+export const SINCE_COMPARISON_KINDS = ['busiest', 'quietest'] as const;
+export type SinceComparisonKind = (typeof SINCE_COMPARISON_KINDS)[number];
+
+export type SinceComparisonHighlight = {
+	type: 'since-comparison';
+	kind: SinceComparisonKind;
+	// The session's encounter total
+	value: number;
+	// ISO date of the most recent prior session day that matched the
+	// comparison (undefined for a quietest-ever highlight — no prior day
+	// undershot or matched the session)
+	sinceDate?: string;
+};
+
 // Which end of the weight range broke a record this session
 export const WEIGHT_RECORD_EXTREMES = ['heaviest', 'lightest'] as const;
 export type WeightRecordExtreme = (typeof WEIGHT_RECORD_EXTREMES)[number];
@@ -126,6 +145,7 @@ export type WeightRecordHighlight = {
 
 export type SessionHighlight =
 	| SessionTotalRecordHighlight
+	| SinceComparisonHighlight
 	| SpeciesCountRecordHighlight
 	| FirstEverSpeciesHighlight
 	| FirstOfYearSpeciesHighlight
@@ -283,6 +303,92 @@ export function deriveSessionTotalRecords({
 		}
 	}
 	return highlights;
+}
+
+// Busiest/quietest-since compares the session's encounter total against
+// prior session days only (later days can't have happened yet from the
+// editorial's point of view):
+// - busiest-since: the most recent prior day whose total >= the session's;
+//   the session has been the busiest since that day. No qualifying prior day
+//   means the session is the busiest ever — suppressed here, since the
+//   all-time busiest record from the totals family already reports it.
+// - quietest-since: the most recent prior day whose total <= the session's;
+//   the session has been the quietest since that day. No qualifying prior day
+//   means "Quietest session ever", except on the group's first session.
+// Both are only reported when the since date is more than a month before the
+// session (a recent since date isn't editorial-worthy), and when both qualify
+// only the one with the earlier since date is reported.
+export function deriveSinceHighlights({
+	date,
+	stats
+}: {
+	date: string;
+	stats: SessionStatsData;
+}): SinceComparisonHighlight[] {
+	const sessionDate = new Date(date);
+	const dayTotals = buildDayTotals(stats);
+	const currentDay = dayTotals.find((day) => day.date === date);
+	if (!currentDay) return [];
+	const sessionValue = currentDay.encounters;
+	const priorDays = dayTotals
+		.filter((day) => day.date < date)
+		.sort((a, b) => a.date.localeCompare(b.date));
+
+	// A since date only counts as "more than a month before the session" when
+	// it falls strictly before the day one month prior to the session
+	const oneMonthBeforeSession = subMonths(sessionDate, 1);
+	const isOverAMonthBefore = (sinceDate: string) =>
+		isBefore(new Date(sinceDate), oneMonthBeforeSession);
+
+	const busiestSinceDate = priorDays
+		.filter((day) => day.encounters >= sessionValue)
+		.map((day) => day.date)
+		.at(-1);
+	const quietestSinceDate = priorDays
+		.filter((day) => day.encounters <= sessionValue)
+		.map((day) => day.date)
+		.at(-1);
+
+	const candidates: SinceComparisonHighlight[] = [];
+	// Busiest is suppressed with no qualifying prior day — that case is the
+	// all-time busiest record, already covered by the totals family
+	if (busiestSinceDate !== undefined && isOverAMonthBefore(busiestSinceDate)) {
+		candidates.push({
+			type: 'since-comparison',
+			kind: 'busiest',
+			value: sessionValue,
+			sinceDate: busiestSinceDate
+		});
+	}
+	if (quietestSinceDate === undefined) {
+		// No prior day matched or undershot — quietest ever, unless this is the
+		// group's first session (nothing to be quieter than)
+		if (priorDays.length > 0) {
+			candidates.push({
+				type: 'since-comparison',
+				kind: 'quietest',
+				value: sessionValue
+			});
+		}
+	} else if (isOverAMonthBefore(quietestSinceDate)) {
+		candidates.push({
+			type: 'since-comparison',
+			kind: 'quietest',
+			value: sessionValue,
+			sinceDate: quietestSinceDate
+		});
+	}
+
+	if (candidates.length < 2) return candidates;
+	// Both qualify — report only the one with the earlier since date. A
+	// quietest-ever highlight has no since date but reaches back further than
+	// any dated comparison, so it always wins the tie-break.
+	const earliest = candidates.reduce((earlier, candidate) => {
+		if (earlier.sinceDate === undefined) return earlier;
+		if (candidate.sinceDate === undefined) return candidate;
+		return candidate.sinceDate < earlier.sinceDate ? candidate : earlier;
+	});
+	return [earliest];
 }
 
 // 2nd/3rd placements are only reported while the top tiers are sparsely
@@ -637,6 +743,7 @@ export function deriveWeightRecordBreakers({
 
 const HIGHLIGHT_TYPE_PRIORITY: SessionHighlight['type'][] = [
 	'session-total-record',
+	'since-comparison',
 	'species-count-record',
 	'first-ever-species',
 	'first-of-year-species',
@@ -721,6 +828,26 @@ const WEIGHT_RECORD_DESCRIPTOR: Record<WeightRecordExtreme, string> = {
 	lightest: 'Lightest'
 };
 
+const SINCE_COMPARISON_DESCRIPTOR: Record<SinceComparisonKind, string> = {
+	busiest: 'Busiest',
+	quietest: 'Quietest'
+};
+
+function buildSinceComparisonSentence(
+	highlight: SinceComparisonHighlight
+): string {
+	const descriptor = SINCE_COMPARISON_DESCRIPTOR[highlight.kind];
+	const valueCopy = `${highlight.value} birds`;
+	if (highlight.sinceDate === undefined) {
+		return `${descriptor} session ever — ${valueCopy}`;
+	}
+	const formattedSinceDate = formatDate(
+		new Date(highlight.sinceDate),
+		'd MMM yyyy'
+	);
+	return `${descriptor} session since ${formattedSinceDate} — ${valueCopy}`;
+}
+
 function buildWeightRecordSentence(highlight: WeightRecordHighlight): string {
 	const { speciesName, extreme, weight } = highlight;
 	const descriptor = WEIGHT_RECORD_DESCRIPTOR[extreme];
@@ -734,6 +861,8 @@ export function buildHighlightSentence(highlight: SessionHighlight): string {
 	switch (highlight.type) {
 		case 'session-total-record':
 			return buildSessionTotalRecordSentence(highlight);
+		case 'since-comparison':
+			return buildSinceComparisonSentence(highlight);
 		case 'species-count-record':
 			return buildSpeciesCountRecordSentence(highlight);
 		case 'first-ever-species':


### PR DESCRIPTION
## What this covers

The final session-highlights family from [#323](https://github.com/wheresrhys/totf/issues/323) (part of #219 — architecture v2): a **busiest/quietest-since** comparison. Model + UI only, no DB change (per the v2 stats-blob architecture; supersedes closed #322).

Derives in pure TS from the memoised per-group stats blob (`buildDayTotals`), comparing the session's encounter total against **prior** session days only:

- **busiest-since** — most recent prior day whose total ≥ the session's; suppressed when none exists (that's the all-time busiest record, already reported by the totals family).
- **quietest-since** — most recent prior day whose total ≤ the session's; "Quietest session ever" when none exists, except on the group's first session.
- Both reported only when the since date is **more than a month** before the session (date-fns `subMonths`/`isBefore`).
- Zero-encounter session days count in the comparisons.
- When both busiest-since and quietest-since qualify, only the one with the **earlier since date** is reported (quietest-ever always wins, reaching back furthest).

Also finalises the `sortHighlights` family priority: **totals → since → species records → first-ever → first-of-year → long-absence → weight**.

## Copy

- `Busiest session since 12 May 2023 — 41 birds`
- `Quietest session since 14 Sep 2023 — 3 birds`
- `Quietest session ever — 3 birds`

## Tests

- `deriveSinceHighlights` — 8 cases (busiest/quietest selection, zero-encounter days, busiest suppression, quietest-ever, first-session guard, one-month gate, earlier-since-date tie-break)
- `buildHighlightSentence — since` — busiest-since, quietest-since, quietest-ever copy
- `sortHighlights` — fixed family priority order (all seven families)
- `SessionHighlights` — full mixed set rendered in priority order

`npm run qa` passes (366 tests).

## Assumptions

- **"More than a month before"** interpreted as the since date falling strictly before the day one month prior to the session (`isBefore(sinceDate, subMonths(sessionDate, 1))`).
- **Tie-break when both qualify:** a quietest-ever highlight (no since date) reaches back further than any dated comparison, so it always wins the earlier-since-date tie-break.
- **Value unit copy** is `N birds` (matching the busiest session-total record copy).
- The parent tracking issue #219 is already closed, so this PR closes the child ticket #323 rather than the parent (per the implement-ticket convention of never closing the parent).

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)