### PR TITLE
feat: add previous/next session navigation to session pages

### DIFF
--- a/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
@@ -94,11 +94,18 @@ const mockEncounters = [
 	}
 ];
 
+const mockPreviousSession = [{ visit_date: '2024-03-01' }];
+const mockNextSession = [{ visit_date: '2024-04-01' }];
+
 function makeSessionClient() {
 	const makeChain = (data: unknown) => ({
 		select: vi.fn().mockReturnThis(),
 		eq: vi.fn().mockReturnThis(),
 		in: vi.fn().mockReturnThis(),
+		lt: vi.fn().mockReturnThis(),
+		gt: vi.fn().mockReturnThis(),
+		order: vi.fn().mockReturnThis(),
+		limit: vi.fn().mockReturnThis(),
 		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
 			Promise.resolve({ data, error: null }).then(resolve)
 	});
@@ -106,6 +113,8 @@ function makeSessionClient() {
 		from: vi
 			.fn()
 			.mockReturnValueOnce(makeChain(mockSessions))
+			.mockReturnValueOnce(makeChain(mockPreviousSession))
+			.mockReturnValueOnce(makeChain(mockNextSession))
 			.mockReturnValueOnce(makeChain(mockEncounters))
 	};
 }
@@ -172,5 +181,27 @@ describe('session detail page', () => {
 		const highlights = await screen.findByTestId('session-highlights');
 		expect(highlights.textContent).toContain('Highlights');
 		expect(highlights.textContent).toContain('Busiest session ever — 3 birds');
+	});
+
+	describe('session navigation', () => {
+		it('renders a "Previous" link pointing to the previous session date', async () => {
+			render(await renderPage());
+			const previousLink = await screen.findByRole('link', {
+				name: /previous session/i
+			});
+			expect(previousLink.getAttribute('href')).toBe(
+				`/group/${TEST_GROUP_ID}/session/${mockPreviousSession[0].visit_date}`
+			);
+		});
+
+		it('renders a "Next" link pointing to the next session date', async () => {
+			render(await renderPage());
+			const nextLink = await screen.findByRole('link', {
+				name: /next session/i
+			});
+			expect(nextLink.getAttribute('href')).toBe(
+				`/group/${TEST_GROUP_ID}/session/${mockNextSession[0].visit_date}`
+			);
+		});
 	});
 });

--- a/app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx
@@ -57,11 +57,18 @@ const mockEncounters = [
 	}
 ];
 
+const mockPreviousSession = [{ visit_date: '2024-03-01' }];
+const mockNextSession = [{ visit_date: '2024-04-01' }];
+
 function makeSessionClient() {
 	const makeChain = (data: unknown) => ({
 		select: vi.fn().mockReturnThis(),
 		eq: vi.fn().mockReturnThis(),
 		in: vi.fn().mockReturnThis(),
+		lt: vi.fn().mockReturnThis(),
+		gt: vi.fn().mockReturnThis(),
+		order: vi.fn().mockReturnThis(),
+		limit: vi.fn().mockReturnThis(),
 		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
 			Promise.resolve({ data, error: null }).then(resolve)
 	});
@@ -69,6 +76,8 @@ function makeSessionClient() {
 		from: vi
 			.fn()
 			.mockReturnValueOnce(makeChain(mockSessions))
+			.mockReturnValueOnce(makeChain(mockPreviousSession))
+			.mockReturnValueOnce(makeChain(mockNextSession))
 			.mockReturnValueOnce(makeChain(mockEncounters))
 	};
 }

--- a/app/group/[groupId]/session/_shared.tsx
+++ b/app/group/[groupId]/session/_shared.tsx
@@ -25,10 +25,45 @@ export type PageParams = {
 	locationId: number | undefined;
 };
 
+export type AdjacentSessionDates = {
+	previousSessionDate: string | null;
+	nextSessionDate: string | null;
+};
+
 export type DayData = {
 	encounters: SessionEncounter[];
 	locations: LocationRow[];
+	adjacentSessionDates: AdjacentSessionDates;
 };
