### PR TITLE
feat: combine "first" highlights into one species-list line

### DIFF
--- a/app/components/session-highlight-renderers.tsx
+++ b/app/components/session-highlight-renderers.tsx
@@ -2,6 +2,8 @@
 import type { ReactElement } from 'react';
 import { format as formatDate } from 'date-fns';
 import type {
+	CombinedFirstEverHighlight,
+	CombinedFirstOfYearHighlight,
 	CombinedOnlyOfYearHighlight,
 	CombinedSessionTotalRecordHighlight,
 	CombinedSpeciesCountRecordHighlight,
@@ -106,21 +108,45 @@ function buildCombinedSessionTotalRecordSentence(
 	return `Busiest and most varied session ever — ${valueCopy}`;
 }
 
-// "Only A, B and C records of the year" — a comma list with "and" before the
-// last name. Two names read "A and B"; the plural "records" is fixed because a
-// combined line always covers at least two species.
+// A comma list with "and" before the last name: two names read "A and B",
+// three "A, B and C". Combined highlights always list at least two species.
+function buildSpeciesList(speciesNames: string[]): string {
+	return speciesNames.length === 2
+		? speciesNames.join(' and ')
+		: `${speciesNames.slice(0, -1).join(', ')} and ${speciesNames.at(-1)}`;
+}
+
+// "of the year" while the year is still current; otherwise "of <year>".
+function buildOfYearPhrase(highlight: {
+	isCurrentYear: boolean;
+	year: number;
+}): string {
+	return highlight.isCurrentYear ? 'of the year' : `of ${highlight.year}`;
+}
+
+// "Only A, B and C records of the year" — the plural "records" is fixed because
+// a combined line always covers at least two species.
 function buildCombinedOnlyOfYearSentence(
 	highlight: CombinedOnlyOfYearHighlight
 ): string {
-	const { speciesNames } = highlight;
-	const speciesList =
-		speciesNames.length === 2
-			? speciesNames.join(' and ')
-			: `${speciesNames.slice(0, -1).join(', ')} and ${speciesNames.at(-1)}`;
-	const yearPhrase = highlight.isCurrentYear
-		? 'of the year'
-		: `of ${highlight.year}`;
-	return `Only ${speciesList} records ${yearPhrase}`;
+	return `Only ${buildSpeciesList(highlight.speciesNames)} records ${buildOfYearPhrase(highlight)}`;
+}
+
+// "First ever A, B and C records" — merges multiple singular/plural "First ever
+// <species> record(s)" lines. Always plural "records": a combined line lists at
+// least two species.
+function buildCombinedFirstEverSentence(
+	highlight: CombinedFirstEverHighlight
+): string {
+	return `First ever ${buildSpeciesList(highlight.speciesNames)} records`;
+}
+
+// "First A, B and C records of the year" — merges multiple "First <species>
+// record(s) of the year" lines. Always plural "records" (see first-ever above).
+function buildCombinedFirstOfYearSentence(
+	highlight: CombinedFirstOfYearHighlight
+): string {
+	return `First ${buildSpeciesList(highlight.speciesNames)} records ${buildOfYearPhrase(highlight)}`;
 }
 
 // "Highest A, B and C counts of the year" — the single-species "the most this
@@ -130,16 +156,10 @@ function buildCombinedOnlyOfYearSentence(
 function buildCombinedSpeciesCountRecordSentence(
 	highlight: CombinedSpeciesCountRecordHighlight
 ): string {
-	const { speciesNames } = highlight;
-	const speciesList =
-		speciesNames.length === 2
-			? speciesNames.join(' and ')
-			: `${speciesNames.slice(0, -1).join(', ')} and ${speciesNames.at(-1)}`;
+	const speciesList = buildSpeciesList(highlight.speciesNames);
 	const periodPhrase =
 		highlight.scope === 'this-year'
-			? highlight.isCurrentYear
-				? 'of the year'
-				: `of ${highlight.year}`
+			? buildOfYearPhrase(highlight)
 			: highlight.isCurrentSeason
 				? `this ${highlight.seasonName}`
 				: `in ${highlight.seasonPeriodLabel}`;
@@ -308,6 +328,10 @@ const HIGHLIGHT_RENDERERS: {
 		renderSentence(buildCombinedSessionTotalRecordSentence(highlight)),
 	'combined-only-of-year': (highlight) =>
 		renderSentence(buildCombinedOnlyOfYearSentence(highlight)),
+	'combined-first-ever': (highlight) =>
+		renderSentence(buildCombinedFirstEverSentence(highlight)),
+	'combined-first-of-year': (highlight) =>
+		renderSentence(buildCombinedFirstOfYearSentence(highlight)),
 	'combined-species-count-record': (highlight) =>
 		renderSentence(buildCombinedSpeciesCountRecordSentence(highlight))
 };

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -2034,3 +2034,87 @@ describe('render — combined-species-count-record', () => {
 		).toBe('Highest Robin and Dunnock counts in summer 2026');
 	});
 });
