### PR TITLE
refactor: align Row/Result suffixes on DB result types and variables

### DIFF
--- a/app/(routes)/effort/page.tsx
+++ b/app/(routes)/effort/page.tsx
@@ -12,7 +12,7 @@ import {
 	fetchPayOffStats,
 	type PayOffStatsData
 } from '@/app/actions/pay-off-stats';
-import type { AggregateStatsRow } from '@/app/models/db';
+import type { AggregateStatsResult } from '@/app/models/db';
 import { formatPostgresIntervalForDisplay } from '@/lib/postgres-interval';
 import { PayOffEffortChart } from '@/app/components/PayOffEffortChart';
 
@@ -29,10 +29,10 @@ function formatAvgEncounters(n: number | null | undefined): string {
 }
 
 /** Expects `yearly` from aggregate_stats with group_by_time_period 'year' (ascending by time_period). */
-function PayOffYearlyTable({ yearly }: { yearly: AggregateStatsRow[] }) {
+function PayOffYearlyTable({ yearly }: { yearly: AggregateStatsResult[] }) {
 	const metricRows: {
 		label: string;
-		cell: (row: AggregateStatsRow) => string;
+		cell: (row: AggregateStatsResult) => string;
 	}[] = [
 		{
 			label: 'Total ringing effort',

--- a/app/(routes)/species/[speciesName]/page.tsx
+++ b/app/(routes)/species/[speciesName]/page.tsx
@@ -7,7 +7,7 @@ import { SpPage } from '@/app/components/SpPage';
 import { fetchPageOfBirds } from '@/app/actions/sp-data';
 
 import type {
-	AggregateStatsRow,
+	AggregateStatsResult,
 	TopMetricsFilterParams,
 	TopPeriodsResult
 } from '@/app/models/db';
@@ -17,7 +17,7 @@ type PageProps = { params: Promise<PageParams> };
 export type FullFatPageData = {
 	topSessions: TopPeriodsResult[];
 	birds: EnrichedBirdOfSpecies[];
-	speciesStats: AggregateStatsRow;
+	speciesStats: AggregateStatsResult;
 	speciesId: number;
 	speciesName: string;
 };
@@ -42,7 +42,7 @@ async function getSpeciesStats(species: string, viewedGroupId: number) {
 			species_name_filter: species,
 			ringing_group_filter: viewedGroupId
 		})
-		.then(catchSupabaseErrors) as Promise<AggregateStatsRow[]>;
+		.then(catchSupabaseErrors) as Promise<AggregateStatsResult[]>;
 }
 
 export async function fetchSpPageData(

--- a/app/(routes)/species/page.tsx
+++ b/app/(routes)/species/page.tsx
@@ -6,12 +6,12 @@ import { SppStatsTable } from '@/app/components/SppStatsTable';
 import { fetchSpeciesData } from '@/app/actions/spp-data';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
-import type { AggregateStatsRow } from '@/app/models/db';
+import type { AggregateStatsResult } from '@/app/models/db';
 
 //TODO get year/date range from URL params
 
 export type PageData = {
-	speciesStats: AggregateStatsRow[];
+	speciesStats: AggregateStatsResult[];
 	years: number[];
 };
 

--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { StatsPerDayAndSpeciesRow } from '@/app/models/db';
+import type { StatsPerDayAndSpeciesResult } from '@/app/models/db';
 
 const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
 	mockGetAuthenticatedSupabaseClient: vi.fn()
@@ -15,14 +15,14 @@ const PAGE_SIZE = 1000;
 
 // Queries are paginated (PostgREST caps responses at 1000 rows), so the
 // mock builders serve rows page by page from these arrays
-let rpcPages: StatsPerDayAndSpeciesRow[][];
+let rpcPages: StatsPerDayAndSpeciesResult[][];
 let sessionPages: { visit_date: string }[][];
 
 function statsRow(
 	species_name: string,
 	visit_date: string,
 	encounter_count: number
-): StatsPerDayAndSpeciesRow {
+): StatsPerDayAndSpeciesResult {
 	return {
 		species_name,
 		visit_date,

--- a/app/actions/pay-off-stats.ts
+++ b/app/actions/pay-off-stats.ts
@@ -1,10 +1,10 @@
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
-import type { AggregateStatsRow } from '@/app/models/db';
+import type { AggregateStatsResult } from '@/app/models/db';
 
 export type PayOffStatsData = {
-	yearly: AggregateStatsRow[];
-	monthly: AggregateStatsRow[];
+	yearly: AggregateStatsResult[];
+	monthly: AggregateStatsResult[];
 };
 
 export async function fetchPayOffStats(
@@ -18,14 +18,14 @@ export async function fetchPayOffStats(
 				group_by_species: false,
 				group_by_time_period: 'year'
 			})
-			.then(catchSupabaseErrors) as Promise<AggregateStatsRow[] | null>,
+			.then(catchSupabaseErrors) as Promise<AggregateStatsResult[] | null>,
 		supabase
 			.rpc('aggregate_stats', {
 				ringing_group_filter: viewedGroupId,
 				group_by_species: false,
 				group_by_time_period: 'month'
 			})
-			.then(catchSupabaseErrors) as Promise<AggregateStatsRow[] | null>
+			.then(catchSupabaseErrors) as Promise<AggregateStatsResult[] | null>
 	]);
 	if (yearly == null || monthly == null) {
 		return null;

--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -15,7 +15,7 @@ import {
 } from '@/app/models/session-highlights';
 import type {
 	LongAbsenceRetrapsResult,
-	StatsPerDayAndSpeciesRow
+	StatsPerDayAndSpeciesResult
 } from '@/app/models/db';
 
 // The stats blob only changes when new data is imported, so cache it
@@ -35,7 +35,7 @@ async function fetchSessionStats(
 	}
 	const supabase = await getAuthenticatedSupabaseClient();
 	const [daySpeciesStats, sessionRows] = await Promise.all([
-		fetchAllPaginatedRows<StatsPerDayAndSpeciesRow>((fromRow, toRow) =>
+		fetchAllPaginatedRows<StatsPerDayAndSpeciesResult>((fromRow, toRow) =>
 			supabase
 				.rpc('stats_per_day_and_species', {
 					ringing_group_filter: viewedGroupId

--- a/app/actions/sp-data.ts
+++ b/app/actions/sp-data.ts
@@ -11,7 +11,7 @@ import type { NotableRetrapsResult } from '@/app/models/db';
 import { getSexOfBird, type EncounterOfBird } from '@/app/models/bird';
 import type { GraphableBird } from '@/app/components/WeightAndWingChart';
 import type { SexedGraphableBird } from '@/app/components/WeightAndWingChart';
-import type { AggregateStatsRow } from '@/app/models/db';
+import type { AggregateStatsResult } from '@/app/models/db';
 export async function fetchPageOfBirds(
 	speciesId: number,
 	viewedGroupId: number,
@@ -108,7 +108,7 @@ export async function getSpeciesStatsHistory(
 			ringing_group_filter: viewedGroupId,
 			group_by_time_period: 'month'
 		})
-		.then(catchSupabaseErrors) as Promise<AggregateStatsRow[]>;
+		.then(catchSupabaseErrors) as Promise<AggregateStatsResult[]>;
 }
 
 export async function getSpeciesYearComparison(
@@ -122,5 +122,5 @@ export async function getSpeciesYearComparison(
 			ringing_group_filter: viewedGroupId,
 			group_by_time_period: 'year'
 		})
-		.then(catchSupabaseErrors) as Promise<AggregateStatsRow[]>;
+		.then(catchSupabaseErrors) as Promise<AggregateStatsResult[]>;
 }

--- a/app/actions/spp-data.ts
+++ b/app/actions/spp-data.ts
@@ -1,13 +1,13 @@
 'use server';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
-import type { AggregateStatsRow } from '@/app/models/db';
+import type { AggregateStatsResult } from '@/app/models/db';
 
 export async function fetchSpeciesData(
 	viewedGroupId: number,
 	fromDate?: string,
 	toDate?: string
-): Promise<AggregateStatsRow[]> {
+): Promise<AggregateStatsResult[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	return supabase
 		.rpc('aggregate_stats', {
@@ -16,5 +16,5 @@ export async function fetchSpeciesData(
 			ringing_group_filter: viewedGroupId,
 			group_by_species: true
 		})
-		.then(catchSupabaseErrors) as Promise<AggregateStatsRow[]>;
+		.then(catchSupabaseErrors) as Promise<AggregateStatsResult[]>;
 }

--- a/app/components/PayOffEffortChart.tsx
+++ b/app/components/PayOffEffortChart.tsx
@@ -3,7 +3,7 @@
 import { LineChart } from 'react-chartkick';
 import 'chartkick/chart.js';
 import { format } from 'date-fns';
-import type { AggregateStatsRow } from '@/app/models/db';
+import type { AggregateStatsResult } from '@/app/models/db';
 import {
 	postgresIntervalToHours,
 	postgresIntervalToMinutes
@@ -14,7 +14,7 @@ type SeriesPoint = [string, number];
 export function PayOffEffortChart({
 	monthly
 }: {
-	monthly: AggregateStatsRow[];
+	monthly: AggregateStatsResult[];
 }) {
 	const sorted = [...monthly].sort(
 		(a, b) =>

--- a/app/components/SpStats.tsx
+++ b/app/components/SpStats.tsx
@@ -2,7 +2,7 @@ import { BoxyList } from '@/app/components/shared/DesignSystem';
 import type { FullFatPageData } from '@/app/(routes)/species/[speciesName]/page';
 import { StatOutput } from './shared/StatOutput';
 import { UnwrappedBadgeList } from './shared/DesignSystem';
-import type { AggregateStatsRow } from '@/app/models/db';
+import type { AggregateStatsResult } from '@/app/models/db';
 import type { SpeciesStatConfig } from '@/app/models/species-stats';
 import { speciesStatConfigs } from '@/app/models/species-stats';
 
@@ -51,7 +51,7 @@ function MeasurementCategory({
 function StatsByCategory({
 	speciesStats
 }: {
-	speciesStats: AggregateStatsRow;
+	speciesStats: AggregateStatsResult;
 }) {
 	return categoryOrder.map((categoryName) => {
 		if (categoryName === 'Weight') {
@@ -87,7 +87,7 @@ function StatsByCategory({
 				<UnwrappedBadgeList
 					items={subStats.map(
 						(stat) =>
-							`${stat.prefix ? `${stat.prefix} ` : ''}${speciesStats[stat.property as keyof AggregateStatsRow]}${stat.suffix ? ` ${stat.suffix}` : ''}`
+							`${stat.prefix ? `${stat.prefix} ` : ''}${speciesStats[stat.property as keyof AggregateStatsResult]}${stat.suffix ? ` ${stat.suffix}` : ''}`
 					)}
 				/>
 			</li>

--- a/app/components/SpYearComparisonTab.tsx
+++ b/app/components/SpYearComparisonTab.tsx
@@ -7,7 +7,7 @@ import {
 	type ColumnConfig,
 	type RowModelWithRawData
 } from '@/app/components/shared/SortableTable';
-import type { AggregateStatsRow } from '@/app/models/db';
+import type { AggregateStatsResult } from '@/app/models/db';
 
 const yearComparisonStatConfigs = speciesStatConfigs.filter(
 	(c) => c.property !== 'species_name'
@@ -22,12 +22,12 @@ const yearComparisonColumnConfigs = {
 		}),
 		{}
 	)
-} as Record<keyof AggregateStatsRow, ColumnConfig>;
+} as Record<keyof AggregateStatsResult, ColumnConfig>;
 
 function YearComparisonTableBody({
 	data
 }: {
-	data: RowModelWithRawData<AggregateStatsRow, AggregateStatsRow>[];
+	data: RowModelWithRawData<AggregateStatsResult, AggregateStatsResult>[];
 }) {
 	return (
 		<tbody>
@@ -50,7 +50,7 @@ export function SpYearComparisonTab({
 	speciesName: string;
 	viewedGroupId: number;
 }) {
-	const [yearData, setYearData] = useState<AggregateStatsRow[]>([]);
+	const [yearData, setYearData] = useState<AggregateStatsResult[]>([]);
 	const [isLoaded, setIsLoaded] = useState(false);
 
 	useEffect(() => {
@@ -74,7 +74,7 @@ export function SpYearComparisonTab({
 	}
 
 	return (
-		<SortableTable<AggregateStatsRow, AggregateStatsRow>
+		<SortableTable<AggregateStatsResult, AggregateStatsResult>
 			columnConfigs={yearComparisonColumnConfigs}
 			data={yearData}
 			initialSortColumn="time_period"

--- a/app/components/SppStatsTable.tsx
+++ b/app/components/SppStatsTable.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { PageWrapper } from '@/app/components/shared/DesignSystem';
 import { speciesStatConfigs } from '@/app/models/species-stats';
-import type { AggregateStatsRow } from '@/app/models/db';
+import type { AggregateStatsResult } from '@/app/models/db';
 import type { PageData } from '@/app/(routes)/species/page';
 import { useState, useEffect, useRef } from 'react';
 import { fetchSpeciesData } from '@/app/actions/spp-data';
@@ -11,7 +11,7 @@ import {
 } from '@/app/components/shared/SortableTable';
 import { NoPrefetchLink } from '@/app/components/shared/NoPrefetchLink';
 
-function MultiSpeciesTableBody({ data }: { data: AggregateStatsRow[] }) {
+function MultiSpeciesTableBody({ data }: { data: AggregateStatsResult[] }) {
 	return (
 		<tbody>
 			{data.map((species) => (
@@ -44,7 +44,7 @@ const sortableColumnConfigs = speciesStatConfigs.reduce(
 			invertSort: column.invertSort
 		}
 	}),
-	{} as Record<keyof AggregateStatsRow, ColumnConfig>
+	{} as Record<keyof AggregateStatsResult, ColumnConfig>
 );
 
 export function SppStatsTable({
@@ -60,7 +60,7 @@ export function SppStatsTable({
 	const [fromDate, setFromDate] = useState<string | null>(null);
 	const [toDate, setToDate] = useState<string | null>(null);
 	const [speciesStats, setSpeciesStats] =
-		useState<AggregateStatsRow[]>(initialSpeciesStats);
+		useState<AggregateStatsResult[]>(initialSpeciesStats);
 	const isFirstRender = useRef(true);
 	useEffect(() => {
 		if (isFirstRender.current) {
@@ -191,7 +191,7 @@ export function SppStatsTable({
 					</div>
 				</form>
 			</PageWrapper>
-			<SortableTable<AggregateStatsRow, AggregateStatsRow>
+			<SortableTable<AggregateStatsResult, AggregateStatsResult>
 				columnConfigs={sortableColumnConfigs}
 				data={speciesStats}
 				rowDataTransform={(data) => data}

--- a/app/components/StatsHistoryChart.tsx
+++ b/app/components/StatsHistoryChart.tsx
@@ -1,10 +1,10 @@
 import { LineChart, type LineChartData } from 'react-chartkick';
-import type { AggregateStatsRow } from '@/app/models/db';
+import type { AggregateStatsResult } from '@/app/models/db';
 import { useEffect, useState } from 'react';
 import { getSpeciesStatsHistory } from '../actions/sp-data';
 import { SecondaryHeading } from './shared/DesignSystem';
 
-function getCounts(statsHistory: AggregateStatsRow[]): LineChartData[] {
+function getCounts(statsHistory: AggregateStatsResult[]): LineChartData[] {
 	return [
 		{
 			name: 'encounters',
@@ -17,7 +17,7 @@ function getCounts(statsHistory: AggregateStatsRow[]): LineChartData[] {
 	];
 }
 
-function getYoungsters(statsHistory: AggregateStatsRow[]): LineChartData[] {
+function getYoungsters(statsHistory: AggregateStatsResult[]): LineChartData[] {
 	return [
 		{
 			name: '3j',
@@ -41,7 +41,7 @@ function getYoungsters(statsHistory: AggregateStatsRow[]): LineChartData[] {
 	];
 }
 
-function getSizes(statsHistory: AggregateStatsRow[]): LineChartData[] {
+function getSizes(statsHistory: AggregateStatsResult[]): LineChartData[] {
 	return [
 		{
 			name: 'max weight',
@@ -78,7 +78,7 @@ export function StatsHistoryChart({
 	speciesName: string;
 	viewedGroupId: number;
 }) {
-	const [statsHistory, setStatsHistory] = useState<AggregateStatsRow[]>([]);
+	const [statsHistory, setStatsHistory] = useState<AggregateStatsResult[]>([]);
 	useEffect(() => {
 		if (statsHistory.length > 0) return;
 		getSpeciesStatsHistory(speciesName, viewedGroupId).then((data) => {

--- a/app/components/__tests__/SpYearComparisonTab.test.tsx
+++ b/app/components/__tests__/SpYearComparisonTab.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, screen, cleanup, waitFor } from '@testing-library/react';
 import { SpYearComparisonTab } from '../SpYearComparisonTab';
 import yearComparisonSnapshot from '@/test-fixtures/snapshots/getSpeciesYearComparison.alpha.robin.json';
-import type { AggregateStatsRow } from '@/app/models/db';
+import type { AggregateStatsResult } from '@/app/models/db';
 
 vi.mock('@/app/actions/sp-data', () => ({
 	getSpeciesYearComparison: vi.fn()
@@ -16,13 +16,13 @@ describe('SpYearComparisonTab', () => {
 	beforeEach(async () => {
 		const { getSpeciesYearComparison } = await import('@/app/actions/sp-data');
 		vi.mocked(getSpeciesYearComparison).mockResolvedValue(
-			yearComparisonSnapshot as unknown as AggregateStatsRow[]
+			yearComparisonSnapshot as unknown as AggregateStatsResult[]
 		);
 	});
 
 	it('shows a loading spinner while data is fetching', async () => {
 		const { getSpeciesYearComparison } = await import('@/app/actions/sp-data');
-		let resolveData!: (v: AggregateStatsRow[]) => void;
+		let resolveData!: (v: AggregateStatsResult[]) => void;
 		vi.mocked(getSpeciesYearComparison).mockReturnValue(
 			new Promise((resolve) => {
 				resolveData = resolve;
@@ -30,7 +30,7 @@ describe('SpYearComparisonTab', () => {
 		);
 		render(<SpYearComparisonTab speciesName="Robin" viewedGroupId={1} />);
 		expect(document.querySelector('.loading')).toBeDefined();
-		resolveData(yearComparisonSnapshot as unknown as AggregateStatsRow[]);
+		resolveData(yearComparisonSnapshot as unknown as AggregateStatsResult[]);
 	});
 
 	it('renders a row per year once loaded', async () => {

--- a/app/components/__tests__/SppStatsTable.test.tsx
+++ b/app/components/__tests__/SppStatsTable.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '@testing-library/react';
 import { SppStatsTable } from '../SppStatsTable';
 import speciesDataSnapshot from '@/test-fixtures/snapshots/fetchSpeciesData.alpha.json';
-import type { AggregateStatsRow } from '@/app/models/db';
+import type { AggregateStatsResult } from '@/app/models/db';
 import type { PageData } from '@/app/(routes)/species/page';
 
 vi.mock('@/app/actions/spp-data', () => ({
@@ -16,7 +16,7 @@ vi.mock('@/app/actions/spp-data', () => ({
 }));
 
 const pageData: PageData = {
-	speciesStats: speciesDataSnapshot as unknown as AggregateStatsRow[],
+	speciesStats: speciesDataSnapshot as unknown as AggregateStatsResult[],
 	years: [2021, 2022, 2023]
 };
 
@@ -44,7 +44,7 @@ describe('SppStatsTable', () => {
 		it('CES only checkbox is enabled after year is selected', async () => {
 			const { fetchSpeciesData } = await import('@/app/actions/spp-data');
 			vi.mocked(fetchSpeciesData).mockResolvedValue(
-				speciesDataSnapshot as unknown as AggregateStatsRow[]
+				speciesDataSnapshot as unknown as AggregateStatsResult[]
 			);
 			render(<SppStatsTable data={pageData} viewedGroupId={1} />);
 			const yearSelect = screen.getByLabelText('select') as HTMLSelectElement;
@@ -56,7 +56,7 @@ describe('SppStatsTable', () => {
 		it('triggers fetchSpeciesData with correct date range when year changes', async () => {
 			const { fetchSpeciesData } = await import('@/app/actions/spp-data');
 			vi.mocked(fetchSpeciesData).mockResolvedValue(
-				speciesDataSnapshot as unknown as AggregateStatsRow[]
+				speciesDataSnapshot as unknown as AggregateStatsResult[]
 			);
 			render(<SppStatsTable data={pageData} viewedGroupId={1} />);
 			const yearSelect = screen.getByLabelText('select') as HTMLSelectElement;

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -19,7 +19,7 @@ import {
 	type WeightRecordHighlight
 } from '../session-highlights';
 import type {
-	StatsPerDayAndSpeciesRow,
+	StatsPerDayAndSpeciesResult,
 	LongAbsenceRetrapsResult
 } from '@/app/models/db';
 
@@ -45,7 +45,7 @@ const PRIOR_SPRING_YEAR_THREE = '2023-05-01';
 function dayRows(
 	date: string,
 	speciesCounts: Record<string, number>
-): StatsPerDayAndSpeciesRow[] {
+): StatsPerDayAndSpeciesResult[] {
 	return Object.entries(speciesCounts).map(
 		([species_name, encounter_count]) => ({
 			species_name,
@@ -58,17 +58,20 @@ function dayRows(
 	);
 }
 
-function statsFor(rows: StatsPerDayAndSpeciesRow[]): SessionStatsData {
+function statsFor(results: StatsPerDayAndSpeciesResult[]): SessionStatsData {
 	return {
-		daySpeciesStats: rows,
-		sessionDates: [...new Set(rows.map((row) => row.visit_date))]
+		daySpeciesStats: results,
+		sessionDates: [...new Set(results.map((row) => row.visit_date))]
 	};
 }
 
-function derive(rows: StatsPerDayAndSpeciesRow[], today = PAST_PERIOD_TODAY) {
+function derive(
+	results: StatsPerDayAndSpeciesResult[],
+	today = PAST_PERIOD_TODAY
+) {
 	return deriveSessionTotalRecords({
 		date: SESSION_DATE,
-		stats: statsFor(rows),
+		stats: statsFor(results),
 		today
 	});
 }
@@ -311,13 +314,13 @@ describe('deriveSessionTotalRecords', () => {
 const WITHIN_A_MONTH = '2024-08-20';
 
 function deriveSince(
-	rows: StatsPerDayAndSpeciesRow[],
+	results: StatsPerDayAndSpeciesResult[],
 	sessionDates?: string[]
 ) {
 	const stats: SessionStatsData = {
-		daySpeciesStats: rows,
+		daySpeciesStats: results,
 		sessionDates: sessionDates ?? [
-			...new Set(rows.map((row) => row.visit_date))
+			...new Set(results.map((row) => row.visit_date))
 		]
 	};
 	return deriveSinceHighlights({ date: SESSION_DATE, stats });
@@ -531,7 +534,7 @@ function speciesRow(
 	date: string,
 	species: string,
 	count: number
-): StatsPerDayAndSpeciesRow {
+): StatsPerDayAndSpeciesResult {
 	return {
 		visit_date: date,
 		species_name: species,
@@ -542,20 +545,22 @@ function speciesRow(
 	};
 }
 
-function statsForSpecies(rows: StatsPerDayAndSpeciesRow[]): SessionStatsData {
+function statsForSpecies(
+	results: StatsPerDayAndSpeciesResult[]
+): SessionStatsData {
 	return {
-		daySpeciesStats: rows,
-		sessionDates: [...new Set(rows.map((row) => row.visit_date))]
+		daySpeciesStats: results,
+		sessionDates: [...new Set(results.map((row) => row.visit_date))]
 	};
 }
 
 function deriveSpecies(
-	rows: StatsPerDayAndSpeciesRow[],
+	results: StatsPerDayAndSpeciesResult[],
 	today = PAST_PERIOD_TODAY
 ) {
 	return deriveSpeciesRecords({
 		date: SESSION_DATE,
-		stats: statsForSpecies(rows),
+		stats: statsForSpecies(results),
 		today
 	});
 }
@@ -1027,14 +1032,13 @@ describe('buildHighlightSentence — species-count-record', () => {
 const FIRECREST = 'Firecrest';
 
 function deriveFirstEver(
-	rows: StatsPerDayAndSpeciesRow[],
+	results: StatsPerDayAndSpeciesResult[],
 	sessionDates?: string[]
 ) {
-	const daySpeciesStats = rows;
 	const stats: SessionStatsData = {
-		daySpeciesStats,
+		daySpeciesStats: results,
 		sessionDates: sessionDates ?? [
-			...new Set(rows.map((row) => row.visit_date))
+			...new Set(results.map((row) => row.visit_date))
 		]
 	};
 	return deriveFirstEverSpecies({ date: SESSION_DATE, stats });
@@ -1111,16 +1115,16 @@ describe('deriveFirstEverSpecies', () => {
 // ---- deriveFirstOfYearSpecies ----
 
 function deriveFirstOfYear(
-	rows: StatsPerDayAndSpeciesRow[],
+	results: StatsPerDayAndSpeciesResult[],
 	{
 		sessionDates,
 		today = PAST_PERIOD_TODAY
 	}: { sessionDates?: string[]; today?: Date } = {}
 ) {
 	const stats: SessionStatsData = {
-		daySpeciesStats: rows,
+		daySpeciesStats: results,
 		sessionDates: sessionDates ?? [
-			...new Set(rows.map((row) => row.visit_date))
+			...new Set(results.map((row) => row.visit_date))
 		]
 	};
 	return deriveFirstOfYearSpecies({ date: SESSION_DATE, stats, today });
@@ -1425,7 +1429,7 @@ function weightRow(
 		minWeight,
 		maxWeight
 	}: { weighedBirds?: number; minWeight: number; maxWeight: number }
-): StatsPerDayAndSpeciesRow {
+): StatsPerDayAndSpeciesResult {
 	return {
 		visit_date: date,
 		species_name: species,
@@ -1436,10 +1440,10 @@ function weightRow(
 	};
 }
 
-function deriveWeights(rows: StatsPerDayAndSpeciesRow[]) {
+function deriveWeights(results: StatsPerDayAndSpeciesResult[]) {
 	return deriveWeightRecordBreakers({
 		date: SESSION_DATE,
-		stats: statsFor(rows)
+		stats: statsFor(results)
 	});
 }
 

--- a/app/models/db.ts
+++ b/app/models/db.ts
@@ -19,7 +19,7 @@ export type TopSpeciesArgs =
 
 export type TopMetricsFilterParams =
 	Database['public']['CompositeTypes']['top_metrics_filter_params'];
-export type AggregateStatsRow =
+export type AggregateStatsResult =
 	Database['public']['Functions']['aggregate_stats']['Returns'][number];
 
 export type DiscrepenciesResult =
@@ -28,5 +28,5 @@ export type NotableRetrapsResult =
 	Database['public']['Functions']['notable_retraps']['Returns'][number];
 export type LongAbsenceRetrapsResult =
 	Database['public']['Functions']['long_absence_retraps']['Returns'][number];
-export type StatsPerDayAndSpeciesRow =
+export type StatsPerDayAndSpeciesResult =
 	Database['public']['Functions']['stats_per_day_and_species']['Returns'][number];

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -12,7 +12,7 @@ import {
 	isCurrentSeasonPeriod
 } from '@/app/models/seasons';
 import type {
-	StatsPerDayAndSpeciesRow,
+	StatsPerDayAndSpeciesResult,
 	LongAbsenceRetrapsResult
 } from '@/app/models/db';
 
@@ -33,7 +33,7 @@ export type RecordScope = (typeof RECORD_SCOPES)[number];
 // weighed-bird counts, weight extremes) plus the full list of session
 // dates (so zero-encounter sessions still count)
 export type SessionStatsData = {
-	daySpeciesStats: StatsPerDayAndSpeciesRow[];
+	daySpeciesStats: StatsPerDayAndSpeciesResult[];
 	sessionDates: string[];
 };
 

--- a/app/models/species-stats.ts
+++ b/app/models/species-stats.ts
@@ -1,8 +1,8 @@
-import type { AggregateStatsRow } from './db';
+import type { AggregateStatsResult } from './db';
 
 export type SpeciesStatConfig = {
 	label: string;
-	property: keyof AggregateStatsRow;
+	property: keyof AggregateStatsResult;
 	suffix?: string;
 	category?: string;
 	prefix?: string;


### PR DESCRIPTION
## Summary

- Rename `AggregateStatsRow` → `AggregateStatsResult` (type for `aggregate_stats` RPC return)
- Rename `StatsPerDayAndSpeciesRow` → `StatsPerDayAndSpeciesResult` (type for `stats_per_day_and_species` RPC return)
- Update all consumers across actions, components, pages, and their tests
- Rename `rows` function parameters to `results` in test helpers in `app/models/__tests__/session-highlights.test.ts` that hold arrays of RPC results

No behaviour change — mechanical rename only.

Closes #344

## Test plan

- [x] `npm run qa` passes (372 tests, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)