### PR TITLE
feat: add rare-species session highlight

### DIFF
--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -219,6 +219,28 @@ describe('fetchSessionHighlights', () => {
 		);
 	});
 
+	it('includes rare-species highlights in the fan-out', async () => {
+		rpcPages = [
+			[
+				statsRow('Firecrest', SESSION_DATE, 1),
+				statsRow('Firecrest', '2022-05-01', 1)
+			]
+		];
+		sessionPages = [
+			[{ visit_date: '2022-05-01' }, { visit_date: SESSION_DATE }]
+		];
+		const fetchSessionHighlights = await importFetchSessionHighlights();
+		const highlights = await fetchSessionHighlights({
+			date: SESSION_DATE,
+			viewedGroupId: GROUP_ID
+		});
+		expect(highlights).toContainEqual({
+			type: 'rare-species',
+			speciesName: 'Firecrest',
+			totalSessionDays: 2
+		});
+	});
+
 	it('returns cached data within the TTL', async () => {
 		const fetchSessionHighlights = await importFetchSessionHighlights();
 		await fetchSessionHighlights({

--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -5,6 +5,7 @@ import {
 	deriveFirstEverSpecies,
 	deriveFirstOfYearSpecies,
 	deriveLongAbsenceRetraps,
+	deriveRareSpecies,
 	deriveSessionTotalRecords,
 	deriveSinceHighlights,
 	deriveSpeciesRecords,
@@ -88,6 +89,7 @@ export async function fetchSessionHighlights({
 		...deriveSpeciesRecords({ date, stats }),
 		...deriveFirstEverSpecies({ date, stats }),
 		...deriveFirstOfYearSpecies({ date, stats }),
+		...deriveRareSpecies({ date, stats }),
 		...deriveLongAbsenceRetraps(longAbsenceRetrapResults, date),
 		...deriveWeightRecordBreakers({ date, stats })
 	]);

--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -176,6 +176,28 @@ describe('SessionHighlights', () => {
 		expect(items[0].textContent).toBe('First ever Firecrest record');
 	});
 
+	it('renders rare-species sentences', async () => {
+		const rareSpeciesHighlight: SessionHighlight = {
+			type: 'rare-species',
+			speciesName: 'Firecrest',
+			totalSessionDays: 2
+		};
+		const { fetchSessionHighlights } =
+			await import('@/app/actions/session-highlights');
+		vi.mocked(fetchSessionHighlights).mockResolvedValue([rareSpeciesHighlight]);
+		render(<SessionHighlights date="2024-09-15" viewedGroupId={1} />);
+		await waitFor(() => {
+			expect(screen.getByRole('heading', { name: 'Highlights' })).toBeDefined();
+		});
+		const items = screen
+			.getByTestId('session-highlights')
+			.querySelectorAll('li');
+		expect(items.length).toBe(1);
+		expect(items[0].textContent).toBe(
+			'Rarely recorded — Firecrest seen on only 2 days ever'
+		);
+	});
+
 	it('renders long-absence sentences', async () => {
 		const longAbsenceHighlight: LongAbsenceRetrapHighlight = {
 			type: 'long-absence-retrap',

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -4,6 +4,7 @@ import {
 	deriveLongAbsenceRetraps,
 	deriveFirstEverSpecies,
 	deriveFirstOfYearSpecies,
+	deriveRareSpecies,
 	deriveSessionTotalRecords,
 	deriveSinceHighlights,
 	deriveSpeciesRecords,
@@ -12,6 +13,7 @@ import {
 	type FirstEverSpeciesHighlight,
 	type FirstOfYearSpeciesHighlight,
 	type LongAbsenceRetrapHighlight,
+	type RareSpeciesHighlight,
 	type SessionStatsData,
 	type SessionTotalRecordHighlight,
 	type SinceComparisonHighlight,
@@ -1232,6 +1234,124 @@ describe('deriveFirstOfYearSpecies', () => {
 	});
 });
 
+// ---- deriveRareSpecies ----
+
+function deriveRare(
+	results: StatsPerDayAndSpeciesResult[],
+	sessionDates?: string[]
+) {
+	const stats: SessionStatsData = {
+		daySpeciesStats: results,
+		sessionDates: sessionDates ?? [
+			...new Set(results.map((row) => row.visit_date))
+		]
+	};
+	return deriveRareSpecies({ date: SESSION_DATE, stats });
+}
+
+describe('deriveRareSpecies', () => {
+	it('highlights a species seen on only two session days ever', () => {
+		const highlights = deriveRare([
+			speciesRow(SESSION_DATE, FIRECREST, 1),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, FIRECREST, 1)
+		]);
+		expect(highlights).toEqual([
+			{ type: 'rare-species', speciesName: FIRECREST, totalSessionDays: 2 }
+		]);
+	});
+
+	it('highlights a species seen on exactly three session days ever', () => {
+		const highlights = deriveRare([
+			speciesRow(SESSION_DATE, FIRECREST, 2),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, FIRECREST, 1),
+			speciesRow(PRIOR_AUTUMN_OTHER_YEAR, FIRECREST, 3)
+		]);
+		expect(highlights).toEqual([
+			{ type: 'rare-species', speciesName: FIRECREST, totalSessionDays: 3 }
+		]);
+	});
+
+	it('counts later days towards the total', () => {
+		// prior + session + two later = 4 days, above the threshold
+		const highlights = deriveRare([
+			speciesRow(SESSION_DATE, FIRECREST, 1),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, FIRECREST, 1),
+			speciesRow(LATER_DAY, FIRECREST, 1),
+			speciesRow(LATER_DAY_TWO, FIRECREST, 1)
+		]);
+		expect(highlights).toEqual([]);
+	});
+
+	it('excludes a species seen on more than three session days ever', () => {
+		const highlights = deriveRare([
+			speciesRow(SESSION_DATE, FIRECREST, 1),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, FIRECREST, 1),
+			speciesRow(PRIOR_AUTUMN_OTHER_YEAR, FIRECREST, 1),
+			speciesRow(PRIOR_SPRING_THIS_YEAR, FIRECREST, 1)
+		]);
+		expect(highlights).toEqual([]);
+	});
+
+	it('excludes a first-ever species — the first-ever highlight covers it', () => {
+		// Firecrest appears only from the session onwards (no earlier day)
+		const highlights = deriveRare([
+			speciesRow(SESSION_DATE, FIRECREST, 1),
+			speciesRow(LATER_DAY, FIRECREST, 1)
+		]);
+		expect(highlights).toEqual([]);
+	});
+
+	it('reports multiple rare species from one session', () => {
+		const highlights = deriveRare([
+			speciesRow(SESSION_DATE, FIRECREST, 1),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, FIRECREST, 1),
+			speciesRow(SESSION_DATE, REED_WARBLER, 1),
+			speciesRow(PRIOR_AUTUMN_OTHER_YEAR, REED_WARBLER, 1)
+		]);
+		expect(highlights.map((h) => h.speciesName)).toEqual([
+			FIRECREST,
+			REED_WARBLER
+		]);
+	});
+
+	it('does not highlight common species', () => {
+		const highlights = deriveRare([
+			speciesRow(SESSION_DATE, ROBIN, 5),
+			speciesRow(PRIOR_SPRING_OTHER_YEAR, ROBIN, 4),
+			speciesRow(PRIOR_AUTUMN_OTHER_YEAR, ROBIN, 3),
+			speciesRow(PRIOR_SPRING_THIS_YEAR, ROBIN, 6)
+		]);
+		expect(highlights).toEqual([]);
+	});
+});
+
+// ---- buildHighlightSentence — rare-species ----
+
+function makeRareSpeciesHighlight(
+	overrides: Partial<RareSpeciesHighlight> = {}
+): RareSpeciesHighlight {
+	return {
+		type: 'rare-species',
+		speciesName: FIRECREST,
+		totalSessionDays: 2,
+		...overrides
+	};
+}
+
+describe('buildHighlightSentence — rare-species', () => {
+	it('renders the total session-day count', () => {
+		expect(buildHighlightSentence(makeRareSpeciesHighlight())).toBe(
+			'Rarely recorded — Firecrest seen on only 2 days ever'
+		);
+	});
+
+	it('renders a three-day count', () => {
+		expect(
+			buildHighlightSentence(makeRareSpeciesHighlight({ totalSessionDays: 3 }))
+		).toBe('Rarely recorded — Firecrest seen on only 3 days ever');
+	});
+});
+
 // ---- buildHighlightSentence — first-ever-species ----
 
 function makeFirstEverHighlight(
@@ -1725,6 +1845,7 @@ describe('sortHighlights', () => {
 		const longAbsence: LongAbsenceRetrapHighlight = makeLongAbsenceHighlight();
 		const firstOfYear: FirstOfYearSpeciesHighlight = makeFirstOfYearHighlight();
 		const firstEver: FirstEverSpeciesHighlight = makeFirstEverHighlight();
+		const rareSpecies: RareSpeciesHighlight = makeRareSpeciesHighlight();
 		const speciesRecord: SpeciesCountRecordHighlight = makeSpeciesHighlight({});
 		const since: SinceComparisonHighlight = makeSinceHighlight();
 		const total: SessionTotalRecordHighlight = makeHighlight({});
@@ -1732,6 +1853,7 @@ describe('sortHighlights', () => {
 		const sorted = sortHighlights([
 			weight,
 			longAbsence,
+			rareSpecies,
 			firstOfYear,
 			firstEver,
 			speciesRecord,
@@ -1744,6 +1866,7 @@ describe('sortHighlights', () => {
 			'species-count-record',
 			'first-ever-species',
 			'first-of-year-species',
+			'rare-species',
 			'long-absence-retrap',
 			'weight-record'
 		]);

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -98,6 +98,19 @@ export type FirstOfYearSpeciesHighlight = {
 	isOnlyRecord: boolean;
 };
 
+// A species the group has recorded on very few session days ever is always
+// worth a mention when it turns up again. Excludes first-ever appearances,
+// which the first-ever highlight covers with more specific copy.
+export const MAX_RARE_SPECIES_SESSION_DAYS = 3;
+
+export type RareSpeciesHighlight = {
+	type: 'rare-species';
+	speciesName: string;
+	// Distinct session days the species has ever been recorded on (2–3 here;
+	// a count of 1 is a first-ever appearance, handled elsewhere)
+	totalSessionDays: number;
+};
+
 export type LongAbsenceRetrapHighlight = {
 	type: 'long-absence-retrap';
 	ringNo: string;
@@ -149,6 +162,7 @@ export type SessionHighlight =
 	| SpeciesCountRecordHighlight
 	| FirstEverSpeciesHighlight
 	| FirstOfYearSpeciesHighlight
+	| RareSpeciesHighlight
 	| LongAbsenceRetrapHighlight
 	| WeightRecordHighlight;
 
@@ -624,6 +638,45 @@ export function deriveFirstOfYearSpecies({
 		}));
 }
 
+// Returns a highlight for each species in the session that the group has ever
+// recorded on only a handful of session days (MAX_RARE_SPECIES_SESSION_DAYS or
+// fewer, counting every day it appears before or after this session). A
+// species seen for the first time this session is excluded — the first-ever
+// highlight already covers it with more specific copy.
+export function deriveRareSpecies({
+	date,
+	stats
+}: {
+	date: string;
+	stats: SessionStatsData;
+}): RareSpeciesHighlight[] {
+	const sessionRows = stats.daySpeciesStats.filter(
+		(row) => row.visit_date === date
+	);
+	if (sessionRows.length === 0) return [];
+
+	return sessionRows
+		.map((sessionRow) => {
+			const speciesDays = new Set(
+				stats.daySpeciesStats
+					.filter((row) => row.species_name === sessionRow.species_name)
+					.map((row) => row.visit_date)
+			);
+			return { sessionRow, speciesDays };
+		})
+		.filter(
+			({ speciesDays }) =>
+				speciesDays.size <= MAX_RARE_SPECIES_SESSION_DAYS &&
+				// A species recorded on no earlier day is first-ever territory
+				[...speciesDays].some((visitDate) => visitDate < date)
+		)
+		.map(({ sessionRow, speciesDays }) => ({
+			type: 'rare-species' as const,
+			speciesName: sessionRow.species_name,
+			totalSessionDays: speciesDays.size
+		}));
+}
+
 // Maps RPC rows to LongAbsenceRetrapHighlights, preserving the gap-descending
 // order returned by the RPC. The session date is needed to compute the
 // years+months gap relative to the day the bird was last seen.
@@ -741,6 +794,7 @@ const HIGHLIGHT_TYPE_PRIORITY: SessionHighlight['type'][] = [
 	'species-count-record',
 	'first-ever-species',
 	'first-of-year-species',
+	'rare-species',
 	'long-absence-retrap',
 	'weight-record'
 ];
@@ -887,6 +941,8 @@ export function buildHighlightSentence(highlight: SessionHighlight): string {
 				: `of ${highlight.year}`;
 			return `${highlight.isOnlyRecord ? 'Only' : 'First'} ${buildSpeciesRecordsPhrase(highlight)} ${yearPhrase}`;
 		}
+		case 'rare-species':
+			return `Rarely recorded — ${highlight.speciesName} seen on only ${highlight.totalSessionDays} days ever`;
 		case 'long-absence-retrap': {
 			const { ringNo, speciesName, previousDate, gapYears, gapMonths } =
 				highlight;


### PR DESCRIPTION
## What this covers

Second and final PR for [#359](https://github.com/wheresrhys/totf/issues/359) (New highlight types). **Stacked on #361** — review/merge that first.

Adds a **rare-species** highlight: any species the group has ever recorded on very few session days (three or fewer) is flagged whenever it turns up again.

- Counts distinct session days the species appears on across the whole dataset (before and after this session), consistent with how the other highlight families count later data.
- First-ever appearances are excluded — the first-ever/only highlight already covers a species' debut with more specific copy.
- Copy: `Rarely recorded — Firecrest seen on only 2 days ever`.
- Slotted into the family priority order between first-of-year-species and long-absence-retrap.

## Assumptions

- Interpreted "3 sessions or less" as **distinct session days** the species appears on (the stats blob is per day+species; a day can span multiple locations). Threshold is `MAX_RARE_SPECIES_SESSION_DAYS = 3`.
- The count is all-time (before + after), matching the existing highlights' treatment of later data. A count of 1 is a first-ever appearance and is handled by the first-ever family, so rare-species only fires for totals of 2–3 and requires at least one prior day.
- Did not gate on encounter count or add plural "records" copy — the count-of-days phrasing reads naturally without it.

## Tests

`npm run qa` — lint + type-check + app tests all pass (387 tests). New model tests (`deriveRareSpecies` + sentence rendering), an action fan-out test, and a component render test.

Closes #359.

🤖 Generated with [Claude Code](https://claude.com/claude-code)