### PR TITLE
feat: add last_encounter_date to find_discrepencies RPC (#324, 1/2)

### DIFF
--- a/supabase/__tests__/rpc-functions.test.ts
+++ b/supabase/__tests__/rpc-functions.test.ts
@@ -559,14 +559,18 @@ describe('Postgres RPC integration tests', () => {
 			});
 			expect(error).toBeNull();
 			const rows = data!
-				.map((r) => ({ ring_no: r.ring_no, type: r.discrepency_type }))
+				.map((r) => ({
+					ring_no: r.ring_no,
+					type: r.discrepency_type,
+					last_encounter_date: r.last_encounter_date,
+				}))
 				.sort((a, b) => a.ring_no.localeCompare(b.ring_no) || a.type.localeCompare(b.type));
 			expect(rows).toEqual([
-				{ ring_no: 'ABTITMIS',  type: 'age' },
-				{ ring_no: 'ABTITMIS',  type: 'sex' },
-				{ ring_no: 'AKINGF001', type: 'age' },
-				{ ring_no: 'ARRETRAP',  type: 'age' },
-				{ ring_no: 'ARRETRAP',  type: 'wing_length' },
+				{ ring_no: 'ABTITMIS',  type: 'age',         last_encounter_date: '2022-06-15' },
+				{ ring_no: 'ABTITMIS',  type: 'sex',         last_encounter_date: '2022-06-15' },
+				{ ring_no: 'AKINGF001', type: 'age',         last_encounter_date: '2023-07-08' },
+				{ ring_no: 'ARRETRAP',  type: 'age',         last_encounter_date: '2024-05-10' },
+				{ ring_no: 'ARRETRAP',  type: 'wing_length', last_encounter_date: '2024-05-10' },
 			]);
 		});
 

--- a/supabase/schema/schemas/public/functions/find_discrepencies.sql
+++ b/supabase/schema/schemas/public/functions/find_discrepencies.sql
@@ -2,7 +2,8 @@ CREATE FUNCTION public.find_discrepencies (ringing_group_filter bigint DEFAULT N
 	bird_id bigint,
 	ring_no text,
 	species_name text,
-	discrepency_type text
+	discrepency_type text,
+	last_encounter_date date
 ) LANGUAGE plpgsql STABLE
 SET
 	search_path TO 'public',
@@ -68,6 +69,7 @@ WITH
 		SELECT
 			MAX(hatch_ages.min_hatch_year) AS max_min_year,
 			MIN(hatch_ages.max_hatch_year) AS min_max_year,
+			MAX(hatch_ages.visit_date) AS last_encounter_date,
 			hatch_ages.bird_id as bird_id,
 			hatch_ages.ring_no as ring_no,
 			hatch_ages.species_name as species_name
@@ -83,10 +85,12 @@ WITH
 			b.id AS bird_id,
 			b.ring_no AS ring_no,
 			s.species_name,
-			count(DISTINCT e.sex) AS sex_count
+			count(DISTINCT e.sex) AS sex_count,
+			MAX(sess.visit_date) AS last_encounter_date
 		FROM
 			"Birds" b
 			JOIN "Encounters" e ON e.bird_id = b.id
+			JOIN "Sessions" sess ON sess.id = e.session_id
 			JOIN "Species" s ON s.id = b.species_id
 		WHERE
 			NOT e.sex ILIKE 'u'
@@ -100,9 +104,11 @@ WITH
   b.ring_no as ring_no,
   s.species_name,
   MAX(e.wing_length) as max_wing_length,
-  MIN(e.wing_length) as min_wing_length
+  MIN(e.wing_length) as min_wing_length,
+  MAX(sess.visit_date) as last_encounter_date
 from "Birds" b
 JOIN "Encounters" e on e.bird_id = b.id
+JOIN "Sessions" sess on sess.id = e.session_id
 JOIN "Species" s on s.id = b.species_id
 WHERE e.wing_length IS NOT NULL
 AND (ringing_group_filter IS NULL OR e.ringing_group_id = ringing_group_filter)