+
+describe('render — combined-first-ever', () => {
+	it('renders three species with commas and a trailing "and"', () => {
+		expect(
+			renderedText({
+				type: 'combined-first-ever',
+				sortValue: 0,
+				speciesNames: ['Blackbird', 'Blackcap', "Cetti's Warbler"]
+			})
+		).toBe("First ever Blackbird, Blackcap and Cetti's Warbler records");
+	});
+
+	it('renders two species joined by "and"', () => {
+		expect(
+			renderedText({
+				type: 'combined-first-ever',
+				sortValue: 0,
+				speciesNames: ['Blackbird', 'Blackcap']
+			})
+		).toBe('First ever Blackbird and Blackcap records');
+	});
+
+	it('always reads "records" (plural) regardless of the merged parts', () => {
+		// The combined line covers at least two species, so the copy is fixed
+		// plural even when each source highlight was singular
+		expect(
+			renderedText({
+				type: 'combined-first-ever',
+				sortValue: 0,
+				speciesNames: ['Blackbird', 'Blackcap']
+			})
+		).toMatch(/records$/);
+	});
+});
+
+describe('render — combined-first-of-year', () => {
+	it('renders three species with commas and a trailing "and"', () => {
+		expect(
+			renderedText({
+				type: 'combined-first-of-year',
+				sortValue: 0,
+				speciesNames: ['Blackbird', 'Blackcap', "Cetti's Warbler"],
+				year: 2026,
+				isCurrentYear: true
+			})
+		).toBe("First Blackbird, Blackcap and Cetti's Warbler records of the year");
+	});
+
+	it('renders two species joined by "and"', () => {
+		expect(
+			renderedText({
+				type: 'combined-first-of-year',
+				sortValue: 0,
+				speciesNames: ['Blackbird', 'Blackcap'],
+				year: 2026,
+				isCurrentYear: true
+			})
+		).toBe('First Blackbird and Blackcap records of the year');
+	});
+
+	it('renders the absolute year for a past-year session', () => {
+		expect(
+			renderedText({
+				type: 'combined-first-of-year',
+				sortValue: 0,
+				speciesNames: ['Blackbird', 'Blackcap'],
+				year: 2024,
+				isCurrentYear: false
+			})
+		).toBe('First Blackbird and Blackcap records of 2024');
+	});
+
+	it('always reads "records" (plural) regardless of the merged parts', () => {
+		expect(
+			renderedText({
+				type: 'combined-first-of-year',
+				sortValue: 0,
+				speciesNames: ['Blackbird', 'Blackcap'],
+				year: 2026,
+				isCurrentYear: true
+			})
+		).toMatch(/records of the year$/);
+	});
+});

