### PR TITLE
feat: gate low-ranked weight placements

### DIFF
--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -1597,14 +1597,20 @@ function weightRow(
 	species: string,
 	{
 		weighedBirds = 1,
+		encounters,
 		minWeight,
 		maxWeight
-	}: { weighedBirds?: number; minWeight: number; maxWeight: number }
+	}: {
+		weighedBirds?: number;
+		encounters?: number;
+		minWeight: number;
+		maxWeight: number;
+	}
 ): StatsPerDayAndSpeciesResult {
 	return {
 		visit_date: date,
 		species_name: species,
-		encounter_count: weighedBirds,
+		encounter_count: encounters ?? weighedBirds,
 		weighed_birds_count: weighedBirds,
 		min_weight: minWeight,
 		max_weight: maxWeight
@@ -1661,7 +1667,11 @@ describe('deriveWeightRecordBreakers', () => {
 
 	it('reports a 2nd-heaviest placement when one other day is heavier', () => {
 		const highlights = deriveWeights([
-			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+			weightRow(SESSION_DATE, BLUE_TIT, {
+				encounters: 41,
+				minWeight: 11,
+				maxWeight: 13.1
+			}),
 			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
 				weighedBirds: 3,
 				minWeight: 10.5,
@@ -1682,7 +1692,11 @@ describe('deriveWeightRecordBreakers', () => {
 
 	it('reports a 3rd-heaviest placement when two other days are heavier', () => {
 		const highlights = deriveWeights([
-			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+			weightRow(SESSION_DATE, BLUE_TIT, {
+				encounters: 41,
+				minWeight: 11,
+				maxWeight: 13.1
+			}),
 			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
 				weighedBirds: 3,
 				minWeight: 10.5,
@@ -1738,7 +1752,11 @@ describe('deriveWeightRecordBreakers', () => {
 	it('counts later days when ranking placements', () => {
 		// the later day is heavier, demoting the session to 2nd
 		const highlights = deriveWeights([
-			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+			weightRow(SESSION_DATE, BLUE_TIT, {
+				encounters: 41,
+				minWeight: 11,
+				maxWeight: 13.1
+			}),
 			weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
 				weighedBirds: 3,
 				minWeight: 10.5,
@@ -1777,6 +1795,98 @@ describe('deriveWeightRecordBreakers', () => {
 			})
 		]);
 		expect(highlights).toEqual([]);
+	});
+
+	describe('lower-ranked placement gates', () => {
+		it('drops a 2nd-lightest placement', () => {
+			// session is the 2nd-lightest ever; only 1st-lightest is worth reporting.
+			// Session max stays below the other day so no heaviest placement fires.
+			const highlights = deriveWeights([
+				weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 9.8, maxWeight: 11 }),
+				weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+					weighedBirds: 3,
+					minWeight: 9.5,
+					maxWeight: 15
+				})
+			]);
+			expect(highlights).toEqual([]);
+		});
+
+		it('drops a 3rd-lightest placement', () => {
+			// two other days are lighter, so the session ranks 3rd-lightest.
+			const highlights = deriveWeights([
+				weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 9.8, maxWeight: 11 }),
+				weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+					weighedBirds: 2,
+					minWeight: 9.5,
+					maxWeight: 15
+				}),
+				weightRow(LATER_DAY, BLUE_TIT, {
+					weighedBirds: 2,
+					minWeight: 9.0,
+					maxWeight: 15
+				})
+			]);
+			expect(highlights).toEqual([]);
+		});
+
+		it('drops a 2nd-heaviest placement for a sparsely-recorded species', () => {
+			// one other day is heavier (rank 2) but the species has only a handful
+			// of encounters ever, so the placement is not worth reporting.
+			const highlights = deriveWeights([
+				weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+				weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+					weighedBirds: 3,
+					minWeight: 10.5,
+					maxWeight: 14
+				})
+			]);
+			expect(highlights.map((h) => h.extreme)).not.toContain('heaviest');
+		});
+
+		it('drops a 2nd-heaviest placement at exactly 40 encounters ever', () => {
+			// 1 (session) + 3 (weighed other day) + 36 (unweighed other day) = 40.
+			const highlights = deriveWeights([
+				weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+				weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+					weighedBirds: 3,
+					minWeight: 10.5,
+					maxWeight: 14
+				}),
+				weightRow(LATER_DAY, BLUE_TIT, {
+					weighedBirds: 0,
+					encounters: 36,
+					minWeight: 0,
+					maxWeight: 0
+				})
+			]);
+			expect(highlights.map((h) => h.extreme)).not.toContain('heaviest');
+		});
+
+		it('keeps a 2nd-heaviest placement above 40 encounters, counting every day including unweighed', () => {
+			// 1 (session) + 3 (weighed other day) + 37 (unweighed other day) = 41.
+			const highlights = deriveWeights([
+				weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+				weightRow(PRIOR_SPRING_OTHER_YEAR, BLUE_TIT, {
+					weighedBirds: 3,
+					minWeight: 10.5,
+					maxWeight: 14
+				}),
+				weightRow(LATER_DAY, BLUE_TIT, {
+					weighedBirds: 0,
+					encounters: 37,
+					minWeight: 0,
+					maxWeight: 0
+				})
+			]);
+			expect(highlights).toContainEqual(
+				expect.objectContaining({
+					extreme: 'heaviest',
+					weight: 13.1,
+					placementRank: 2
+				})
+			);
+		});
 	});
 });
 

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -780,6 +780,10 @@ export function deriveLongAbsenceRetraps(
 // before a weight placement is worth reporting
 const MIN_WEIGHED_ENCOUNTERS_FOR_RECORD = 3;
 
+// Lower-ranked (2nd/3rd) heaviest placements only surface once a species is
+// well-recorded — more than this many encounters ever.
+const MIN_ENCOUNTERS_FOR_LOWER_HEAVIEST = 40;
+
 // Ranks the session's extreme against every other day's extreme (heaviest =
 // larger is better, lightest = smaller is better). Returns null when the
 // session doesn't make the top 3. The rank counts how many other days hold a
@@ -832,6 +836,10 @@ export function deriveWeightRecordBreakers({
 		);
 		if (otherWeighedEncounters < MIN_WEIGHED_ENCOUNTERS_FOR_RECORD) continue;
 
+		const speciesEncountersEver = stats.daySpeciesStats
+			.filter((row) => row.species_name === sessionRow.species_name)
+			.reduce((total, row) => total + row.encounter_count, 0);
+
 		for (const extreme of WEIGHT_RECORD_EXTREMES) {
 			const isHeaviest = extreme === 'heaviest';
 			const sessionWeight = isHeaviest
@@ -846,6 +854,15 @@ export function deriveWeightRecordBreakers({
 				isHeaviest
 			);
 			if (placement) {
+				// Editorial gates on lower-ranked (2nd/3rd) placements: 2nd/3rd
+				// lightest is never worth reporting; 2nd/3rd heaviest only once the
+				// species is well-recorded.
+				if (placement.placementRank > 1) {
+					if (extreme === 'lightest') continue;
+					if (speciesEncountersEver <= MIN_ENCOUNTERS_FOR_LOWER_HEAVIEST) {
+						continue;
+					}
+				}
 				highlights.push({
 					type: 'weight-record',
 					sortValue: TRAILING_SORT_VALUES['weight-record'],


### PR DESCRIPTION
## What

Two editorial gates on weight-record highlights, added to `deriveWeightRecordBreakers` alongside the existing weighed-encounters gate:

- **Never 2nd/3rd lightest** — only the all-time lightest (rank 1) is worth reporting.
- **2nd/3rd heaviest only for well-recorded species** — dropped unless the species has **more than 40** encounters recorded ever (summed across every day, weighed or not, including this session; strictly `> 40`).

Rank-1 placements always survive.

## Why

Low-ranked weight placements are noise: a light bird a couple of days beat isn't a story, and a "2nd-heaviest" for a species caught a handful of times is near-meaningless.

## Placement

Both gates depend only on a single highlight plus the species' encounter count — no cross-highlight interaction — so they live in the derive step next to the existing `MIN_WEIGHED_ENCOUNTERS_FOR_RECORD` gate, not in the refinement machine (whose rules resolve interactions *between* highlights).

## Tests

New `lower-ranked placement gates` block in `deriveWeightRecordBreakers` tests: drops 2nd/3rd lightest, drops 2nd-heaviest for sparse species, boundary at exactly 40 (drop) vs 41 (keep) counting unweighed days. Existing 2nd/3rd-heaviest ranking tests bumped above the threshold so they still assert ranking. `npm run qa` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)