### PR TITLE
feat: suppress "joint third" placement highlights

### DIFF
--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -801,16 +801,31 @@ describe('deriveSpeciesRecords', () => {
 			});
 		});
 
-		it('reports a joint 3rd-best day when the session ties the 3rd-best value', () => {
+		it('does not report a joint 3rd-best day when the session ties the 3rd-best value', () => {
+			// A joint 3rd merely repeats an already-lesser record — suppressed
 			const highlights = deriveSpecies([
 				speciesRow(SESSION_DATE, REED_WARBLER, 5),
 				speciesRow(PRIOR_SUMMER_OTHER_YEAR, REED_WARBLER, 10),
 				speciesRow(PRIOR_SUMMER_YEAR_ONE, REED_WARBLER, 8),
 				speciesRow(PRIOR_SUMMER_YEAR_THREE, REED_WARBLER, 5)
 			]);
+			expect(highlights).toHaveLength(0);
+		});
+
+		it('reports a joint 2nd-best day even when many other days share the tied value', () => {
+			// Ties for 2nd stay notable however many days hold the value — only
+			// the top value's day count gates whether 2nd place is reported
+			const highlights = deriveSpecies([
+				speciesRow(SESSION_DATE, REED_WARBLER, 8),
+				speciesRow(PRIOR_SUMMER_OTHER_YEAR, REED_WARBLER, 10),
+				speciesRow(PRIOR_SUMMER_YEAR_ONE, REED_WARBLER, 8),
+				speciesRow(PRIOR_SUMMER_YEAR_THREE, REED_WARBLER, 8),
+				speciesRow(PRIOR_THIS_SEASON, REED_WARBLER, 8)
+			]);
 			expect(highlights).toHaveLength(1);
 			expect(highlights[0]).toMatchObject({
-				placementRank: 3,
+				scope: 'all-time',
+				placementRank: 2,
 				isJointPlacement: true
 			});
 		});
@@ -894,18 +909,16 @@ describe('deriveSpeciesRecords', () => {
 			expect(highlights).toHaveLength(0);
 		});
 
-		it('ranks by prior day count, so tying the 2nd value behind two joint-top days is joint 3rd', () => {
+		it('suppresses a joint 3rd when tying the 2nd value behind two joint-top days', () => {
+			// Two joint-top days rank the session 3rd, and it ties another day at
+			// that value — a joint 3rd, so it is suppressed
 			const highlights = deriveSpecies([
 				speciesRow(SESSION_DATE, REED_WARBLER, 8),
 				speciesRow(PRIOR_SUMMER_OTHER_YEAR, REED_WARBLER, 10),
 				speciesRow(PRIOR_SUMMER_YEAR_ONE, REED_WARBLER, 10),
 				speciesRow(PRIOR_SUMMER_YEAR_THREE, REED_WARBLER, 8)
 			]);
-			expect(highlights).toHaveLength(1);
-			expect(highlights[0]).toMatchObject({
-				placementRank: 3,
-				isJointPlacement: true
-			});
+			expect(highlights).toHaveLength(0);
 		});
 
 		it('reports no placement when the session falls below all existing tier values', () => {
@@ -1047,18 +1060,6 @@ describe('render — species-count-record', () => {
 				})
 			)
 		).toBe('Joint second best day for Reed Warbler ever — 8 birds');
-	});
-
-	it('renders joint third-best placement copy', () => {
-		expect(
-			renderedText(
-				makeSpeciesHighlight({
-					placementRank: 3,
-					isJointPlacement: true,
-					value: 8
-				})
-			)
-		).toBe('Joint third best day for Reed Warbler ever — 8 birds');
 	});
 });
 
@@ -1733,6 +1734,24 @@ describe('deriveWeightRecordBreakers', () => {
 			placementRank: 1,
 			isJointPlacement: true
 		});
