### PR TITLE
refactor: align RPC group filtering to session level (#340)

### DIFF
--- a/supabase/schema/schemas/public/functions/aggregate_stats.sql
+++ b/supabase/schema/schemas/public/functions/aggregate_stats.sql
@@ -59,7 +59,7 @@ CREATE FUNCTION public.aggregate_stats (
     WHERE (from_date IS NULL OR sess.visit_date >=from_date)
      AND (to_date IS NULL OR sess.visit_date<=to_date)
      AND (species_name_filter IS NULL OR sp.species_name = species_name_filter)
-     AND (ringing_group_filter IS NULL OR e.ringing_group_id = ringing_group_filter)
+     AND (ringing_group_filter IS NULL OR sess.ringing_group_id = ringing_group_filter)
   ), species_spine AS (
     SELECT
       DISTINCT re.species_id, re.species_name

--- a/supabase/schema/schemas/public/functions/find_discrepencies.sql
+++ b/supabase/schema/schemas/public/functions/find_discrepencies.sql
@@ -63,7 +63,7 @@ WITH
 			JOIN "Sessions" s ON s.id = e.session_id
 			JOIN "Species" sp ON sp.id = b.species_id
 		WHERE
-			(ringing_group_filter IS NULL OR e.ringing_group_id = ringing_group_filter)
+			(ringing_group_filter IS NULL OR s.ringing_group_id = ringing_group_filter)
 	),
 	hatch_year_differences AS (
 		SELECT
@@ -94,7 +94,7 @@ WITH
 			JOIN "Species" s ON s.id = b.species_id
 		WHERE
 			NOT e.sex ILIKE 'u'
-			AND (ringing_group_filter IS NULL OR e.ringing_group_id = ringing_group_filter)
+			AND (ringing_group_filter IS NULL OR sess.ringing_group_id = ringing_group_filter)
 		GROUP BY
 			b.id,
 			b.ring_no,
@@ -111,7 +111,7 @@ JOIN "Encounters" e on e.bird_id = b.id
 JOIN "Sessions" sess on sess.id = e.session_id
 JOIN "Species" s on s.id = b.species_id
 WHERE e.wing_length IS NOT NULL
-AND (ringing_group_filter IS NULL OR e.ringing_group_id = ringing_group_filter)
+AND (ringing_group_filter IS NULL OR sess.ringing_group_id = ringing_group_filter)
 GROUP by b.id, b.ring_no, s.species_name)
 
 SELECT

--- a/supabase/schema/schemas/public/functions/most_caught_birds.sql
+++ b/supabase/schema/schemas/public/functions/most_caught_birds.sql
@@ -29,7 +29,7 @@ BEGIN
   WHERE
     (species_filter IS NULL OR sp.species_name ilike species_filter) AND
     (year_filter IS NULL OR EXTRACT(YEAR FROM sess.visit_date) = year_filter)
-		AND (ringing_group_filter IS NULL OR en.ringing_group_id = ringing_group_filter)
+		AND (ringing_group_filter IS NULL OR sess.ringing_group_id = ringing_group_filter)
   GROUP BY
     sp.species_name,
     b.ring_no

--- a/supabase/schema/schemas/public/functions/notable_retraps.sql
+++ b/supabase/schema/schemas/public/functions/notable_retraps.sql
@@ -32,7 +32,7 @@ BEGIN
   WHERE
     (species_filter IS NULL OR sp.species_name ilike species_filter) AND
     (year_filter IS NULL OR EXTRACT(YEAR FROM sess.visit_date) = year_filter)
-		AND (ringing_group_filter IS NULL OR en.ringing_group_id = ringing_group_filter)
+		AND (ringing_group_filter IS NULL OR sess.ringing_group_id = ringing_group_filter)
   GROUP BY
     sp.species_name,
     b.ring_no,

--- a/supabase/schema/schemas/public/functions/ring_sequence_controls.sql
+++ b/supabase/schema/schemas/public/functions/ring_sequence_controls.sql
@@ -12,7 +12,7 @@ BEGIN
   JOIN "Encounters" e  ON e.bird_id = b.id
   JOIN "Sessions"   s  ON s.id = e.session_id
   JOIN "Species"    sp ON sp.id = b.species_id
-  WHERE (ringing_group_filter IS NULL OR e.ringing_group_id = ringing_group_filter)
+  WHERE (ringing_group_filter IS NULL OR s.ringing_group_id = ringing_group_filter)
   GROUP BY b.ring_no, sp.species_name
   HAVING COUNT(*) = COUNT(*) FILTER (WHERE e.record_type = 'S')
   ORDER BY b.ring_no;

--- a/supabase/schema/schemas/public/functions/ring_sequence_detail.sql
+++ b/supabase/schema/schemas/public/functions/ring_sequence_detail.sql
@@ -19,7 +19,7 @@ BEGIN
   WHERE e.record_type = 'N'
     AND LEFT(b.ring_no, 3) = sequence_prefix_filter
     AND LENGTH(b.ring_no) = ring_length_filter
-    AND (ringing_group_filter IS NULL OR e.ringing_group_id = ringing_group_filter)
+    AND (ringing_group_filter IS NULL OR s.ringing_group_id = ringing_group_filter)
   ORDER BY b.ring_no;
 END;
 $function$;

--- a/supabase/schema/schemas/public/functions/ring_sequence_summaries.sql
+++ b/supabase/schema/schemas/public/functions/ring_sequence_summaries.sql
@@ -20,7 +20,7 @@ BEGIN
   JOIN "Encounters" e ON e.bird_id = b.id
   JOIN "Sessions"   s ON s.id = e.session_id
   WHERE e.record_type = 'N'
-    AND (ringing_group_filter IS NULL OR e.ringing_group_id = ringing_group_filter)
+    AND (ringing_group_filter IS NULL OR s.ringing_group_id = ringing_group_filter)
   GROUP BY LEFT(b.ring_no, 3), LENGTH(b.ring_no)
   ORDER BY MAX(s.visit_date) DESC, MIN(s.visit_date) DESC, LEFT(b.ring_no, 3) ASC;
 END;


### PR DESCRIPTION
## Summary

- In 7 RPC functions that already join `Encounters` to `Sessions`, replaced the encounter-level group predicate (`e.ringing_group_id = ringing_group_filter`) with the equivalent session-level predicate (`sess.ringing_group_id` / `s.ringing_group_id = ringing_group_filter`), preserving the nullable pattern where present
- Functions updated: `notable_retraps`, `aggregate_stats`, `most_caught_birds`, `find_discrepencies` (3 CTAs), `ring_sequence_controls`, `ring_sequence_summaries`, `ring_sequence_detail`
- Pure refactor — results are identical since every encounter's `ringing_group_id` matches its session's group

## Test plan

- [x] DB integration tests (`npm run test:integration`) — 78 tests pass unchanged
- [x] App tests (`npm run qa`) — 372 tests pass, lint clean
- [ ] Human to run `npm run db:migration:push` to deploy the generated migration to production

Closes #340