--- a/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
+++ b/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
+	combineFirstEverHighlights,
+	combineFirstOfYearHighlights,
 	combineOnlyOfYearHighlights,
 	combineSessionTotalRecords,
 	combineYearAndSeasonSpeciesCounts,
@@ -67,7 +69,8 @@ function speciesCountRecord(
 
 function firstOfYear(
 	speciesName: string,
-	isOnlyRecord: boolean
+	isOnlyRecord: boolean,
+	multipleIndividualsRecorded = false
 ): FirstOfYearSpeciesHighlight {
 	return {
 		type: 'first-of-year-species',
@@ -75,7 +78,21 @@ function firstOfYear(
 		speciesName,
 		year: 2026,
 		isCurrentYear: true,
-		multipleIndividualsRecorded: false,
+		multipleIndividualsRecorded,
+		isOnlyRecord
+	};
+}
+
+function firstEver(
+	speciesName: string,
+	isOnlyRecord: boolean,
+	multipleIndividualsRecorded = false
+): FirstEverSpeciesHighlight {
+	return {
+		type: 'first-ever-species',
+		sortValue: TRAILING_SORT_VALUES['first-ever-species'],
+		speciesName,
+		multipleIndividualsRecorded,
 		isOnlyRecord
 	};
 }
@@ -527,6 +544,204 @@ describe('combineYearAndSeasonSpeciesCounts (Comb-3)', () => {
 	});
 });
 
