### PR TITLE
feat: highest-species-count highlight refinements (#371)

### DIFF
--- a/app/components/session-highlight-renderers.tsx
+++ b/app/components/session-highlight-renderers.tsx
@@ -4,6 +4,7 @@ import { format as formatDate } from 'date-fns';
 import type {
 	CombinedOnlyOfYearHighlight,
 	CombinedSessionTotalRecordHighlight,
+	CombinedSpeciesCountRecordHighlight,
 	FirstEverSpeciesHighlight,
 	FirstOfYearSpeciesHighlight,
 	LongAbsenceRetrapHighlight,
@@ -120,6 +121,29 @@ function buildCombinedOnlyOfYearSentence(
 		? 'of the year'
 		: `of ${highlight.year}`;
 	return `Only ${speciesList} records ${yearPhrase}`;
+}
+
+// "Highest A, B and C counts of the year" — the single-species "the most this
+// year/season" record copy, folded into one species-list line that drops each
+// per-species count. Year and season each phrase their period the way the
+// standalone record line does (absolute label once the period is past).
+function buildCombinedSpeciesCountRecordSentence(
+	highlight: CombinedSpeciesCountRecordHighlight
+): string {
+	const { speciesNames } = highlight;
+	const speciesList =
+		speciesNames.length === 2
+			? speciesNames.join(' and ')
+			: `${speciesNames.slice(0, -1).join(', ')} and ${speciesNames.at(-1)}`;
+	const periodPhrase =
+		highlight.scope === 'this-year'
+			? highlight.isCurrentYear
+				? 'of the year'
+				: `of ${highlight.year}`
+			: highlight.isCurrentSeason
+				? `this ${highlight.seasonName}`
+				: `in ${highlight.seasonPeriodLabel}`;
+	return `Highest ${speciesList} counts ${periodPhrase}`;
 }
 
 function buildSpeciesCountRecordSentence(
@@ -283,7 +307,9 @@ const HIGHLIGHT_RENDERERS: {
 	'combined-session-total-record': (highlight) =>
 		renderSentence(buildCombinedSessionTotalRecordSentence(highlight)),
 	'combined-only-of-year': (highlight) =>
-		renderSentence(buildCombinedOnlyOfYearSentence(highlight))
+		renderSentence(buildCombinedOnlyOfYearSentence(highlight)),
+	'combined-species-count-record': (highlight) =>
+		renderSentence(buildCombinedSpeciesCountRecordSentence(highlight))
 };
 
 export function renderHighlight(highlight: SessionHighlight): ReactElement {

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -1967,3 +1967,70 @@ describe('render — combined-only-of-year', () => {
 		).toBe('Only Chaffinch and Goldfinch records of 2024');
 	});
 });
+
+describe('render — combined-species-count-record', () => {
+	const combinedFields = {
+		type: 'combined-species-count-record' as const,
+		sortValue: 0,
+		seasonName: 'spring',
+		year: 2026,
+		isCurrentYear: true,
+		isCurrentSeason: true,
+		seasonPeriodLabel: 'spring 2026'
+	};
+
+	it('renders three this-year species with commas and a trailing "and"', () => {
+		expect(
+			renderedText({
+				...combinedFields,
+				scope: 'this-year',
+				speciesNames: ["Cetti's Warbler", 'Chiffchaff', 'Whitethroat']
+			})
+		).toBe(
+			"Highest Cetti's Warbler, Chiffchaff and Whitethroat counts of the year"
+		);
+	});
+
+	it('renders two this-year species joined by "and"', () => {
+		expect(
+			renderedText({
+				...combinedFields,
+				scope: 'this-year',
+				speciesNames: ['Blue Tit', 'Wren']
+			})
+		).toBe('Highest Blue Tit and Wren counts of the year');
+	});
+
+	it('renders the absolute year for a past-year session', () => {
+		expect(
+			renderedText({
+				...combinedFields,
+				scope: 'this-year',
+				isCurrentYear: false,
+				year: 2024,
+				speciesNames: ['Blue Tit', 'Wren']
+			})
+		).toBe('Highest Blue Tit and Wren counts of 2024');
+	});
+
+	it('renders this-season copy for a current-season session', () => {
+		expect(
+			renderedText({
+				...combinedFields,
+				scope: 'this-season',
+				speciesNames: ['Robin', 'Dunnock']
+			})
+		).toBe('Highest Robin and Dunnock counts this spring');
+	});
+
+	it('renders the absolute season label for a past-season session', () => {
+		expect(
+			renderedText({
+				...combinedFields,
+				scope: 'this-season',
+				isCurrentSeason: false,
+				speciesNames: ['Robin', 'Dunnock']
+			})
+		).toBe('Highest Robin and Dunnock counts in spring 2026');
+	});
+});

--- a/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
+++ b/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
 	combineOnlyOfYearHighlights,
 	combineSessionTotalRecords,
+	combineYearAndSeasonSpeciesCounts,
 	orderBySortValue,
 	removeBusiestSinceWhenBusiestRecordHeld,
 	removeNarrowerScopeSpeciesRecords,
@@ -437,6 +438,95 @@ describe('combineOnlyOfYearHighlights (Comb-2)', () => {
 	});
 });
 
