### PR TITLE
feat: rank weight highlights as top-3 placements

### DIFF
--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -213,7 +213,8 @@ describe('fetchSessionHighlights', () => {
 				speciesName: 'Blue Tit',
 				extreme: 'heaviest',
 				weight: 13.1,
-				previousRecord: 13.0
+				placementRank: 1,
+				isJointPlacement: false
 			})
 		);
 	});

--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -252,7 +252,8 @@ describe('SessionHighlights', () => {
 				speciesName: 'Blue Tit',
 				extreme: 'heaviest',
 				weight: 13.1,
-				previousRecord: 13.0
+				placementRank: 1,
+				isJointPlacement: false
 			}
 		];
 		const { fetchSessionHighlights } =
@@ -271,7 +272,7 @@ describe('SessionHighlights', () => {
 			'Record day for Reed Warbler — 12 caught, the most ever',
 			'First ever Firecrest record',
 			'Robin ARRETRAP recaught after 2 years, 10 months away (last seen 20 Jun 2021)',
-			'Heaviest Blue Tit ever weighed — 13.1g (previous record 13g)'
+			'Heaviest Blue Tit ever weighed — 13.1g'
 		]);
 	});
 
@@ -281,7 +282,8 @@ describe('SessionHighlights', () => {
 			speciesName: 'Blue Tit',
 			extreme: 'heaviest',
 			weight: 13.1,
-			previousRecord: 13.0
+			placementRank: 1,
+			isJointPlacement: false
 		};
 		const { fetchSessionHighlights } =
 			await import('@/app/actions/session-highlights');
@@ -294,8 +296,6 @@ describe('SessionHighlights', () => {
 			.getByTestId('session-highlights')
 			.querySelectorAll('li');
 		expect(items.length).toBe(1);
-		expect(items[0].textContent).toBe(
-			'Heaviest Blue Tit ever weighed — 13.1g (previous record 13g)'
-		);
+		expect(items[0].textContent).toBe('Heaviest Blue Tit ever weighed — 13.1g');
 	});
 });

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -1448,7 +1448,7 @@ function deriveWeights(results: StatsPerDayAndSpeciesResult[]) {
 }
 
 describe('deriveWeightRecordBreakers', () => {
-	it('returns a heaviest record beating the max across all other sessions', () => {
+	it('ranks the heaviest bird 1st when its max beats every other day', () => {
 		const highlights = deriveWeights([
 			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
 			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
@@ -1462,11 +1462,12 @@ describe('deriveWeightRecordBreakers', () => {
 			speciesName: BLUE_TIT,
 			extreme: 'heaviest',
 			weight: 13.1,
-			previousRecord: 13.0
+			placementRank: 1,
+			isJointPlacement: false
 		});
 	});
 
-	it('returns a lightest record beating the min across all other sessions', () => {
+	it('ranks the lightest bird 1st when its min beats every other day', () => {
 		const highlights = deriveWeights([
 			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 9.8, maxWeight: 12 }),
 			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
@@ -1480,11 +1481,12 @@ describe('deriveWeightRecordBreakers', () => {
 			speciesName: BLUE_TIT,
 			extreme: 'lightest',
 			weight: 9.8,
-			previousRecord: 10.2
+			placementRank: 1,
+			isJointPlacement: false
 		});
 	});
 
-	it('suppresses a would-be record beaten by a later session', () => {
+	it('reports a 2nd-heaviest placement when one other day is heavier', () => {
 		const highlights = deriveWeights([
 			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
 			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
@@ -1494,22 +1496,52 @@ describe('deriveWeightRecordBreakers', () => {
 			}),
 			weightRow(LATER_DAY, BLUE_TIT, { minWeight: 10.9, maxWeight: 14.0 })
 		]);
-		expect(highlights.map((h) => h.extreme)).not.toContain('heaviest');
+		expect(highlights).toContainEqual({
+			type: 'weight-record',
+			speciesName: BLUE_TIT,
+			extreme: 'heaviest',
+			weight: 13.1,
+			placementRank: 2,
+			isJointPlacement: false
+		});
 	});
 
-	it('requires at least 3 weighed encounters on other days', () => {
+	it('reports a 3rd-heaviest placement when two other days are heavier', () => {
 		const highlights = deriveWeights([
 			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
 			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
-				weighedBirds: 2,
+				weighedBirds: 3,
 				minWeight: 10.5,
-				maxWeight: 13.0
-			})
+				maxWeight: 14.0
+			}),
+			weightRow(LATER_DAY, BLUE_TIT, { minWeight: 10.9, maxWeight: 13.5 })
 		]);
-		expect(highlights).toEqual([]);
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				extreme: 'heaviest',
+				weight: 13.1,
+				placementRank: 3,
+				isJointPlacement: false
+			})
+		);
 	});
 
-	it('reports a prior tie older than a year as a for-N-years record', () => {
+	it('does not report a placement beyond the top 3', () => {
+		// three other days are heavier, so the session ranks 4th
+		const highlights = deriveWeights([
+			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+				weighedBirds: 3,
+				minWeight: 10.5,
+				maxWeight: 14.0
+			}),
+			weightRow(LATER_DAY, BLUE_TIT, { minWeight: 10.9, maxWeight: 13.8 }),
+			weightRow(LATER_DAY_TWO, BLUE_TIT, { minWeight: 10.8, maxWeight: 13.5 })
+		]);
+		expect(highlights.map((h) => h.extreme)).not.toContain('heaviest');
+	});
+
+	it('flags a joint placement when another day matches the extreme exactly', () => {
 		const highlights = deriveWeights([
 			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
 			weightRow(PRIOR_AUTUMN_OTHER_YEAR, BLUE_TIT, {
@@ -1523,24 +1555,13 @@ describe('deriveWeightRecordBreakers', () => {
 			speciesName: BLUE_TIT,
 			extreme: 'heaviest',
 			weight: 13.1,
-			previousRecord: 13.1,
-			recordEqualledYearsAgo: 3
+			placementRank: 1,
+			isJointPlacement: true
 		});
 	});
 
-	it('ignores ties under a year old', () => {
-		const highlights = deriveWeights([
-			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
-			weightRow(PRIOR_SPRING_THIS_YEAR, BLUE_TIT, {
-				weighedBirds: 3,
-				minWeight: 10.5,
-				maxWeight: 13.1
-			})
-		]);
-		expect(highlights.map((h) => h.extreme)).not.toContain('heaviest');
-	});
-
-	it('ignores ties held only by a later session', () => {
+	it('counts later days when ranking placements', () => {
+		// the later day is heavier, demoting the session to 2nd
 		const highlights = deriveWeights([
 			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
 			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
@@ -1548,9 +1569,23 @@ describe('deriveWeightRecordBreakers', () => {
 				minWeight: 10.5,
 				maxWeight: 12.0
 			}),
-			weightRow(LATER_DAY, BLUE_TIT, { minWeight: 11.5, maxWeight: 13.1 })
+			weightRow(LATER_DAY, BLUE_TIT, { minWeight: 11.5, maxWeight: 13.5 })
 		]);
-		expect(highlights.map((h) => h.extreme)).not.toContain('heaviest');
+		expect(highlights).toContainEqual(
+			expect.objectContaining({ extreme: 'heaviest', placementRank: 2 })
+		);
+	});
+
+	it('requires at least 3 weighed encounters on other days', () => {
+		const highlights = deriveWeights([
+			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+				weighedBirds: 2,
+				minWeight: 10.5,
+				maxWeight: 13.0
+			})
+		]);
+		expect(highlights).toEqual([]);
 	});
 
 	it('ignores species with no weighed encounter in the session', () => {
@@ -1580,34 +1615,63 @@ function makeWeightHighlight(
 		speciesName: BLUE_TIT,
 		extreme: 'heaviest',
 		weight: 13.1,
-		previousRecord: 13.0,
+		placementRank: 1,
+		isJointPlacement: false,
 		...overrides
 	};
 }
 
 describe('buildHighlightSentence — weight-record', () => {
-	it('renders heaviest copy with previous record', () => {
+	it('renders heaviest-ever copy for a 1st placement', () => {
 		expect(buildHighlightSentence(makeWeightHighlight())).toBe(
-			'Heaviest Blue Tit ever weighed — 13.1g (previous record 13g)'
+			'Heaviest Blue Tit ever weighed — 13.1g'
 		);
 	});
 
-	it('renders lightest copy with previous record', () => {
+	it('renders lightest-ever copy for a 1st placement', () => {
+		expect(
+			buildHighlightSentence(
+				makeWeightHighlight({ extreme: 'lightest', weight: 9.8 })
+			)
+		).toBe('Lightest Blue Tit ever weighed — 9.8g');
+	});
+
+	it('renders 2nd-heaviest copy', () => {
+		expect(
+			buildHighlightSentence(
+				makeWeightHighlight({ placementRank: 2, weight: 12.9 })
+			)
+		).toBe('2nd-heaviest Blue Tit ever weighed — 12.9g');
+	});
+
+	it('renders 3rd-lightest copy', () => {
 		expect(
 			buildHighlightSentence(
 				makeWeightHighlight({
 					extreme: 'lightest',
-					weight: 9.8,
-					previousRecord: 10.2
+					placementRank: 3,
+					weight: 10.4
 				})
 			)
-		).toBe('Lightest Blue Tit ever weighed — 9.8g (previous record 10.2g)');
+		).toBe('3rd-lightest Blue Tit ever weighed — 10.4g');
 	});
 
-	it('renders heaviest-for-N-years copy for a tie', () => {
+	it('renders joint heaviest copy for a 1st-place tie', () => {
 		expect(
-			buildHighlightSentence(makeWeightHighlight({ recordEqualledYearsAgo: 4 }))
-		).toBe('Heaviest Blue Tit for 4 years — 13.1g');
+			buildHighlightSentence(makeWeightHighlight({ isJointPlacement: true }))
+		).toBe('Joint heaviest Blue Tit ever weighed — 13.1g');
+	});
+
+	it('renders joint 2nd-heaviest copy', () => {
+		expect(
+			buildHighlightSentence(
+				makeWeightHighlight({
+					placementRank: 2,
+					isJointPlacement: true,
+					weight: 12.9
+				})
+			)
+		).toBe('Joint 2nd-heaviest Blue Tit ever weighed — 12.9g');
 	});
 });
 

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -126,7 +126,7 @@ export type SinceComparisonHighlight = {
 	sinceDate?: string;
 };
 
-// Which end of the weight range broke a record this session
+// Which end of the weight range the placement concerns this session
 export const WEIGHT_RECORD_EXTREMES = ['heaviest', 'lightest'] as const;
 export type WeightRecordExtreme = (typeof WEIGHT_RECORD_EXTREMES)[number];
 
@@ -134,13 +134,13 @@ export type WeightRecordHighlight = {
 	type: 'weight-record';
 	speciesName: string;
 	extreme: WeightRecordExtreme;
-	// The session's record-breaking weight, in grams
+	// The session's weight for this extreme, in grams
 	weight: number;
-	// The extreme across all other sessions (may postdate the session)
-	previousRecord: number;
-	// Set only for ties where the equalled record is over a year old — the
-	// number of full years the record has stood
-	recordEqualledYearsAgo?: number;
+	// Where the session's weight ranks across every day the species was weighed
+	// (1 = heaviest/lightest ever, capped at the top 3)
+	placementRank: 1 | 2 | 3;
+	// True when another day's extreme exactly matches the session's weight
+	isJointPlacement: boolean;
 };
 
 export type SessionHighlight =
@@ -653,13 +653,35 @@ export function deriveLongAbsenceRetraps(
 }
 
 // Minimum number of weighed encounters across other days for a species
-// before a weight record is worth reporting
+// before a weight placement is worth reporting
 const MIN_WEIGHED_ENCOUNTERS_FOR_RECORD = 3;
 
-// Weight records are inherently all-time — a species' heaviest/lightest bird
-// this session is compared against every other day it was weighed, including
-// later days (which can erase a highlight). A record needs the species to have
-// been weighed at least three times across those other days.
+// Ranks the session's extreme against every other day's extreme (heaviest =
+// larger is better, lightest = smaller is better). Returns null when the
+// session doesn't make the top 3. The rank counts how many other days hold a
+// strictly better extreme, so ties share a rank.
+function deriveWeightPlacement(
+	sessionWeight: number,
+	otherWeights: number[],
+	isHeaviest: boolean
+): { placementRank: 1 | 2 | 3; isJointPlacement: boolean } | null {
+	const isBetter = (candidate: number, reference: number) =>
+		isHeaviest ? candidate > reference : candidate < reference;
+	const betterDays = otherWeights.filter((weight) =>
+		isBetter(weight, sessionWeight)
+	).length;
+	const placementRank = betterDays + 1;
+	if (placementRank > 3) return null;
+	return {
+		placementRank: placementRank as 1 | 2 | 3,
+		isJointPlacement: otherWeights.includes(sessionWeight)
+	};
+}
+
+// Weight placements are inherently all-time — a species' heaviest/lightest bird
+// this session is ranked against every other day it was weighed, including
+// later days (which can demote a placement). A placement needs the species to
+// have been weighed at least three times across those other days.
 export function deriveWeightRecordBreakers({
 	date,
 	stats
@@ -667,7 +689,6 @@ export function deriveWeightRecordBreakers({
 	date: string;
 	stats: SessionStatsData;
 }): WeightRecordHighlight[] {
-	const sessionDate = new Date(date);
 	const sessionRows = stats.daySpeciesStats.filter(
 		(row) => row.visit_date === date && row.weighed_birds_count > 0
 	);
@@ -695,46 +716,19 @@ export function deriveWeightRecordBreakers({
 			const otherWeights = otherWeighedRows.map((row) =>
 				isHeaviest ? row.max_weight : row.min_weight
 			);
-			// The record to beat: the biggest max (heaviest) / smallest min (lightest)
-			const previousRecord = isHeaviest
-				? Math.max(...otherWeights)
-				: Math.min(...otherWeights);
-			const beatsRecord = isHeaviest
-				? sessionWeight > previousRecord
-				: sessionWeight < previousRecord;
-			const baseHighlight: WeightRecordHighlight = {
-				type: 'weight-record',
-				speciesName: sessionRow.species_name,
-				extreme,
-				weight: sessionWeight,
-				previousRecord
-			};
-			if (beatsRecord) {
-				highlights.push(baseHighlight);
-				continue;
-			}
-			if (sessionWeight === previousRecord) {
-				// The for-N-years copy describes how long the record has stood, so
-				// only a prior day holding the extreme value counts — a tie held
-				// only by a later session is unreportable
-				const mostRecentPriorTieDate = otherWeighedRows
-					.filter(
-						(row) =>
-							(isHeaviest ? row.max_weight : row.min_weight) ===
-								previousRecord && row.visit_date < date
-					)
-					.map((row) => row.visit_date)
-					.sort()
-					.at(-1);
-				if (mostRecentPriorTieDate !== undefined) {
-					const recordEqualledYearsAgo = differenceInYears(
-						sessionDate,
-						new Date(mostRecentPriorTieDate)
-					);
-					if (recordEqualledYearsAgo >= 1) {
-						highlights.push({ ...baseHighlight, recordEqualledYearsAgo });
-					}
-				}
+			const placement = deriveWeightPlacement(
+				sessionWeight,
+				otherWeights,
+				isHeaviest
+			);
+			if (placement) {
+				highlights.push({
+					type: 'weight-record',
+					speciesName: sessionRow.species_name,
+					extreme,
+					weight: sessionWeight,
+					...placement
+				});
 			}
 		}
 	}
@@ -823,9 +817,11 @@ function buildSpeciesRecordsPhrase(
 	return `${highlight.speciesName} record${highlight.multipleIndividualsRecorded ? 's' : ''}`;
 }
 
-const WEIGHT_RECORD_DESCRIPTOR: Record<WeightRecordExtreme, string> = {
-	heaviest: 'Heaviest',
-	lightest: 'Lightest'
+// The bare extreme word ('heaviest'/'lightest'), combined with a placement
+// prefix ('', '2nd-', '3rd-') and capitalised for the sentence
+const WEIGHT_RECORD_EXTREME_WORD: Record<WeightRecordExtreme, string> = {
+	heaviest: 'heaviest',
+	lightest: 'lightest'
 };
 
 const SINCE_COMPARISON_DESCRIPTOR: Record<SinceComparisonKind, string> = {
@@ -848,13 +844,29 @@ function buildSinceComparisonSentence(
 	return `${descriptor} session since ${formattedSinceDate} — ${valueCopy}`;
 }
 
+const WEIGHT_PLACEMENT_PREFIX: Record<1 | 2 | 3, string> = {
+	1: '',
+	2: '2nd-',
+	3: '3rd-'
+};
+
 function buildWeightRecordSentence(highlight: WeightRecordHighlight): string {
-	const { speciesName, extreme, weight } = highlight;
-	const descriptor = WEIGHT_RECORD_DESCRIPTOR[extreme];
-	if (highlight.recordEqualledYearsAgo !== undefined) {
-		return `${descriptor} ${speciesName} for ${buildYearsAgoCopy(highlight.recordEqualledYearsAgo)} — ${weight}g`;
+	const { speciesName, extreme, weight, placementRank, isJointPlacement } =
+		highlight;
+	const extremeWord = WEIGHT_RECORD_EXTREME_WORD[extreme];
+	// "heaviest" / "2nd-heaviest" / "3rd-heaviest"
+	const rankedExtreme = `${WEIGHT_PLACEMENT_PREFIX[placementRank]}${extremeWord}`;
+	// A joint placement leads with "Joint"; otherwise the sentence opens with
+	// the extreme word, which is only capitalised when a rank prefix (a digit)
+	// isn't already sitting in front of it
+	if (isJointPlacement) {
+		return `Joint ${rankedExtreme} ${speciesName} ever weighed — ${weight}g`;
 	}
-	return `${descriptor} ${speciesName} ever weighed — ${weight}g (previous record ${highlight.previousRecord}g)`;
+	const descriptor =
+		placementRank === 1
+			? `${extremeWord[0].toUpperCase()}${extremeWord.slice(1)}`
+			: rankedExtreme;
+	return `${descriptor} ${speciesName} ever weighed — ${weight}g`;
 }
 
 export function buildHighlightSentence(highlight: SessionHighlight): string {


### PR DESCRIPTION
## What this covers

First of two PRs for [#359](https://github.com/wheresrhys/totf/issues/359) (New highlight types).

Reworks the **weight highlight family** so it stops focusing on record-breaking and instead reports the top 3 (including ties), matching the species-count-record family:

- `WeightRecordHighlight` now carries `placementRank: 1 | 2 | 3` and `isJointPlacement` instead of `previousRecord` / `recordEqualledYearsAgo`.
- The session's heaviest/lightest bird is ranked against every day the species was weighed (later days included, as before), reported only when it makes the top 3.
- Copy: `Heaviest Blue Tit ever weighed — 13.1g`, `2nd-heaviest …`, `3rd-lightest …`, `Joint heaviest …`, `Joint 2nd-heaviest …`. The old `(previous record …)` and `for N years` tie copy are gone.

The 3-weighed-encounters-on-other-days gate is retained.

## Assumptions

- Kept the existing "must be weighed at least 3 times on other days" threshold — the issue only asked to change the record-vs-top-3 framing, not the minimum-history gate.
- Placement is computed against per-day weight extremes (`max_weight` / `min_weight`), consistent with the previous implementation.
- Copy phrasing (`2nd-heaviest`, `Joint …`) mirrors the species-count-record placement wording for consistency.

## Tests

`npm run qa` — lint + type-check + app tests all pass (376 tests). Weight-family model tests rewritten for the placement model; action + component tests updated.

Part of #359 — does not close the issue (the rare-species highlight follows in PR 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)