+describe('combineFirstEverHighlights (Comb-4)', () => {
+	it('leaves a single first-ever highlight unchanged', () => {
+		const only = firstEver('Firecrest', false);
+		expect(combineFirstEverHighlights([only])).toEqual([only]);
+	});
+
+	it('merges two first-ever highlights into one line listing both species', () => {
+		const combined = combineFirstEverHighlights([
+			firstEver('Blackbird', false),
+			firstEver('Blackcap', false)
+		]);
+		expect(combined).toEqual([
+			{
+				type: 'combined-first-ever',
+				sortValue: combinedSortValue([
+					firstEver('Blackbird', false),
+					firstEver('Blackcap', false)
+				]),
+				speciesNames: ['Blackbird', 'Blackcap']
+			}
+		]);
+	});
+
+	it('merges three first-ever highlights into one line listing all species', () => {
+		const combined = combineFirstEverHighlights([
+			firstEver('Blackbird', false),
+			firstEver('Blackcap', false),
+			firstEver("Cetti's Warbler", false)
+		]);
+		expect(combined).toEqual([
+			{
+				type: 'combined-first-ever',
+				sortValue: combinedSortValue([
+					firstEver('Blackbird', false),
+					firstEver('Blackcap', false),
+					firstEver("Cetti's Warbler", false)
+				]),
+				speciesNames: ['Blackbird', 'Blackcap', "Cetti's Warbler"]
+			}
+		]);
+	});
+
+	it('merges regardless of each part being singular or plural', () => {
+		const combined = combineFirstEverHighlights([
+			firstEver('Blackbird', false, false),
+			firstEver('Blackcap', false, true)
+		]);
+		expect(combined).toEqual([
+			expect.objectContaining({
+				type: 'combined-first-ever',
+				speciesNames: ['Blackbird', 'Blackcap']
+			})
+		]);
+	});
+
+	it('never merges "Only ... ever" (isOnlyRecord) highlights', () => {
+		const firstA = firstEver('Robin', true);
+		const firstB = firstEver('Wren', true);
+		expect(combineFirstEverHighlights([firstA, firstB])).toEqual([
+			firstA,
+			firstB
+		]);
+	});
+
+	it('merges only the first-ever items, leaving "only ever" items in place', () => {
+		const onlyEver = firstEver('Robin', true);
+		const combined = combineFirstEverHighlights([
+			onlyEver,
+			firstEver('Blackbird', false),
+			firstEver('Blackcap', false)
+		]);
+		expect(combined).toEqual([
+			onlyEver,
+			{
+				type: 'combined-first-ever',
+				sortValue: combinedSortValue([
+					firstEver('Blackbird', false),
+					firstEver('Blackcap', false)
+				]),
+				speciesNames: ['Blackbird', 'Blackcap']
+			}
+		]);
+	});
+
+	it('takes the list position of the first first-ever highlight', () => {
+		const combined = combineFirstEverHighlights([
+			firstEver('Blackbird', false),
+			rareSpecies,
+			firstEver('Blackcap', false)
+		]);
+		expect(combined.map((highlight) => highlight.type)).toEqual([
+			'combined-first-ever',
+			'rare-species'
+		]);
+	});
+
+	it('is a noop on unrelated highlights', () => {
+		const pool = [rareSpecies, weightRecord];
+		expect(combineFirstEverHighlights(pool)).toEqual(pool);
+	});
+});
+
+describe('combineFirstOfYearHighlights (Comb-5)', () => {
+	it('leaves a single first-of-year highlight unchanged', () => {
+		const only = firstOfYear('Robin', false);
+		expect(combineFirstOfYearHighlights([only])).toEqual([only]);
+	});
+
+	it('merges two first-of-year highlights into one line listing both species', () => {
+		const combined = combineFirstOfYearHighlights([
+			firstOfYear('Blackbird', false),
+			firstOfYear('Blackcap', false)
+		]);
+		expect(combined).toEqual([
+			{
+				type: 'combined-first-of-year',
+				sortValue: combinedSortValue([
+					firstOfYear('Blackbird', false),
+					firstOfYear('Blackcap', false)
+				]),
+				speciesNames: ['Blackbird', 'Blackcap'],
+				year: 2026,
+				isCurrentYear: true
+			}
+		]);
+	});
+
+	it('merges three first-of-year highlights into one line listing all species', () => {
+		const combined = combineFirstOfYearHighlights([
+			firstOfYear('Blackbird', false),
+			firstOfYear('Blackcap', false),
+			firstOfYear("Cetti's Warbler", false)
+		]);
+		expect(combined).toEqual([
+			{
+				type: 'combined-first-of-year',
+				sortValue: combinedSortValue([
+					firstOfYear('Blackbird', false),
+					firstOfYear('Blackcap', false),
+					firstOfYear("Cetti's Warbler", false)
+				]),
+				speciesNames: ['Blackbird', 'Blackcap', "Cetti's Warbler"],
+				year: 2026,
+				isCurrentYear: true
+			}
+		]);
+	});
+
+	it('merges regardless of each part being singular or plural', () => {
+		const combined = combineFirstOfYearHighlights([
+			firstOfYear('Blackbird', false, false),
+			firstOfYear('Blackcap', false, true)
+		]);
+		expect(combined).toEqual([
+			expect.objectContaining({
+				type: 'combined-first-of-year',
+				speciesNames: ['Blackbird', 'Blackcap']
+			})
+		]);
+	});
+
+	it('never merges "Only ... of the year" (isOnlyRecord) highlights', () => {
+		const onlyA = firstOfYear('Chaffinch', true);
+		const onlyB = firstOfYear('Goldfinch', true);
+		expect(combineFirstOfYearHighlights([onlyA, onlyB])).toEqual([
+			onlyA,
+			onlyB
+		]);
+	});
+
+	it('merges only the first-of-year items, leaving "only of year" items in place', () => {
+		const onlyOfYear = firstOfYear('Chaffinch', true);
+		const combined = combineFirstOfYearHighlights([
+			onlyOfYear,
+			firstOfYear('Blackbird', false),
+			firstOfYear('Blackcap', false)
+		]);
+		expect(combined).toEqual([
+			onlyOfYear,
+			{
+				type: 'combined-first-of-year',
+				sortValue: combinedSortValue([
+					firstOfYear('Blackbird', false),
+					firstOfYear('Blackcap', false)
+				]),
+				speciesNames: ['Blackbird', 'Blackcap'],
+				year: 2026,
+				isCurrentYear: true
+			}
+		]);
+	});
+
+	it('is a noop on unrelated highlights', () => {
+		const pool = [rareSpecies, weightRecord];
+		expect(combineFirstOfYearHighlights(pool)).toEqual(pool);
+	});
+});
+
 // ---- Full machine ----
 
 describe('runHighlightMachine', () => {
@@ -583,6 +798,30 @@ describe('runHighlightMachine', () => {
 			['species-count-record', 'Chiffchaff'], // this-season, 2.01 (lone, unmerged)
 			['combined-only-of-year', 'Chaffinch+Goldfinch+Lesser Whitethroat'], // 0.8
 			['weight-record', 'Blue Tit'] // 0.0
+		]);
+	});
+
+	it('folds first-ever and first-of-year highlights into their own combined lines', () => {
+		const pool: SessionHighlight[] = [
+			firstEver('Blackbird', false),
+			firstEver('Blackcap', false),
+			firstEver("Cetti's Warbler", false),
+			firstOfYear('Chiffchaff', false),
+			firstOfYear('Whitethroat', false),
+			weightRecord
+		];
+		const machined = runHighlightMachine(pool);
+		expect(
+			machined.map((highlight) =>
+				'speciesNames' in highlight
+					? [highlight.type, highlight.speciesNames.join('+')]
+					: [highlight.type]
+			)
+		).toEqual([
+			// first-ever (0.8 + 0.2 = 1.0) above first-of-year (0.6 + 0.1 = 0.7)
+			['combined-first-ever', "Blackbird+Blackcap+Cetti's Warbler"],
+			['combined-first-of-year', 'Chiffchaff+Whitethroat'],
+			['weight-record']
 		]);
 	});
 });