+describe('combineYearAndSeasonSpeciesCounts (Comb-3)', () => {
+	it('leaves a single this-year species record unchanged', () => {
+		const lone = speciesCountRecord('Chiffchaff', 'this-year', 5);
+		expect(combineYearAndSeasonSpeciesCounts([lone])).toEqual([lone]);
+	});
+
+	it('merges multiple this-year records into one line dropping the counts', () => {
+		const combined = combineYearAndSeasonSpeciesCounts([
+			speciesCountRecord("Cetti's Warbler", 'this-year', 6),
+			speciesCountRecord('Chiffchaff', 'this-year', 5),
+			speciesCountRecord('Whitethroat', 'this-year', 4)
+		]);
+		expect(combined).toEqual([
+			{
+				type: 'combined-species-count-record',
+				sortValue: combinedSortValue([
+					speciesCountRecord("Cetti's Warbler", 'this-year', 6),
+					speciesCountRecord('Chiffchaff', 'this-year', 5),
+					speciesCountRecord('Whitethroat', 'this-year', 4)
+				]),
+				scope: 'this-year',
+				speciesNames: ["Cetti's Warbler", 'Chiffchaff', 'Whitethroat'],
+				...periodFields
+			}
+		]);
+	});
+
+	it('merges multiple this-season records independently of this-year', () => {
+		const combined = combineYearAndSeasonSpeciesCounts([
+			speciesCountRecord('Blackcap', 'this-year', 5),
+			speciesCountRecord('Wren', 'this-year', 4),
+			speciesCountRecord('Robin', 'this-season', 3),
+			speciesCountRecord('Dunnock', 'this-season', 3)
+		]);
+		expect(combined.map((highlight) => highlight.type)).toEqual([
+			'combined-species-count-record',
+			'combined-species-count-record'
+		]);
+		expect(combined).toEqual([
+			expect.objectContaining({
+				scope: 'this-year',
+				speciesNames: ['Blackcap', 'Wren']
+			}),
+			expect.objectContaining({
+				scope: 'this-season',
+				speciesNames: ['Robin', 'Dunnock']
+			})
+		]);
+	});
+
+	it('takes the list position of the first record for the scope', () => {
+		const combined = combineYearAndSeasonSpeciesCounts([
+			speciesCountRecord("Cetti's Warbler", 'this-year', 6),
+			speciesCountRecord('Blackcap', 'any-season', 24),
+			speciesCountRecord('Chiffchaff', 'this-year', 5)
+		]);
+		expect(combined.map((highlight) => highlight.type)).toEqual([
+			'combined-species-count-record',
+			'species-count-record'
+		]);
+	});
+
+	it('never merges all-time or any-season records', () => {
+		const allTime = speciesCountRecord('Reed Warbler', 'all-time', 67, {
+			placementRank: 2,
+			isJointPlacement: false
+		});
+		const anySeason = speciesCountRecord('Blackcap', 'any-season', 24);
+		expect(combineYearAndSeasonSpeciesCounts([allTime, anySeason])).toEqual([
+			allTime,
+			anySeason
+		]);
+	});
+
+	it('leaves a lone record per scope unchanged', () => {
+		const year = speciesCountRecord('Chiffchaff', 'this-year', 5);
+		const season = speciesCountRecord('Wren', 'this-season', 3);
+		expect(combineYearAndSeasonSpeciesCounts([year, season])).toEqual([
+			year,
+			season
+		]);
+	});
+
+	it('is a noop on unrelated highlights', () => {
+		const pool = [rareSpecies, weightRecord];
+		expect(combineYearAndSeasonSpeciesCounts(pool)).toEqual(pool);
+	});
+});
+
 // ---- Full machine ----
 
 describe('runHighlightMachine', () => {
@@ -483,11 +573,14 @@ describe('runHighlightMachine', () => {
 			['combined-session-total-record', 'combined-session-total-record'],
 			['species-count-record', 'Reed Warbler'], // all-time placement, 5.01
 			['species-count-record', 'Blackcap'], // any-season, 4.01
-			['species-count-record', 'Blue Tit'], // this-year, 3.01
-			['species-count-record', "Cetti's Warbler"],
-			['species-count-record', 'Dunnock'],
-			['species-count-record', 'Wren'],
-			['species-count-record', 'Chiffchaff'], // this-season, 2.01
+			// the four surviving this-year single-species records fold into one
+			// line (3.01 + 0.3 = 3.31); Reed Warbler's this-year record was already
+			// dropped by Rem-2 in favour of its all-time placement
+			[
+				'combined-species-count-record',
+				"Blue Tit+Cetti's Warbler+Dunnock+Wren"
+			],
+			['species-count-record', 'Chiffchaff'], // this-season, 2.01 (lone, unmerged)
 			['combined-only-of-year', 'Chaffinch+Goldfinch+Lesser Whitethroat'], // 0.8
 			['weight-record', 'Blue Tit'] // 0.0
 		]);

--- a/app/models/highlight-refinement-machine/combine-year-and-season-species-counts.ts
+++ b/app/models/highlight-refinement-machine/combine-year-and-season-species-counts.ts
@@ -1,0 +1,77 @@
+import {
+	combinedSortValue,
+	type CombinedSpeciesCountRecordHighlight,
+	type SessionHighlight,
+	type SpeciesCountRecordHighlight
+} from '@/app/models/session-highlights';
+
+// Scopes whose species-count records merge into one line — only the
+// current-period scopes, whose copy is "the most this year/season" and so reads
+// cleanly as a species list. All-time/any-season records stay per-species
+// (placements, "the most ever") and are never merged.
+const COMBINABLE_SCOPES = ['this-year', 'this-season'] as const;
+type CombinableScope = (typeof COMBINABLE_SCOPES)[number];
+
+function isCombinable(
+	highlight: SessionHighlight
+): highlight is SpeciesCountRecordHighlight & { scope: CombinableScope } {
+	return (
+		highlight.type === 'species-count-record' &&
+		(COMBINABLE_SCOPES as readonly string[]).includes(highlight.scope)
+	);
+}
+
+// Comb-3: multiple single-species "Record day for X — N caught, the most this
+// year/season" highlights over the same scope merge into one "Highest A, B and
+// C counts of the year" line, dropping the per-species count. Each scope merges
+// independently; a scope with a lone record is left unchanged. The combined
+// item takes the position of the first record for its scope.
+export function combineYearAndSeasonSpeciesCounts(
+	highlights: SessionHighlight[]
+): SessionHighlight[] {
+	const recordsByScope = new Map<
+		CombinableScope,
+		(SpeciesCountRecordHighlight & { scope: CombinableScope })[]
+	>();
+	for (const highlight of highlights) {
+		if (!isCombinable(highlight)) continue;
+		const forScope = recordsByScope.get(highlight.scope) ?? [];
+		forScope.push(highlight);
+		recordsByScope.set(highlight.scope, forScope);
+	}
+	// Only scopes holding at least two records combine
+	const combiningScopes = new Set(
+		[...recordsByScope]
+			.filter(([, records]) => records.length >= 2)
+			.map(([scope]) => scope)
+	);
+	if (combiningScopes.size === 0) return highlights;
+
+	const insertedScopes = new Set<CombinableScope>();
+	const result: SessionHighlight[] = [];
+	for (const highlight of highlights) {
+		if (isCombinable(highlight) && combiningScopes.has(highlight.scope)) {
+			// Emit the combined line in place of the scope's first record; drop
+			// every other record for that scope
+			if (insertedScopes.has(highlight.scope)) continue;
+			insertedScopes.add(highlight.scope);
+			const records = recordsByScope.get(highlight.scope)!;
+			const [first] = records;
+			const combined: CombinedSpeciesCountRecordHighlight = {
+				type: 'combined-species-count-record',
+				sortValue: combinedSortValue(records),
+				scope: highlight.scope,
+				speciesNames: records.map((record) => record.speciesName),
+				seasonName: first.seasonName,
+				year: first.year,
+				isCurrentYear: first.isCurrentYear,
+				isCurrentSeason: first.isCurrentSeason,
+				seasonPeriodLabel: first.seasonPeriodLabel
+			};
+			result.push(combined);
+			continue;
+		}
+		result.push(highlight);
+	}
+	return result;
+}

--- a/app/models/highlight-refinement-machine/index.ts
+++ b/app/models/highlight-refinement-machine/index.ts
@@ -3,12 +3,14 @@ import { removeBusiestSinceWhenBusiestRecordHeld } from './remove-busiest-since-
 import { removeNarrowerScopeSpeciesRecords } from './remove-narrower-scope-species-records';
 import { combineSessionTotalRecords } from './combine-session-total-records';
 import { combineOnlyOfYearHighlights } from './combine-only-of-year-highlights';
+import { combineYearAndSeasonSpeciesCounts } from './combine-year-and-season-species-counts';
 import { orderBySortValue } from './order-by-sort-value';
 
 export { removeBusiestSinceWhenBusiestRecordHeld } from './remove-busiest-since-when-busiest-record-held';
 export { removeNarrowerScopeSpeciesRecords } from './remove-narrower-scope-species-records';
 export { combineSessionTotalRecords } from './combine-session-total-records';
 export { combineOnlyOfYearHighlights } from './combine-only-of-year-highlights';
+export { combineYearAndSeasonSpeciesCounts } from './combine-year-and-season-species-counts';
 export { orderBySortValue } from './order-by-sort-value';
 
 type HighlightRule = (highlights: SessionHighlight[]) => SessionHighlight[];
@@ -25,6 +27,7 @@ const RULES: HighlightRule[] = [
 	removeNarrowerScopeSpeciesRecords, // Rem-2
 	combineSessionTotalRecords, // Comb-1
 	combineOnlyOfYearHighlights, // Comb-2
+	combineYearAndSeasonSpeciesCounts, // Comb-3
 	orderBySortValue // Ord-1
 ];
 

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -245,6 +245,26 @@ export type CombinedOnlyOfYearHighlight = {
 	isCurrentYear: boolean;
 };
 
+// Multiple "Record day for <species> — N caught, the most this year/season"
+// highlights over the *same* scope (this-year or this-season only) merged by
+// the machine's combine pass into one "Highest A, B and C counts of the year"
+// line. Drops the per-species count; keeps the shared period fields so the
+// renderer can phrase the scope. Broader scopes (all-time, any-season) never
+// merge — their copy is per-species (placements, "the most ever").
+export type CombinedSpeciesCountRecordHighlight = {
+	type: 'combined-species-count-record';
+	sortValue: number;
+	// Only the current-period scopes carry combinable per-species copy
+	scope: 'this-year' | 'this-season';
+	// Species names in the order the source highlights appeared
+	speciesNames: string[];
+	seasonName: string;
+	year: number;
+	isCurrentYear: boolean;
+	isCurrentSeason: boolean;
+	seasonPeriodLabel: string;
+};
+
 // The discriminated union the highlight machine's passes and the client
 // renderers both operate over. Highlights are plain serializable data so they
 // can cross the server-action -> client boundary; rendering happens client
@@ -259,7 +279,8 @@ export type SessionHighlight =
 	| LongAbsenceRetrapHighlight
 	| WeightRecordHighlight
 	| CombinedSessionTotalRecordHighlight
-	| CombinedOnlyOfYearHighlight;
+	| CombinedOnlyOfYearHighlight
+	| CombinedSpeciesCountRecordHighlight;
 
 type DayTotals = {
 	date: string;


### PR DESCRIPTION
Closes #371

## What this covers

Two refinements to highest-species-count session highlights:

1. **Combine year/season records into one line, dropping the count.** Multiple single-species records over the same current-period scope, e.g.

   > Record day for Cetti's Warbler — 6 caught, the most this year
   > Record day for Chiffchaff — 5 caught, the most this year
   > Record day for Whitethroat — 4 caught, the most this year

   now fold into a single line:

   > Highest Cetti's Warbler, Chiffchaff and Whitethroat counts of the year

   `this-year` and `this-season` records merge independently of one another. Broader scopes (`all-time`, `any-season`) are never merged — their copy is per-species (placements, "the most ever").

2. **Never output when the count is 1.** Already enforced at derivation time in `deriveSpeciesRecords` (`if (sessionValue === 1) continue;`), with an existing test. No change needed.

## How

Follows the existing combine-rule pattern exactly:

- New machine rule `combine-year-and-season-species-counts.ts` (Comb-3), slotted into `RULES` after Comb-2 and before the final ordering rule. Combined lines carry a bumped `sortValue` via `combinedSortValue`, so ordering is unchanged in principle.
- New `CombinedSpeciesCountRecordHighlight` type + renderer (`buildCombinedSpeciesCountRecordSentence`).
- Season/year period phrasing mirrors the standalone record line: "of the year" / "of {year}" for year; "this {season}" / "in {seasonPeriodLabel}" for season (absolute label once the period is past).

## Assumptions / decisions

- **Only `this-year` and `this-season` scopes combine.** The ticket names "year" and "season". All-time/any-season records carry distinct per-species copy (placements, joint-best, "for N years") that doesn't reduce to a species list, so they stay separate.
- **Season copy:** the ticket only gave the year example ("...counts of the year"). For season I mirror the existing single-record season phrasing — "Highest A and B counts this spring" (current) / "...in spring 2026" (past).
- Requirement 2 was already implemented; I verified it rather than duplicating the gate in the machine.

## Tests (all passing — 432 total)

- `combineYearAndSeasonSpeciesCounts (Comb-3)`: lone record noop, multi-species merge dropping counts, year/season merge independently, list position, never-merge all-time/any-season, unrelated-highlight noop.
- `render — combined-species-count-record`: 2- and 3-species lists, current vs past year, current vs past season.
- Updated the end-to-end `runHighlightMachine` #360 example to reflect the folded this-year line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)