+	});
+
+	it('suppresses a joint 3rd placement when two days are heavier and another ties', () => {
+		// Two heavier days rank the session 3rd, and a fourth day matches its
+		// weight — a joint 3rd, which repeats a lesser record and is suppressed
+		const highlights = deriveWeights([
+			weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+			weightRow(PRIOR_SUMMER_OTHER_YEAR, BLUE_TIT, {
+				weighedBirds: 3,
+				minWeight: 10.5,
+				maxWeight: 14.0
+			}),
+			weightRow(LATER_DAY, BLUE_TIT, { minWeight: 10.9, maxWeight: 13.8 }),
+			weightRow(LATER_DAY_TWO, BLUE_TIT, { minWeight: 10.8, maxWeight: 13.1 })
+		]);
+		expect(highlights.map((highlight) => highlight.extreme)).not.toContain(
+			'heaviest'
+		);
 	});
 
 	it('counts later days when ranking placements', () => {

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -529,10 +529,25 @@ export function deriveSinceHighlights({
 // A 2nd place may be joint (tying other days is still notable, however many
 // days share the value), but a 3rd place is only reported when it is unique —
 // a joint 3rd merely repeats an already-lesser record and isn't worth a line.
+type Placement = { placementRank: 1 | 2 | 3; isJointPlacement: boolean };
+
+// Turns a count of strictly-better other days into a placement. Ties share a
+// rank (they're the same value). A joint 3rd is suppressed — it merely repeats
+// an already-lesser record; joint 1st/2nd stay. Returns null outside the top 3.
+function resolvePlacement(
+	betterDaysCount: number,
+	isJointPlacement: boolean
+): Placement | null {
+	const placementRank = betterDaysCount + 1;
+	if (placementRank > 3) return null;
+	if (placementRank === 3 && isJointPlacement) return null;
+	return { placementRank: placementRank as 1 | 2 | 3, isJointPlacement };
+}
+
 function deriveAllTimePlacement(
 	sessionValue: number,
 	otherValues: number[]
-): { placementRank: 2 | 3; isJointPlacement: boolean } | null {
+): Placement | null {
 	const distinctValuesDescending = [...new Set(otherValues)].sort(
 		(a, b) => b - a
 	);
@@ -551,15 +566,12 @@ function deriveAllTimePlacement(
 	}
 	const minIncludedValue = includedValues.at(-1)!;
 	if (sessionValue < minIncludedValue || sessionValue >= topValue) return null;
-	// The tier rule above means at most two other days can outrank a
-	// qualifying value, so the rank is always 2 or 3
-	const placementRank = (otherValues.filter(
+	// The tier rule above means at most two other days can outrank a qualifying
+	// value, so resolvePlacement always yields a 2nd or 3rd here (never 1st)
+	const betterDays = otherValues.filter(
 		(otherValue) => otherValue > sessionValue
-	).length + 1) as 2 | 3;
-	const isJointPlacement = otherValues.includes(sessionValue);
-	// A joint 3rd best just repeats an existing 3rd-best day — suppress it
-	if (placementRank === 3 && isJointPlacement) return null;
-	return { placementRank, isJointPlacement };
+	).length;
+	return resolvePlacement(betterDays, otherValues.includes(sessionValue));
 }
 
 export function deriveSpeciesRecords({
@@ -842,18 +854,13 @@ function deriveWeightPlacement(
 	sessionWeight: number,
 	otherWeights: number[],
 	isHeaviest: boolean
-): { placementRank: 1 | 2 | 3; isJointPlacement: boolean } | null {
+): Placement | null {
 	const isBetter = (candidate: number, reference: number) =>
 		isHeaviest ? candidate > reference : candidate < reference;
 	const betterDays = otherWeights.filter((weight) =>
 		isBetter(weight, sessionWeight)
 	).length;
-	const placementRank = betterDays + 1;
-	if (placementRank > 3) return null;
-	const isJointPlacement = otherWeights.includes(sessionWeight);
-	// A joint 3rd best just repeats an existing 3rd-best day — suppress it
-	if (placementRank === 3 && isJointPlacement) return null;
-	return { placementRank: placementRank as 1 | 2 | 3, isJointPlacement };
+	return resolvePlacement(betterDays, otherWeights.includes(sessionWeight));
 }
 
 // Weight placements are inherently all-time — a species' heaviest/lightest bird

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -525,6 +525,10 @@ export function deriveSinceHighlights({
 // place needs fewer than three other days across the top two values. The
 // session must also equal or exceed an included tier value — a count below
 // every other value is not a placement, however thin the history.
+//
+// A 2nd place may be joint (tying other days is still notable, however many
+// days share the value), but a 3rd place is only reported when it is unique —
+// a joint 3rd merely repeats an already-lesser record and isn't worth a line.
 function deriveAllTimePlacement(
 	sessionValue: number,
 	otherValues: number[]
@@ -552,10 +556,10 @@ function deriveAllTimePlacement(
 	const placementRank = (otherValues.filter(
 		(otherValue) => otherValue > sessionValue
 	).length + 1) as 2 | 3;
-	return {
-		placementRank,
-		isJointPlacement: otherValues.includes(sessionValue)
-	};
+	const isJointPlacement = otherValues.includes(sessionValue);
+	// A joint 3rd best just repeats an existing 3rd-best day — suppress it
+	if (placementRank === 3 && isJointPlacement) return null;
+	return { placementRank, isJointPlacement };
 }
 
 export function deriveSpeciesRecords({
@@ -832,7 +836,8 @@ const MIN_WEIGHED_ENCOUNTERS_FOR_RECORD = 3;
 // Ranks the session's extreme against every other day's extreme (heaviest =
 // larger is better, lightest = smaller is better). Returns null when the
 // session doesn't make the top 3. The rank counts how many other days hold a
-// strictly better extreme, so ties share a rank.
+// strictly better extreme, so ties share a rank. A joint 3rd is suppressed —
+// it merely repeats a lesser record; joint 1st/2nd are still worth reporting.
 function deriveWeightPlacement(
 	sessionWeight: number,
 	otherWeights: number[],
@@ -845,10 +850,10 @@ function deriveWeightPlacement(
 	).length;
 	const placementRank = betterDays + 1;
 	if (placementRank > 3) return null;
-	return {
-		placementRank: placementRank as 1 | 2 | 3,
-		isJointPlacement: otherWeights.includes(sessionWeight)
-	};
+	const isJointPlacement = otherWeights.includes(sessionWeight);
+	// A joint 3rd best just repeats an existing 3rd-best day — suppress it
+	if (placementRank === 3 && isJointPlacement) return null;
+	return { placementRank: placementRank as 1 | 2 | 3, isJointPlacement };
 }
 
 // Weight placements are inherently all-time — a species' heaviest/lightest bird


### PR DESCRIPTION
## What this covers

"Joint third" placement highlights are no longer generated. This affects the two placement-producing functions in the highlight refinement machine:

- `deriveAllTimePlacement` (species-count records) — a rank-3 placement that ties another day is now suppressed.
- `deriveWeightPlacement` (weight records) — a rank-3 (heaviest/lightest) placement that ties another day is now suppressed.

Preserved behaviour:
- A **unique (strict) 3rd best** is still reported — it's a genuine record, not a repeat of a previous one.
- **Ties for 2nd place** are still reported, however many days share the tied value (only the top value's day count gates whether 2nd place is reported at all).
- Joint 1st / joint 2nd (both families) are unchanged.

## Tests

- Updated the two species-count tests that previously asserted a joint 3rd was generated — they now assert no highlight is produced.
- Added a species-count test confirming a joint 2nd is still reported when many days share the tied value.
- Added a weight-record test confirming a joint 3rd is suppressed.
- Removed the now-dead "renders joint third-best" render test (the copy path is unreachable once joint 3rd is never generated). Strict 3rd render tests remain.

`npm run qa` passes (lint: 0 errors, type-check clean, 459 app tests pass). Pre-push hook (app + integration tests) also passed.

## Assumptions

- Interpreted "third-best should still exist, but only if it's unique" as: keep strict rank-3 placements, drop rank-3 placements where `isJointPlacement` is true — applied symmetrically to both the species-count and weight placement families (the ticket phrasing is generic and both families share the same "joint Nth" concept).
- "Ties for 2nd place should still be included even if there are many instances of the tie" required no logic change: the existing tier gate keys off the *top* value's day count, not the number of days at the tied 2nd value, so joint 2nds were already unaffected — added a test to lock this in.

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)