### PR TITLE
feat: cache bird encounter fetches on mistakes page

### DIFF
--- a/app/(routes)/mistakes/__tests__/page.test.tsx
+++ b/app/(routes)/mistakes/__tests__/page.test.tsx
@@ -1,15 +1,29 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import {
+	render,
+	screen,
+	cleanup,
+	fireEvent,
+	waitFor
+} from '@testing-library/react';
 import Page from '../page';
 import mistakesSnapshot from '@/test-fixtures/snapshots/fetchMistakes.alpha.json';
+import birdDataSnapshot from '@/test-fixtures/snapshots/fetchBirdData.ARRETRAP.json';
+import { clearCachedBirdEncountersForTesting } from '@/app/components/MistakesTable';
 import type { DiscrepenciesResult } from '@/app/models/db';
 
-const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
-	mockGetAuthenticatedSupabaseClient: vi.fn()
-}));
+const { mockGetAuthenticatedSupabaseClient, mockFetchBirdEncounters } =
+	vi.hoisted(() => ({
+		mockGetAuthenticatedSupabaseClient: vi.fn(),
+		mockFetchBirdEncounters: vi.fn()
+	}));
 
 vi.mock('@/lib/group-auth', () => ({
 	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+vi.mock('@/app/actions/bird-encounters', () => ({
+	fetchBirdEncounters: mockFetchBirdEncounters
 }));
 
 function makeRpcClient(data: unknown) {
@@ -25,6 +39,9 @@ describe('mistakes page', () => {
 		mockGetAuthenticatedSupabaseClient.mockResolvedValue(
 			makeRpcClient(mistakesSnapshot)
 		);
+		mockFetchBirdEncounters.mockReset();
+		mockFetchBirdEncounters.mockResolvedValue(birdDataSnapshot.encounters);
+		clearCachedBirdEncountersForTesting();
 	});
 
 	afterEach(() => {
@@ -125,5 +142,103 @@ describe('mistakes page', () => {
 		render(await Page());
 		const tabList = screen.queryByRole('tablist');
 		expect(tabList?.querySelectorAll('button').length ?? 0).toBe(0);
+	});
+
+	describe('expanding a row to show bird encounter detail', () => {
+		async function renderPageAndAwaitMistakesTable() {
+			render(await Page());
+			// the BootstrapPageData mock loads data asynchronously
+			await screen.findByRole('table');
+		}
+
+		function findRowContaining(text: string): HTMLTableRowElement {
+			const mistakesTable = screen.getAllByRole('table')[0];
+			return [...mistakesTable.querySelectorAll('tbody tr')].find((row) =>
+				row.textContent?.includes(text)
+			)! as HTMLTableRowElement;
+		}
+
+		function clickRowToggle(ringNo: string) {
+			fireEvent.click(findRowContaining(ringNo).querySelector('button')!);
+		}
+
+		async function findEncounterDetailTable() {
+			// SingleBirdTable renders a nested table inside the expanded row
+			return waitFor(() => {
+				const tables = screen.getAllByRole('table');
+				expect(tables.length).toBe(2);
+				return tables[1];
+			});
+		}
+
+		function switchToTab(label: string) {
+			const tabList = screen.getByRole('tablist');
+			const tab = [...tabList.querySelectorAll('button')].find(
+				(button) => button.textContent === label
+			)!;
+			fireEvent.click(tab);
+		}
+
+		it('fetches and renders the bird encounter detail when a row is expanded', async () => {
+			await renderPageAndAwaitMistakesTable();
+			clickRowToggle('ABTITMIS');
+			await findEncounterDetailTable();
+			expect(mockFetchBirdEncounters).toHaveBeenCalledTimes(1);
+			expect(mockFetchBirdEncounters).toHaveBeenCalledWith('ABTITMIS');
+		});
+
+		it('does not refetch when the same row is collapsed and re-expanded', async () => {
+			await renderPageAndAwaitMistakesTable();
+			clickRowToggle('ABTITMIS');
+			await findEncounterDetailTable();
+			clickRowToggle('ABTITMIS');
+			expect(screen.getAllByRole('table').length).toBe(1);
+			clickRowToggle('ABTITMIS');
+			await findEncounterDetailTable();
+			expect(mockFetchBirdEncounters).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not refetch when returning to a tab and re-expanding a previously viewed row', async () => {
+			await renderPageAndAwaitMistakesTable();
+			clickRowToggle('ABTITMIS');
+			await findEncounterDetailTable();
+			switchToTab('Sex');
+			switchToTab('Age');
+			clickRowToggle('ABTITMIS');
+			await findEncounterDetailTable();
+			expect(mockFetchBirdEncounters).toHaveBeenCalledTimes(1);
+		});
+
+		it('shows a loading message while encounter detail is being fetched', async () => {
+			mockFetchBirdEncounters.mockImplementation(() => new Promise(() => {}));
+			await renderPageAndAwaitMistakesTable();
+			clickRowToggle('ABTITMIS');
+			expect(screen.getByText('Loading...')).toBeTruthy();
+		});
+
+		it('fetches encounter detail separately for each expanded bird', async () => {
+			await renderPageAndAwaitMistakesTable();
+			clickRowToggle('ABTITMIS');
+			await findEncounterDetailTable();
+			clickRowToggle('AKINGF001');
+			await findEncounterDetailTable();
+			expect(mockFetchBirdEncounters).toHaveBeenCalledTimes(2);
+			expect(mockFetchBirdEncounters).toHaveBeenCalledWith('ABTITMIS');
+			expect(mockFetchBirdEncounters).toHaveBeenCalledWith('AKINGF001');
+		});
+
+		it('retries the fetch when re-expanding a row whose fetch failed', async () => {
+			mockFetchBirdEncounters.mockRejectedValueOnce(new Error('boom'));
+			await renderPageAndAwaitMistakesTable();
+			clickRowToggle('ABTITMIS');
+			await waitFor(() =>
+				expect(mockFetchBirdEncounters).toHaveBeenCalledTimes(1)
+			);
+			expect(screen.getByText('Loading...')).toBeTruthy();
+			clickRowToggle('ABTITMIS');
+			clickRowToggle('ABTITMIS');
+			await findEncounterDetailTable();
+			expect(mockFetchBirdEncounters).toHaveBeenCalledTimes(2);
+		});
 	});
 });

--- a/app/components/MistakesTable.tsx
+++ b/app/components/MistakesTable.tsx
@@ -91,6 +91,16 @@ export function makeHighlighter(
 	return () => false;
 }
 
+// Encounter data only changes when the group imports a CSV, so within a page
+// lifetime it is safe to reuse previously fetched results when a row is
+// collapsed and re-expanded. Failed fetches cache nothing, so re-expanding
+// the row retries.
+const cachedBirdEncounters = new Map<string, EncounterOfBird[]>();
+
+export function clearCachedBirdEncountersForTesting(): void {
+	cachedBirdEncounters.clear();
+}
+
 function LazyBirdDetail({
 	model
 }: {
@@ -100,7 +110,20 @@ function LazyBirdDetail({
 	const { ring_no, discrepency_type } = model._rawRowData;
 
 	useEffect(() => {
-		fetchBirdEncounters(ring_no).then(setEncounters);
+		const cached = cachedBirdEncounters.get(ring_no);
+		if (cached) {
+			setEncounters(cached);
+			return;
+		}
+		fetchBirdEncounters(ring_no).then(
+			(fetchedEncounters) => {
+				cachedBirdEncounters.set(ring_no, fetchedEncounters);
+				setEncounters(fetchedEncounters);
+			},
+			() => {
+				// Leave the loading state; re-expanding the row retries the fetch
+			}
+		);
 	}, [ring_no]);
 
 	if (!encounters) {

--- a/app/components/shared/AccordionTableBody.tsx
+++ b/app/components/shared/AccordionTableBody.tsx
@@ -13,42 +13,6 @@ type AccordionTableProps<ItemModel> = {
 	columnCount: number;
 };
 
-// const [birdDetail, setBirdDetail] = useState<Encounter[]>(
-//   expandedBird === ring_no ? encounters : []
-// );
-// function toggleBirdDetail() {
-//   if (expandedBird === ring_no) {
-//     onExpand(null);
-//     setBirdDetail([]);
-//   } else {
-//     onExpand(ring_no);
-//     setBirdDetail(encounters);
-//   }
-// }
-
-// function ExpandableRowWrapper<ItemModel>({
-//   ExpandedContentComponent
-//   model
-// }: {
-//   ExpandedContentComponent: AccordionTableComponent<ItemModel>;
-//   model: ItemModel;
-// }) {
-
-//   const [expandedData, setExpandedData] = useState<Encounter[]>(
-//     expandedBird === ring_no ? encounters : []
-//   );
-//   function toggleBirdDetail() {
-//     if (expandedBird === ring_no) {
-//       onExpand(null);
-//       setBirdDetail([]);
-//     } else {
-//       onExpand(ring_no);
-//       setBirdDetail(encounters);
-//     }
-//   }
-
-// }
-
 export function AccordionTableBody<ItemModel>({
 	FirstColumnComponent,
 	RestColumnsComponent,
@@ -72,7 +36,6 @@ export function AccordionTableBody<ItemModel>({
 							<td className="flex justify-left gap-2">
 								<button
 									type="button"
-									// className="btn btn-outline btn-secondary btn-xs btn-square"
 									onClick={() => setExpandedRow(isExpanded ? false : rowId)}
 								>
 									<span


### PR DESCRIPTION
## Problem
On the mistakes page, expanding a row lazy-loads that bird's encounters via the `fetchBirdEncounters` server action. Collapsing the row unmounts `LazyBirdDetail`, so re-expanding it (or leaving and returning to a tab) refetched the same data from the server.

## Change
- Cache resolved encounter results in client memory at module scope in `MistakesTable.tsx`, keyed by ring number. No TTL: the cache is per-browser-tab and encounter data only changes when the group imports a CSV, so within-page staleness is acceptable.
- Failed fetches cache nothing and are now handled (previously an unhandled rejection), so collapsing and re-expanding a row retries.
- Deletes dead commented-out code in `AccordionTableBody.tsx` (comment-only, no behaviour change for its other consumers `SpTable`/`SingleSessionTable`).

## Tests
New `describe('expanding a row to show bird encounter detail')` in the mistakes page test covering: expand fetches and renders detail; collapse/re-expand does not refetch; tab-away-and-back does not refetch; loading state; separate fetch per bird; retry after failed fetch.

## Notes
- Stacked on #354 (re-lands the stranded 'last seen' commit); will retarget to main automatically when that merges.
- Follow-up cleanup spotted but not bundled: `AccordionTableBody` has an inert `useEffect(() => setExpandedRow(false), [])` that could be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)