--- a/app/models/highlight-refinement-machine/combine-first-ever-highlights.ts
+++ b/app/models/highlight-refinement-machine/combine-first-ever-highlights.ts
@@ -1,0 +1,43 @@
+import {
+	combinedSortValue,
+	type CombinedFirstEverHighlight,
+	type FirstEverSpeciesHighlight,
+	type SessionHighlight
+} from '@/app/models/session-highlights';
+
+function isFirstEver(
+	highlight: SessionHighlight
+): highlight is FirstEverSpeciesHighlight {
+	return highlight.type === 'first-ever-species' && !highlight.isOnlyRecord;
+}
+
+// Comb-4: multiple "First ever <species> record(s)" highlights merge into one
+// "First ever A, B and C records" line listing every species. One first-ever
+// highlight is left as-is; "Only <species> records ever" (isOnlyRecord)
+// highlights are never merged. The combined line always reads "records" (plural)
+// even if every part was singular, since it covers at least two species. The
+// combined item takes the position of the first first-ever highlight.
+export function combineFirstEverHighlights(
+	highlights: SessionHighlight[]
+): SessionHighlight[] {
+	const firstEver = highlights.filter(isFirstEver);
+	if (firstEver.length < 2) return highlights;
+	const combined: CombinedFirstEverHighlight = {
+		type: 'combined-first-ever',
+		sortValue: combinedSortValue(firstEver),
+		speciesNames: firstEver.map((highlight) => highlight.speciesName)
+	};
+	let combinedInserted = false;
+	const result: SessionHighlight[] = [];
+	for (const highlight of highlights) {
+		if (isFirstEver(highlight)) {
+			if (!combinedInserted) {
+				result.push(combined);
+				combinedInserted = true;
+			}
+			continue;
+		}
+		result.push(highlight);
+	}
+	return result;
+}

