### PR TITLE
feat: spell out day-count placement ordinals

### DIFF
--- a/app/components/session-highlight-renderers.tsx
+++ b/app/components/session-highlight-renderers.tsx
@@ -95,11 +95,16 @@ function buildSpeciesCountRecordSentence(
 		return `Record-equalling day for ${speciesName} — ${valueCopy}, most for ${buildYearsAgoCopy(highlight.recordEqualledYearsAgo)}`;
 	}
 	if (highlight.placementRank !== undefined) {
-		const rankCopy = { 1: 'best', 2: '2nd-best', 3: '3rd-best' }[
+		const rankCopy = { 1: 'best', 2: 'second best', 3: 'third best' }[
 			highlight.placementRank
 		];
 		const jointPrefix = highlight.isJointPlacement ? 'Joint ' : '';
-		return `${jointPrefix}${rankCopy} day for ${speciesName} ever — ${value} birds`;
+		// Non-joint placements open the sentence, so capitalise the ordinal;
+		// with a "Joint " prefix the ordinal stays mid-sentence and lowercase.
+		const placementCopy = jointPrefix
+			? rankCopy
+			: rankCopy.charAt(0).toUpperCase() + rankCopy.slice(1);
+		return `${jointPrefix}${placementCopy} day for ${speciesName} ever — ${value} birds`;
 	}
 	const currentPeriodPhrase = buildCurrentPeriodScopePhrase(highlight);
 	const mostPhrase =

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -994,7 +994,7 @@ describe('render — species-count-record', () => {
 		).toBe('Joint best day for Reed Warbler ever — 12 birds');
 	});
 
-	it('renders 2nd-best placement copy', () => {
+	it('renders second-best placement copy', () => {
 		expect(
 			renderedText(
 				makeSpeciesHighlight({
@@ -1003,10 +1003,10 @@ describe('render — species-count-record', () => {
 					value: 8
 				})
 			)
-		).toBe('2nd-best day for Reed Warbler ever — 8 birds');
+		).toBe('Second best day for Reed Warbler ever — 8 birds');
 	});
 
-	it('renders 3rd-best placement copy', () => {
+	it('renders third-best placement copy', () => {
 		expect(
 			renderedText(
 				makeSpeciesHighlight({
@@ -1015,10 +1015,10 @@ describe('render — species-count-record', () => {
 					value: 8
 				})
 			)
-		).toBe('3rd-best day for Reed Warbler ever — 8 birds');
+		).toBe('Third best day for Reed Warbler ever — 8 birds');
 	});
 
-	it('renders joint 2nd-best placement copy', () => {
+	it('renders joint second-best placement copy', () => {
 		expect(
 			renderedText(
 				makeSpeciesHighlight({
@@ -1027,10 +1027,10 @@ describe('render — species-count-record', () => {
 					value: 8
 				})
 			)
-		).toBe('Joint 2nd-best day for Reed Warbler ever — 8 birds');
+		).toBe('Joint second best day for Reed Warbler ever — 8 birds');
 	});
 
-	it('renders joint 3rd-best placement copy', () => {
+	it('renders joint third-best placement copy', () => {
 		expect(
 			renderedText(
 				makeSpeciesHighlight({
@@ -1039,7 +1039,7 @@ describe('render — species-count-record', () => {
 					value: 8
 				})
 			)
-		).toBe('Joint 3rd-best day for Reed Warbler ever — 8 birds');
+		).toBe('Joint third best day for Reed Warbler ever — 8 birds');
 	});
 });
 


### PR DESCRIPTION
Closes #364.

## What this covers

Rewords single-species all-time day-count **placements**:

- `2nd-best day for <species> ever — N birds` → `Second best day for <species> ever — N birds`
- `3rd-best day for <species> ever — N birds` → `Third best day for <species> ever — N birds`

The ordinal is capitalised when it opens the sentence, and stays lowercase after a `Joint ` prefix (`Joint second best day for …`).

Pure copy change in the species-count highlight renderer (`app/components/session-highlight-renderers.tsx`). Rank-1 placements are always joint, so `Joint best day …` is unchanged. **Weight records untouched** (per #360).

## Tests

Updated the four placement-copy assertions in `session-highlights.test.ts` (2nd/3rd + joint variants). `npm run qa` green — 396 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)