@@ -112,7 +118,8 @@ SELECT
 	hatch_year_differences.bird_id as bird_id,
 	hatch_year_differences.ring_no as ring_no,
 	hatch_year_differences.species_name as species_name,
-	'age' as discrepency_type
+	'age' as discrepency_type,
+	hatch_year_differences.last_encounter_date as last_encounter_date
 FROM
 	hatch_year_differences
 WHERE
@@ -123,7 +130,8 @@ SELECT
 	sex_counts.bird_id as bird_id,
 	sex_counts.ring_no as ring_no,
 	sex_counts.species_name as species_name,
-  'sex' as discrepency_type
+  'sex' as discrepency_type,
+	sex_counts.last_encounter_date as last_encounter_date
 FROM
 	sex_counts
 WHERE
@@ -133,7 +141,8 @@ SELECT
   wing_lengths.bird_id as bird_id,
   wing_lengths.ring_no as ring_no,
   wing_lengths.species_name as species_name,
-  'wing_length' as discrepency_type
+  'wing_length' as discrepency_type,
+  wing_lengths.last_encounter_date as last_encounter_date
 FROM wing_lengths
 WHERE max_wing_length - min_wing_length >= 5;
 

--- a/test-fixtures/snapshots/fetchMistakes.alpha.json
+++ b/test-fixtures/snapshots/fetchMistakes.alpha.json
@@ -3,30 +3,35 @@
     "bird_id": 448,
     "ring_no": "ABTITMIS",
     "species_name": "Blue Tit",
-    "discrepency_type": "age"
+    "discrepency_type": "age",
+    "last_encounter_date": "2022-06-15"
   },
   {
     "bird_id": 436,
     "ring_no": "AKINGF001",
     "species_name": "Kingfisher",
-    "discrepency_type": "age"
+    "discrepency_type": "age",
+    "last_encounter_date": "2023-07-08"
   },
   {
     "bird_id": 437,
     "ring_no": "ARRETRAP",
     "species_name": "Robin",
-    "discrepency_type": "age"
+    "discrepency_type": "age",
+    "last_encounter_date": "2024-05-10"
   },
   {
     "bird_id": 448,
     "ring_no": "ABTITMIS",
     "species_name": "Blue Tit",
-    "discrepency_type": "sex"
+    "discrepency_type": "sex",
+    "last_encounter_date": "2022-06-15"
   },
   {
     "bird_id": 437,
     "ring_no": "ARRETRAP",
     "species_name": "Robin",
-    "discrepency_type": "wing_length"
+    "discrepency_type": "wing_length",
+    "last_encounter_date": "2024-05-10"
   }
 ]

--- a/types/supabase.types.ts
+++ b/types/supabase.types.ts
@@ -315,6 +315,7 @@ export type Database = {
         Returns: {
           bird_id: number
           discrepency_type: string
+          last_encounter_date: string
           ring_no: string
           species_name: string
         }[]


### PR DESCRIPTION
## What this covers (PR 1 of 2)

DB layer for [#324](https://github.com/wheresrhys/totf/issues/324) — "Add 'last seen' to mistakes page".

Adds a `last_encounter_date` column to the `find_discrepencies` RPC. Each discrepancy row now carries the date of the bird's most recent contributing encounter, so the mistakes page (PR 2) can display and sort by "last seen".

- `find_discrepencies` return signature gains `last_encounter_date date`, computed as `MAX(visit_date)` per bird within each discrepancy CTE (age / sex / wing_length).
- Regenerated `types/supabase.types.ts`.
- Updated the `find_discrepencies` integration test to assert the new column.
- Updated the `fetchMistakes.alpha.json` snapshot fixture.

Migration is generated locally (gitignored per repo convention) and deployed by the human via `npm run db:migration:push`.

## Assumptions

- "Last seen" = the most recent encounter date among the encounters that contribute to each discrepancy type (e.g. for `sex`, only non-`u` sexed encounters; for `wing_length`, only measured encounters). This matches how the rows are already grouped and keeps the number monotonic with the underlying discrepancy data. A bird flagged under two types could in principle show two different dates, but in the seed data they coincide.

Does not close the issue — the UI increment (PR 2) will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)