--- a/app/models/highlight-refinement-machine/combine-first-of-year-highlights.ts
+++ b/app/models/highlight-refinement-machine/combine-first-of-year-highlights.ts
@@ -1,0 +1,47 @@
+import {
+	combinedSortValue,
+	type CombinedFirstOfYearHighlight,
+	type FirstOfYearSpeciesHighlight,
+	type SessionHighlight
+} from '@/app/models/session-highlights';
+
+function isFirstOfYear(
+	highlight: SessionHighlight
+): highlight is FirstOfYearSpeciesHighlight {
+	return highlight.type === 'first-of-year-species' && !highlight.isOnlyRecord;
+}
+
+// Comb-5: multiple "First <species> record(s) of the year" highlights merge into
+// one "First A, B and C records of the year" line listing every species. One
+// first-of-year highlight is left as-is; "Only ... of the year" (isOnlyRecord)
+// highlights combine separately (Comb-2). The combined line always reads
+// "records" (plural) even if every part was singular, since it covers at least
+// two species. The combined item takes the position of the first first-of-year
+// highlight.
+export function combineFirstOfYearHighlights(
+	highlights: SessionHighlight[]
+): SessionHighlight[] {
+	const firstOfYear = highlights.filter(isFirstOfYear);
+	if (firstOfYear.length < 2) return highlights;
+	const [first] = firstOfYear;
+	const combined: CombinedFirstOfYearHighlight = {
+		type: 'combined-first-of-year',
+		sortValue: combinedSortValue(firstOfYear),
+		speciesNames: firstOfYear.map((highlight) => highlight.speciesName),
+		year: first.year,
+		isCurrentYear: first.isCurrentYear
+	};
+	let combinedInserted = false;
+	const result: SessionHighlight[] = [];
+	for (const highlight of highlights) {
+		if (isFirstOfYear(highlight)) {
+			if (!combinedInserted) {
+				result.push(combined);
+				combinedInserted = true;
+			}
+			continue;
+		}
+		result.push(highlight);
+	}
+	return result;
+}

--- a/app/models/highlight-refinement-machine/index.ts
+++ b/app/models/highlight-refinement-machine/index.ts
@@ -3,6 +3,8 @@ import { removeBusiestSinceWhenBusiestRecordHeld } from './remove-busiest-since-
 import { removeNarrowerScopeSpeciesRecords } from './remove-narrower-scope-species-records';
 import { combineSessionTotalRecords } from './combine-session-total-records';
 import { combineOnlyOfYearHighlights } from './combine-only-of-year-highlights';
+import { combineFirstEverHighlights } from './combine-first-ever-highlights';
+import { combineFirstOfYearHighlights } from './combine-first-of-year-highlights';
 import { combineYearAndSeasonSpeciesCounts } from './combine-year-and-season-species-counts';
 import { orderBySortValue } from './order-by-sort-value';
 
@@ -10,6 +12,8 @@ export { removeBusiestSinceWhenBusiestRecordHeld } from './remove-busiest-since-
 export { removeNarrowerScopeSpeciesRecords } from './remove-narrower-scope-species-records';
 export { combineSessionTotalRecords } from './combine-session-total-records';
 export { combineOnlyOfYearHighlights } from './combine-only-of-year-highlights';
+export { combineFirstEverHighlights } from './combine-first-ever-highlights';
+export { combineFirstOfYearHighlights } from './combine-first-of-year-highlights';
 export { combineYearAndSeasonSpeciesCounts } from './combine-year-and-season-species-counts';
 export { orderBySortValue } from './order-by-sort-value';
 
@@ -28,6 +32,8 @@ const RULES: HighlightRule[] = [
 	combineSessionTotalRecords, // Comb-1
 	combineOnlyOfYearHighlights, // Comb-2
 	combineYearAndSeasonSpeciesCounts, // Comb-3
+	combineFirstEverHighlights, // Comb-4
+	combineFirstOfYearHighlights, // Comb-5
 	orderBySortValue // Ord-1
 ];
 

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -245,6 +245,32 @@ export type CombinedOnlyOfYearHighlight = {
 	isCurrentYear: boolean;
 };
 