+
+async function fetchAdjacentSessionDates(
+	supabase: Awaited<ReturnType<typeof getAuthenticatedSupabaseClient>>,
+	viewedGroupId: number,
+	date: string
+): Promise<AdjacentSessionDates> {
+	const [previousResult, nextResult] = await Promise.all([
+		supabase
+			.from('Sessions')
+			.select('visit_date')
+			.eq('ringing_group_id', viewedGroupId)
+			.lt('visit_date', date)
+			.order('visit_date', { ascending: false })
+			.limit(1)
+			.then(catchSupabaseErrors) as Promise<{ visit_date: string }[]>,
+		supabase
+			.from('Sessions')
+			.select('visit_date')
+			.eq('ringing_group_id', viewedGroupId)
+			.gt('visit_date', date)
+			.order('visit_date', { ascending: true })
+			.limit(1)
+			.then(catchSupabaseErrors) as Promise<{ visit_date: string }[]>
+	]);
+	return {
+		previousSessionDate: previousResult?.[0]?.visit_date ?? null,
+		nextSessionDate: nextResult?.[0]?.visit_date ?? null
+	};
+}
 
 export async function fetchSessionData({
 	viewedGroupId,
@@ -46,13 +81,26 @@ export async function fetchSessionData({
 		.then(catchSupabaseErrors)) as (SessionRow & { location: LocationRow })[];
 
 	if (!sessions || sessions.length === 0) {
-		return { encounters: [], locations: [] };
+		return {
+			encounters: [],
+			locations: [],
+			adjacentSessionDates: await fetchAdjacentSessionDates(
+				supabase,
+				viewedGroupId,
+				date
+			)
+		};
 	}
 	const locations = sessions.map((item) => item.location);
+	const adjacentSessionDates = await fetchAdjacentSessionDates(
+		supabase,
+		viewedGroupId,
+		date
+	);
 	if (locationId) {
 		sessions = sessions.filter((item) => item.location_id === locationId);
 		if (sessions.length === 0) {
-			return { encounters: [], locations: [] };
+			return { encounters: [], locations: [], adjacentSessionDates };
 		}
 	}
 
@@ -91,7 +139,8 @@ export async function fetchSessionData({
 
 	return {
 		encounters,
-		locations
+		locations,
+		adjacentSessionDates
 	};
 }
 
@@ -170,6 +219,39 @@ function Locations({
 	);
 }
 
+function SessionNavigation({
+	adjacentSessionDates,
+	viewedGroupId
+}: {
+	adjacentSessionDates: AdjacentSessionDates;
+	viewedGroupId: number;
+}) {
+	const { previousSessionDate, nextSessionDate } = adjacentSessionDates;
+	if (!previousSessionDate && !nextSessionDate) return null;
+	return (
+		<nav aria-label="Session navigation" className="flex gap-2 text-sm mt-1">
+			{previousSessionDate ? (
+				<Link
+					href={`/group/${viewedGroupId}/session/${previousSessionDate}`}
+					aria-label="Previous session"
+					className="link"
+				>
+					← Previous
+				</Link>
+			) : null}
+			{nextSessionDate ? (
+				<Link
+					href={`/group/${viewedGroupId}/session/${nextSessionDate}`}
+					aria-label="Next session"
+					className="link"
+				>
+					Next →
+				</Link>
+			) : null}
+		</nav>
+	);
+}
+
 export function SessionSummary({
 	data: dayData,
 	params: { date, locationId, viewedGroupId }
@@ -208,6 +290,10 @@ export function SessionSummary({
 					viewedGroupId={viewedGroupId}
 				/>
 			</PrimaryHeading>
+			<SessionNavigation
+				adjacentSessionDates={dayData.adjacentSessionDates}
+				viewedGroupId={viewedGroupId}
+			/>
 			<BadgeList
 				testId="session-stats"
 				items={

--- a/app/group/[groupId]/session/_shared.tsx
+++ b/app/group/[groupId]/session/_shared.tsx
@@ -229,7 +229,7 @@ function SessionNavigation({
 	const { previousSessionDate, nextSessionDate } = adjacentSessionDates;
 	if (!previousSessionDate && !nextSessionDate) return null;
 	return (
-		<nav aria-label="Session navigation" className="flex gap-2 text-sm mt-1">
+		<nav aria-label="Session navigation" className="flex gap-2 text-sm mb-2">
 			{previousSessionDate ? (
 				<Link
 					href={`/group/${viewedGroupId}/session/${previousSessionDate}`}


### PR DESCRIPTION
## Summary

- Fetches the immediately preceding and following session dates from the database in parallel alongside each session's encounter data
- Renders `← Previous` / `Next →` navigation links below the date heading on session pages (both the date-level and site-filtered views)
- The navigation links are skipped when no adjacent sessions exist (e.g. on the very first or last session)

## Test plan

- [x] Unit tests updated to mock the two new adjacent-session queries (`.lt` and `.gt` chains)
- [x] Two new tests added: "Previous" link href and "Next" link href
- [x] `npm run qa` passes (372 tests, 0 errors)

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)