### PR TITLE
feat: sortable 'last seen' column on mistakes page (#324, 2/2)

### DIFF
--- a/app/(routes)/mistakes/__tests__/page.test.tsx
+++ b/app/(routes)/mistakes/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import Page from '../page';
 import mistakesSnapshot from '@/test-fixtures/snapshots/fetchMistakes.alpha.json';
 import type { DiscrepenciesResult } from '@/app/models/db';
@@ -78,6 +78,46 @@ describe('mistakes page', () => {
 			(m) => m.discrepency_type === firstActiveType
 		)!;
 		expect(link?.getAttribute('href')).toBe(`/bird/${firstOfType.ring_no}`);
+	});
+
+	it('renders a "Last seen" column header', async () => {
+		render(await Page());
+		const table = await screen.findByRole('table');
+		const headers = [...table.querySelectorAll('thead th')].map(
+			(th) => th.textContent
+		);
+		expect(headers).toContain('Species');
+		expect(headers).toContain('Last seen');
+	});
+
+	it("renders each row's formatted last encounter date", async () => {
+		render(await Page());
+		const table = await screen.findByRole('table');
+		// ARRETRAP (Robin) last seen 2024-05-10, in the 'age' tab
+		expect(table.textContent).toContain('10 May 2024');
+	});
+
+	it('sorts rows by species ascending on first render', async () => {
+		render(await Page());
+		const table = await screen.findByRole('table');
+		const firstRowSpecies = table
+			.querySelectorAll('tbody tr')[0]
+			.querySelectorAll('td')[1].textContent;
+		// age tab species: Blue Tit, Kingfisher, Robin -> Blue Tit first
+		expect(firstRowSpecies).toBe('Blue Tit');
+	});
+
+	it('re-sorts by last seen when the column header is clicked', async () => {
+		render(await Page());
+		const table = await screen.findByRole('table');
+		const lastSeenHeader = [...table.querySelectorAll('thead th')].find((th) =>
+			th.textContent?.includes('Last seen')
+		)!;
+		fireEvent.click(lastSeenHeader);
+		const rows = table.querySelectorAll('tbody tr');
+		// desc: most recent first -> ARRETRAP (Robin) 2024-05-10
+		expect(rows[0].textContent).toContain('Robin');
+		expect(rows[0].textContent).toContain('10 May 2024');
 	});
 
 	it('renders empty tab gracefully when no data', async () => {

--- a/app/components/MistakesTable.tsx
+++ b/app/components/MistakesTable.tsx
@@ -1,18 +1,46 @@
 'use client';
 import { useState, useEffect } from 'react';
+import { format as formatDate } from 'date-fns';
 import { NoPrefetchLink } from '@/app/components/shared/NoPrefetchLink';
 import { AccordionTableBody } from '@/app/components/shared/AccordionTableBody';
 import { SingleBirdTable } from '@/app/components/SingleBirdTable';
 import { fetchBirdEncounters } from '@/app/actions/bird-encounters';
 import type { DiscrepenciesResult } from '@/app/models/db';
 import type { EncounterOfBird } from '@/app/models/bird';
-import type { RowModelWithRawData } from '@/app/components/shared/SortableTable';
+import {
+	SortableTable,
+	type ColumnConfig,
+	type RowModelWithRawData,
+	getFormattedValue
+} from '@/app/components/shared/SortableTable';
 import { TabNav } from '@/app/components/TabNav';
 
 type MistakesRowModel = {
 	ringNo: string;
 	speciesName: string;
+	lastEncounterDate: Date;
 };
+
+function dateFormatter(value: unknown): string {
+	return formatDate(value as Date, 'dd MMM yyyy');
+}
+
+const columnConfigs = {
+	ringNo: {
+		label: 'Bird',
+		invertSort: true
+	},
+	speciesName: {
+		label: 'Species',
+		invertSort: true
+	},
+	lastEncounterDate: {
+		label: 'Last seen',
+		formatter: dateFormatter
+	}
+} as Record<keyof MistakesRowModel, ColumnConfig>;
+
+const cellFormatter = getFormattedValue<MistakesRowModel>(columnConfigs);
 
 function formatTabLabel(discrepancyType: string): string {
 	const withSpaces = discrepancyType.replace(/_/g, ' ');
@@ -105,7 +133,20 @@ function RestColumns({
 }: {
 	model: RowModelWithRawData<DiscrepenciesResult, MistakesRowModel>;
 }) {
-	return <td>{model.speciesName}</td>;
+	return (
+		<>
+			<td>{model.speciesName}</td>
+			<td>{cellFormatter(model.lastEncounterDate, 'lastEncounterDate')}</td>
+		</>
+	);
+}
+
+function rowDataTransform(mistake: DiscrepenciesResult): MistakesRowModel {
+	return {
+		ringNo: mistake.ring_no,
+		speciesName: mistake.species_name,
+		lastEncounterDate: new Date(mistake.last_encounter_date)
+	};
 }
 
 function MistakesDiscrepancyTable({
@@ -113,30 +154,25 @@ function MistakesDiscrepancyTable({
 }: {
 	mistakes: DiscrepenciesResult[];
 }) {
-	const data: RowModelWithRawData<DiscrepenciesResult, MistakesRowModel>[] =
-		mistakes.map((mistake) => ({
-			ringNo: mistake.ring_no,
-			speciesName: mistake.species_name,
-			_rawRowData: mistake
-		}));
-
 	return (
-		<table className="table">
-			<thead>
-				<tr>
-					<th>Bird</th>
-					<th>Species</th>
-				</tr>
-			</thead>
-			<AccordionTableBody
-				data={data}
-				getKey={(item) => item.ringNo}
-				columnCount={2}
-				FirstColumnComponent={RingCell}
-				RestColumnsComponent={RestColumns}
-				ExpandedContentComponent={LazyBirdDetail}
-			/>
-		</table>
+		<SortableTable<DiscrepenciesResult, MistakesRowModel>
+			columnConfigs={columnConfigs}
+			data={mistakes}
+			initialSortColumn="speciesName"
+			rowDataTransform={rowDataTransform}
+			TableBodyComponent={({ data }) => (
+				<AccordionTableBody<
+					RowModelWithRawData<DiscrepenciesResult, MistakesRowModel>
+				>
+					data={data}
+					getKey={(item) => item.ringNo}
+					columnCount={Object.keys(columnConfigs).length}
+					FirstColumnComponent={RingCell}
+					RestColumnsComponent={RestColumns}
+					ExpandedContentComponent={LazyBirdDetail}
+				/>
+			)}
+		/>
 	);
 }
 


### PR DESCRIPTION
## What this covers (PR 2 of 2 — final)

UI layer for [#324](https://github.com/wheresrhys/totf/issues/324) — "Add 'last seen' to mistakes page".

- Adds a **Last seen** column to each per-discrepancy-type table, showing the bird's most recent encounter date (`dd MMM yyyy`), sourced from the `last_encounter_date` field added to `find_discrepencies` in PR 1.
- Makes the table **sortable** by reusing the existing `SortableTable` + `AccordionTableBody` pattern (same as `SpTable`). Columns are sortable; **Species** is the initial sort, and **Last seen** sorts most-recent-first on click.
- Accordion expand-to-view-bird-detail behaviour and per-type highlighting are preserved.
- New page tests: Last seen header present, formatted date rendered, initial species sort, re-sort by Last seen.

**Stacked on `feature/324-last-seen-mistakes/1-db`** — review/merge that first. Base should be retargeted to `main` once PR 1 merges.

## Assumptions

- The ticket says "sortable on species and last encounter". The shared `SortableTable` makes every column header clickable, so Ring is also clickable — consistent with existing sortable tables in the app; kept for consistency rather than special-casing.
- Species chosen as the initial/default sort.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)