+// Multiple "First ever <species> record(s)" highlights merged by the machine's
+// combine pass into one "First ever A, B and C records" line. Only the "First
+// ever" variant merges — "Only <species> records ever" (isOnlyRecord) items are
+// left per-species. A combined line always covers at least two species, so the
+// copy is always plural ("records") even if every part was singular.
+export type CombinedFirstEverHighlight = {
+	type: 'combined-first-ever';
+	sortValue: number;
+	// Species names in the order the source highlights appeared
+	speciesNames: string[];
+};
+
+// Multiple "First <species> record(s) of the year" highlights merged by the
+// machine's combine pass into one "First A, B and C records of the year" line.
+// Only the "First of year" variant merges — the "Only ... of the year"
+// (isOnlyRecord) items combine separately (CombinedOnlyOfYearHighlight). As with
+// first-ever, the combined copy is always plural.
+export type CombinedFirstOfYearHighlight = {
+	type: 'combined-first-of-year';
+	sortValue: number;
+	// Species names in the order the source highlights appeared
+	speciesNames: string[];
+	year: number;
+	isCurrentYear: boolean;
+};
+
 // Multiple "Record day for <species> — N caught, the most this year/season"
 // highlights over the *same* scope (this-year or this-season only) merged by
 // the machine's combine pass into one "Highest A, B and C counts of the year"
@@ -280,6 +306,8 @@ export type SessionHighlight =
 	| WeightRecordHighlight
 	| CombinedSessionTotalRecordHighlight
 	| CombinedOnlyOfYearHighlight
+	| CombinedFirstEverHighlight
+	| CombinedFirstOfYearHighlight
 	| CombinedSpeciesCountRecordHighlight;
 
 type DayTotals = {


### PR DESCRIPTION
## What this covers

Adds two combine rules to the session-highlight refinement machine so that multiple "first" highlights fold into a single species-list line:

- **Comb-4 `combineFirstEverHighlights`** — merges multiple `First ever <species> record(s)` highlights into one `First ever A, B and C records` line.
- **Comb-5 `combineFirstOfYearHighlights`** — merges multiple `First <species> record(s) of the year` highlights into one `First A, B and C records of the year` line.

Both always read the plural **"records"** — a combined line always covers at least two species — even when every merged part was singular.

New combined highlight types (`CombinedFirstEverHighlight`, `CombinedFirstOfYearHighlight`) added to the discriminated union, wired into the machine's `RULES`, and given renderers. The shared species-list and "of year" phrase helpers were extracted in the renderers (now the 3rd/4th use, so per the DRY-after-3 rule).

This is a single-layer change (models + renderers + tests) — no DB, server-action, or schema changes — so one PR closes the issue.

## Tests

- New `combineFirstEverHighlights (Comb-4)` and `combineFirstOfYearHighlights (Comb-5)` describe blocks in the machine test (merge 2/3 species, singular+plural parts, `isOnlyRecord` exclusion, list position, noop).
- New end-to-end machine test folding first-ever and first-of-year into their own combined lines.
- New `render — combined-first-ever` and `render — combined-first-of-year` copy tests (comma list, two-species "and", absolute year, always-plural "records").

`npm run qa` passes (lint 0 errors, type-check clean, 458 app tests pass).

## Assumptions

- **Which variants combine.** Mirroring the existing rules, only the non-`isOnlyRecord` variants merge: first-ever combines `First ever ...` items (leaving `Only ... ever` per-species), first-of-year combines `First ... of the year` items (the `Only ... of the year` items already combine separately via Comb-2). The ticket's examples are all "First ever", so this matches the intent.
- **Sort placement.** Combined lines keep the family's base `sortValue` bumped by `COMBINE_INCREMENT` per extra part, exactly like the other combine rules — no change to the sort-value spacing scheme.

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)