### PR TITLE
feat: show wing and weight ranges on species bird list

### DIFF
--- a/app/components/MeasurementRangeCell.tsx
+++ b/app/components/MeasurementRangeCell.tsx
@@ -1,0 +1,47 @@
+import type { MeasurementRange } from '@/app/models/measurement-range';
+
+/**
+ * Renders a summarised measurement range (see issue #377):
+ * - empty        → blank cell
+ * - single       → one value
+ * - range        → "min - max"
+ * - dominant endpoint → the matching endpoint is bold, e.g. **67** - 69
+ * - dominant aside    → range followed by bold parenthesised value, e.g. 67 - 70 **(69)**
+ */
+export function MeasurementRangeCell({ range }: { range: MeasurementRange }) {
+	if (range.kind === 'empty') {
+		return null;
+	}
+	if (range.kind === 'single') {
+		return <>{range.value}</>;
+	}
+
+	const { min, max } = range;
+	const dominant = 'dominant' in range ? range.dominant : undefined;
+
+	if (dominant === min) {
+		return (
+			<>
+				<strong>{min}</strong> - {max}
+			</>
+		);
+	}
+	if (dominant === max) {
+		return (
+			<>
+				{min} - <strong>{max}</strong>
+			</>
+		);
+	}
+	return (
+		<>
+			{min} - {max}
+			{dominant !== undefined ? (
+				<>
+					{' '}
+					<strong>({dominant})</strong>
+				</>
+			) : null}
+		</>
+	);
+}

--- a/app/components/MeasurementRangeCell.tsx
+++ b/app/components/MeasurementRangeCell.tsx
@@ -2,22 +2,26 @@ import type { MeasurementRange } from '@/app/models/measurement-range';
 
 /**
  * Renders a summarised measurement range (see issue #377):
- * - empty        → blank cell
- * - single       → one value
- * - range        → "min - max"
+ * - null           → blank cell
+ * - min === max    → the single value (collapsing the range is presentational)
+ * - min < max      → "min - max"
  * - dominant endpoint → the matching endpoint is bold, e.g. **67** - 69
  * - dominant aside    → range followed by bold parenthesised value, e.g. 67 - 70 **(69)**
  */
-export function MeasurementRangeCell({ range }: { range: MeasurementRange }) {
-	if (range.kind === 'empty') {
+export function MeasurementRangeCell({
+	range
+}: {
+	range: MeasurementRange | null;
+}) {
+	if (range === null) {
 		return null;
 	}
-	if (range.kind === 'single') {
-		return <>{range.value}</>;
-	}
 
-	const { min, max } = range;
-	const dominant = 'dominant' in range ? range.dominant : undefined;
+	const { min, max, dominant } = range;
+
+	if (min === max) {
+		return <>{min}</>;
+	}
 
 	if (dominant === min) {
 		return (

--- a/app/components/SpTable.tsx
+++ b/app/components/SpTable.tsx
@@ -1,7 +1,12 @@
 'use client';
 import { format as formatDate } from 'date-fns';
 import { type EnrichedBirdOfSpecies } from '@/app/models/bird';
+import {
+	deriveMeasurementRange,
+	type MeasurementRange
+} from '@/app/models/measurement-range';
 import { SingleBirdTable } from '@/app/components/SingleBirdTable';
+import { MeasurementRangeCell } from '@/app/components/MeasurementRangeCell';
 import { NoPrefetchLink } from '@/app/components/shared/NoPrefetchLink';
 import { AccordionTableBody } from './shared/AccordionTableBody';
 import {
@@ -15,11 +20,18 @@ type RowModel = {
 	ringNo: string;
 	encounterCount: number;
 	sex: string;
+	wingRange: MeasurementRange;
+	weightRange: MeasurementRange;
 	firstEncounterDate: Date;
 	lastEncounterDate: Date;
 	lastEncounterAgeCode: string;
 	provenAge: number;
 };
+
+const rangeColumnProperties = new Set<keyof RowModel>([
+	'wingRange',
+	'weightRange'
+]);
 
 function dateFormatter(date: Date): string {
 	return formatDate(date, 'dd MMM yyyy');
@@ -35,6 +47,12 @@ const columnConfigs = {
 	},
 	sex: {
 		label: 'Sex'
+	},
+	wingRange: {
+		label: 'Wing'
+	},
+	weightRange: {
+		label: 'Weight'
 	},
 	firstEncounterDate: {
 		label: 'First',
@@ -80,7 +98,13 @@ function BirdRow({ model: bird }: { model: RowModel }) {
 	return orderedColumnProperties
 		.slice(1)
 		.map((prop) => (
-			<td key={prop}>{cellFormatter(bird[prop as keyof RowModel], prop)}</td>
+			<td key={prop}>
+				{rangeColumnProperties.has(prop) ? (
+					<MeasurementRangeCell range={bird[prop] as MeasurementRange} />
+				) : (
+					cellFormatter(bird[prop as keyof RowModel], prop)
+				)}
+			</td>
 		));
 }
 
@@ -89,6 +113,13 @@ function rowDataTransform(bird: EnrichedBirdOfSpecies): RowModel {
 		ringNo: bird.ring_no,
 		encounterCount: bird.encounters.length,
 		sex: `${bird.sex}${bird.sexCertainty < 0.5 ? '?' : ''}`,
+		wingRange: deriveMeasurementRange(
+			bird.encounters.map((encounter) => encounter.wing_length),
+			{ withDominant: true }
+		),
+		weightRange: deriveMeasurementRange(
+			bird.encounters.map((encounter) => encounter.weight)
+		),
 		firstEncounterDate: bird.firstEncounterDate,
 		lastEncounterDate: bird.lastEncounterDate,
 		lastEncounterAgeCode: `${bird.lastEncounter.age_code}${bird.lastEncounter.is_juv ? 'J' : ''}`,

--- a/app/components/SpTable.tsx
+++ b/app/components/SpTable.tsx
@@ -20,8 +20,8 @@ type RowModel = {
 	ringNo: string;
 	encounterCount: number;
 	sex: string;
-	wingRange: MeasurementRange;
-	weightRange: MeasurementRange;
+	wingRange: MeasurementRange | null;
+	weightRange: MeasurementRange | null;
 	firstEncounterDate: Date;
 	lastEncounterDate: Date;
 	lastEncounterAgeCode: string;
@@ -100,7 +100,7 @@ function BirdRow({ model: bird }: { model: RowModel }) {
 		.map((prop) => (
 			<td key={prop}>
 				{rangeColumnProperties.has(prop) ? (
-					<MeasurementRangeCell range={bird[prop] as MeasurementRange} />
+					<MeasurementRangeCell range={bird[prop] as MeasurementRange | null} />
 				) : (
 					cellFormatter(bird[prop as keyof RowModel], prop)
 				)}

--- a/app/components/__tests__/MeasurementRangeCell.test.tsx
+++ b/app/components/__tests__/MeasurementRangeCell.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+import { MeasurementRangeCell } from '../MeasurementRangeCell';
+
+function renderCell(
+	range: Parameters<typeof MeasurementRangeCell>[0]['range']
+) {
+	const { container } = render(<MeasurementRangeCell range={range} />);
+	return container;
+}
+
+describe('MeasurementRangeCell', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders nothing for an empty range', () => {
+		const container = renderCell({ kind: 'empty' });
+		expect(container.textContent).toBe('');
+	});
+
+	it('renders a single value', () => {
+		const container = renderCell({ kind: 'single', value: 67 });
+		expect(container.textContent).toBe('67');
+		expect(container.querySelector('strong')).toBeNull();
+	});
+
+	it('renders a plain range', () => {
+		const container = renderCell({ kind: 'range', min: 67, max: 69 });
+		expect(container.textContent).toBe('67 - 69');
+		expect(container.querySelector('strong')).toBeNull();
+	});
+
+	it('bolds a dominant value equal to the min endpoint', () => {
+		const container = renderCell({
+			kind: 'range',
+			min: 67,
+			max: 69,
+			dominant: 67
+		});
+		expect(container.textContent).toBe('67 - 69');
+		expect(container.querySelector('strong')?.textContent).toBe('67');
+	});
+
+	it('bolds a dominant value equal to the max endpoint', () => {
+		const container = renderCell({
+			kind: 'range',
+			min: 67,
+			max: 69,
+			dominant: 69
+		});
+		expect(container.textContent).toBe('67 - 69');
+		expect(container.querySelector('strong')?.textContent).toBe('69');
+	});
+
+	it('appends a bold parenthesised dominant value inside the range', () => {
+		const container = renderCell({
+			kind: 'range',
+			min: 67,
+			max: 70,
+			dominant: 69
+		});
+		expect(container.textContent).toBe('67 - 70 (69)');
+		expect(container.querySelector('strong')?.textContent).toBe('(69)');
+	});
+});

--- a/app/components/__tests__/MeasurementRangeCell.test.tsx
+++ b/app/components/__tests__/MeasurementRangeCell.test.tsx
@@ -14,52 +14,37 @@ describe('MeasurementRangeCell', () => {
 		cleanup();
 	});
 
-	it('renders nothing for an empty range', () => {
-		const container = renderCell({ kind: 'empty' });
+	it('renders nothing for a null range', () => {
+		const container = renderCell(null);
 		expect(container.textContent).toBe('');
 	});
 
-	it('renders a single value', () => {
-		const container = renderCell({ kind: 'single', value: 67 });
+	it('renders a single value when min = max', () => {
+		const container = renderCell({ min: 67, max: 67 });
 		expect(container.textContent).toBe('67');
 		expect(container.querySelector('strong')).toBeNull();
 	});
 
 	it('renders a plain range', () => {
-		const container = renderCell({ kind: 'range', min: 67, max: 69 });
+		const container = renderCell({ min: 67, max: 69 });
 		expect(container.textContent).toBe('67 - 69');
 		expect(container.querySelector('strong')).toBeNull();
 	});
 
 	it('bolds a dominant value equal to the min endpoint', () => {
-		const container = renderCell({
-			kind: 'range',
-			min: 67,
-			max: 69,
-			dominant: 67
-		});
+		const container = renderCell({ min: 67, max: 69, dominant: 67 });
 		expect(container.textContent).toBe('67 - 69');
 		expect(container.querySelector('strong')?.textContent).toBe('67');
 	});
 
 	it('bolds a dominant value equal to the max endpoint', () => {
-		const container = renderCell({
-			kind: 'range',
-			min: 67,
-			max: 69,
-			dominant: 69
-		});
+		const container = renderCell({ min: 67, max: 69, dominant: 69 });
 		expect(container.textContent).toBe('67 - 69');
 		expect(container.querySelector('strong')?.textContent).toBe('69');
 	});
 
 	it('appends a bold parenthesised dominant value inside the range', () => {
-		const container = renderCell({
-			kind: 'range',
-			min: 67,
-			max: 70,
-			dominant: 69
-		});
+		const container = renderCell({ min: 67, max: 70, dominant: 69 });
 		expect(container.textContent).toBe('67 - 70 (69)');
 		expect(container.querySelector('strong')?.textContent).toBe('(69)');
 	});

--- a/app/components/__tests__/SpIndividualsTab.test.tsx
+++ b/app/components/__tests__/SpIndividualsTab.test.tsx
@@ -35,6 +35,43 @@ describe('SpIndividualsTab', () => {
 		expect(rows?.length).toBe(birds.length);
 	});
 
+	it('renders Wing and Weight range columns', () => {
+		render(
+			<SpIndividualsTab
+				speciesId={1}
+				viewedGroupId={1}
+				birds={birds}
+				birdCount={birds.length}
+			/>
+		);
+		const headers = [...document.querySelectorAll('th')].map(
+			(th) => th.textContent
+		);
+		expect(headers).toContain('Wing');
+		expect(headers).toContain('Weight');
+	});
+
+	it('renders a wing range with its bold parenthesised dominant value', () => {
+		render(
+			<SpIndividualsTab
+				speciesId={1}
+				viewedGroupId={1}
+				birds={birds}
+				birdCount={birds.length}
+			/>
+		);
+		// ARRETRAP has wing lengths 74–80 with a dominant (majority) value of 75.
+		const arretrapRow = [...document.querySelectorAll('tbody tr')].find((row) =>
+			row.textContent?.includes('ARRETRAP')
+		);
+		expect(arretrapRow?.textContent).toContain('74 - 80 (75)');
+		expect(
+			[...(arretrapRow?.querySelectorAll('strong') ?? [])].map(
+				(el) => el.textContent
+			)
+		).toContain('(75)');
+	});
+
 	describe('birdCount prop', () => {
 		it('hides infinite scroll loader when birdCount equals loaded birds', () => {
 			render(

--- a/app/models/__tests__/measurement-range.test.ts
+++ b/app/models/__tests__/measurement-range.test.ts
@@ -5,29 +5,28 @@ describe('deriveMeasurementRange', () => {
 	describe('usual cases', () => {
 		it('returns a range for differing measurements', () => {
 			expect(deriveMeasurementRange([67, 69, 68])).toEqual({
-				kind: 'range',
 				min: 67,
 				max: 69
 			});
 		});
 
-		it('returns a single value when all measurements are equal', () => {
+		it('returns a zero-width range when all measurements are equal', () => {
 			expect(deriveMeasurementRange([68, 68, 68])).toEqual({
-				kind: 'single',
-				value: 68
+				min: 68,
+				max: 68
 			});
 		});
 	});
 
 	describe('structure — measurement count', () => {
-		it('returns empty when there are no measurements', () => {
-			expect(deriveMeasurementRange([])).toEqual({ kind: 'empty' });
+		it('returns null when there are no measurements', () => {
+			expect(deriveMeasurementRange([])).toBeNull();
 		});
 
-		it('returns a single value for one measurement', () => {
+		it('returns a zero-width range for one measurement', () => {
 			expect(deriveMeasurementRange([67])).toEqual({
-				kind: 'single',
-				value: 67
+				min: 67,
+				max: 67
 			});
 		});
 	});
@@ -35,16 +34,13 @@ describe('deriveMeasurementRange', () => {
 	describe('structure — null handling', () => {
 		it('ignores null and undefined values', () => {
 			expect(deriveMeasurementRange([null, 67, undefined, 69])).toEqual({
-				kind: 'range',
 				min: 67,
 				max: 69
 			});
 		});
 
-		it('returns empty when every value is null', () => {
-			expect(deriveMeasurementRange([null, undefined])).toEqual({
-				kind: 'empty'
-			});
+		it('returns null when every value is null', () => {
+			expect(deriveMeasurementRange([null, undefined])).toBeNull();
 		});
 	});
 
@@ -53,40 +49,39 @@ describe('deriveMeasurementRange', () => {
 			// sorted: 67,69,69,69,70 → median 69, majority equal 69
 			expect(
 				deriveMeasurementRange([67, 70, 69, 69, 69], { withDominant: true })
-			).toEqual({ kind: 'range', min: 67, max: 70, dominant: 69 });
+			).toEqual({ min: 67, max: 70, dominant: 69 });
 		});
 
 		it('attaches a dominant value equal to the min endpoint', () => {
 			// sorted: 67,67,67,69 → median 67, majority equal 67
 			expect(
 				deriveMeasurementRange([67, 67, 67, 69], { withDominant: true })
-			).toEqual({ kind: 'range', min: 67, max: 69, dominant: 67 });
+			).toEqual({ min: 67, max: 69, dominant: 67 });
 		});
 
 		it('attaches a dominant value equal to the max endpoint', () => {
 			// sorted: 67,69,69,69 → median 69, majority equal 69
 			expect(
 				deriveMeasurementRange([69, 67, 69, 69], { withDominant: true })
-			).toEqual({ kind: 'range', min: 67, max: 69, dominant: 69 });
+			).toEqual({ min: 67, max: 69, dominant: 69 });
 		});
 
 		it('omits a dominant value when no value holds the majority', () => {
 			// sorted: 67,68,69 → median 68 but only one record equals it
 			expect(
 				deriveMeasurementRange([67, 68, 69], { withDominant: true })
-			).toEqual({ kind: 'range', min: 67, max: 69 });
+			).toEqual({ min: 67, max: 69 });
 		});
 
 		it('omits a dominant value on an even split with no majority', () => {
 			// sorted: 67,67,69,69 → no value is a majority
 			expect(
 				deriveMeasurementRange([67, 67, 69, 69], { withDominant: true })
-			).toEqual({ kind: 'range', min: 67, max: 69 });
+			).toEqual({ min: 67, max: 69 });
 		});
 
 		it('does not compute a dominant value when withDominant is false', () => {
 			expect(deriveMeasurementRange([67, 69, 69, 69])).toEqual({
-				kind: 'range',
 				min: 67,
 				max: 69
 			});

--- a/app/models/__tests__/measurement-range.test.ts
+++ b/app/models/__tests__/measurement-range.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { deriveMeasurementRange } from '../measurement-range';
+
+describe('deriveMeasurementRange', () => {
+	describe('usual cases', () => {
+		it('returns a range for differing measurements', () => {
+			expect(deriveMeasurementRange([67, 69, 68])).toEqual({
+				kind: 'range',
+				min: 67,
+				max: 69
+			});
+		});
+
+		it('returns a single value when all measurements are equal', () => {
+			expect(deriveMeasurementRange([68, 68, 68])).toEqual({
+				kind: 'single',
+				value: 68
+			});
+		});
+	});
+
+	describe('structure — measurement count', () => {
+		it('returns empty when there are no measurements', () => {
+			expect(deriveMeasurementRange([])).toEqual({ kind: 'empty' });
+		});
+
+		it('returns a single value for one measurement', () => {
+			expect(deriveMeasurementRange([67])).toEqual({
+				kind: 'single',
+				value: 67
+			});
+		});
+	});
+
+	describe('structure — null handling', () => {
+		it('ignores null and undefined values', () => {
+			expect(deriveMeasurementRange([null, 67, undefined, 69])).toEqual({
+				kind: 'range',
+				min: 67,
+				max: 69
+			});
+		});
+
+		it('returns empty when every value is null', () => {
+			expect(deriveMeasurementRange([null, undefined])).toEqual({
+				kind: 'empty'
+			});
+		});
+	});
+
+	describe('withDominant (wing length)', () => {
+		it('attaches a dominant value strictly inside the range', () => {
+			// sorted: 67,69,69,69,70 → median 69, majority equal 69
+			expect(
+				deriveMeasurementRange([67, 70, 69, 69, 69], { withDominant: true })
+			).toEqual({ kind: 'range', min: 67, max: 70, dominant: 69 });
+		});
+
+		it('attaches a dominant value equal to the min endpoint', () => {
+			// sorted: 67,67,67,69 → median 67, majority equal 67
+			expect(
+				deriveMeasurementRange([67, 67, 67, 69], { withDominant: true })
+			).toEqual({ kind: 'range', min: 67, max: 69, dominant: 67 });
+		});
+
+		it('attaches a dominant value equal to the max endpoint', () => {
+			// sorted: 67,69,69,69 → median 69, majority equal 69
+			expect(
+				deriveMeasurementRange([69, 67, 69, 69], { withDominant: true })
+			).toEqual({ kind: 'range', min: 67, max: 69, dominant: 69 });
+		});
+
+		it('omits a dominant value when no value holds the majority', () => {
+			// sorted: 67,68,69 → median 68 but only one record equals it
+			expect(
+				deriveMeasurementRange([67, 68, 69], { withDominant: true })
+			).toEqual({ kind: 'range', min: 67, max: 69 });
+		});
+
+		it('omits a dominant value on an even split with no majority', () => {
+			// sorted: 67,67,69,69 → no value is a majority
+			expect(
+				deriveMeasurementRange([67, 67, 69, 69], { withDominant: true })
+			).toEqual({ kind: 'range', min: 67, max: 69 });
+		});
+
+		it('does not compute a dominant value when withDominant is false', () => {
+			expect(deriveMeasurementRange([67, 69, 69, 69])).toEqual({
+				kind: 'range',
+				min: 67,
+				max: 69
+			});
+		});
+	});
+});

--- a/app/models/measurement-range.ts
+++ b/app/models/measurement-range.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure logic for summarising a bird's measurements (wing length, weight) as a
+ * range for display on the single-species bird list.
+ *
+ * See issue #377.
+ */
+
+export type MeasurementRange =
+	| { kind: 'empty' }
+	| { kind: 'single'; value: number }
+	| { kind: 'range'; min: number; max: number }
+	// A range with a dominant value that falls outside [min, max] is impossible,
+	// so a dominant value is only ever attached to a range when it equals one of
+	// the endpoints (emphasised endpoint) or sits strictly between them (aside).
+	| { kind: 'range'; min: number; max: number; dominant: number };
+
+/**
+ * Filters an encounter's raw measurement values down to the numbers actually
+ * recorded (dropping null/undefined).
+ */
+function collectMeasurements(
+	values: readonly (number | null | undefined)[]
+): number[] {
+	return values.filter((value): value is number => typeof value === 'number');
+}
+
+/**
+ * The dominant value is the median, but only when the majority (strictly more
+ * than half) of the records equal it. Returns null when there is no such value.
+ */
+function findDominantValue(measurements: number[]): number | null {
+	const sorted = [...measurements].sort((a, b) => a - b);
+	const median = sorted[Math.floor((sorted.length - 1) / 2)];
+	const matchingCount = sorted.filter((value) => value === median).length;
+	return matchingCount * 2 > sorted.length ? median : null;
+}
+
+/**
+ * Summarises a set of measurement values as a range for display. When
+ * `withDominant` is true (used for wing length), a dominant value is attached
+ * to ranges where one exists.
+ */
+export function deriveMeasurementRange(
+	values: readonly (number | null | undefined)[],
+	{ withDominant = false }: { withDominant?: boolean } = {}
+): MeasurementRange {
+	const measurements = collectMeasurements(values);
+	if (measurements.length === 0) {
+		return { kind: 'empty' };
+	}
+	const min = Math.min(...measurements);
+	const max = Math.max(...measurements);
+	if (min === max) {
+		return { kind: 'single', value: min };
+	}
+	if (withDominant) {
+		const dominant = findDominantValue(measurements);
+		if (dominant !== null) {
+			return { kind: 'range', min, max, dominant };
+		}
+	}
+	return { kind: 'range', min, max };
+}

--- a/app/models/measurement-range.ts
+++ b/app/models/measurement-range.ts
@@ -5,14 +5,17 @@
  * See issue #377.
  */
 
-export type MeasurementRange =
-	| { kind: 'empty' }
-	| { kind: 'single'; value: number }
-	| { kind: 'range'; min: number; max: number }
-	// A range with a dominant value that falls outside [min, max] is impossible,
-	// so a dominant value is only ever attached to a range when it equals one of
-	// the endpoints (emphasised endpoint) or sits strictly between them (aside).
-	| { kind: 'range'; min: number; max: number; dominant: number };
+// Every set of measurements maps to a range (min/max); a single measurement, or
+// several equal ones, is simply a range where min === max. Collapsing that to a
+// lone value is a presentational decision (see MeasurementRangeCell), not a
+// property of the data. A dominant value falling outside [min, max] is
+// impossible, so `dominant` only ever equals an endpoint (emphasised endpoint) or
+// sits strictly between them (aside).
+export type MeasurementRange = {
+	min: number;
+	max: number;
+	dominant?: number;
+};
 
 /**
  * Filters an encounter's raw measurement values down to the numbers actually
@@ -36,28 +39,28 @@ function findDominantValue(measurements: number[]): number | null {
 }
 
 /**
- * Summarises a set of measurement values as a range for display. When
+ * Summarises a set of measurement values as a range. Returns null when no
+ * measurements were recorded (there is no range to describe). When
  * `withDominant` is true (used for wing length), a dominant value is attached
- * to ranges where one exists.
+ * where one exists.
  */
 export function deriveMeasurementRange(
 	values: readonly (number | null | undefined)[],
 	{ withDominant = false }: { withDominant?: boolean } = {}
-): MeasurementRange {
+): MeasurementRange | null {
 	const measurements = collectMeasurements(values);
 	if (measurements.length === 0) {
-		return { kind: 'empty' };
+		return null;
 	}
-	const min = Math.min(...measurements);
-	const max = Math.max(...measurements);
-	if (min === max) {
-		return { kind: 'single', value: min };
-	}
+	const range: MeasurementRange = {
+		min: Math.min(...measurements),
+		max: Math.max(...measurements)
+	};
 	if (withDominant) {
 		const dominant = findDominantValue(measurements);
 		if (dominant !== null) {
-			return { kind: 'range', min, max, dominant };
+			range.dominant = dominant;
 		}
 	}
-	return { kind: 'range', min, max };
+	return range;
 }


### PR DESCRIPTION
## What this covers

Adds **Wing** and **Weight** columns to the single-species bird list (the "Bird list" tab), each summarising a bird's measurements across all its encounters as a min–max range.

Behaviour (per the ticket):
- One measurement, or all measurements equal → a single value.
- No measurements → blank cell.
- **Wing** only: when a dominant value exists (the median, held by a strict majority of records):
  - if it equals the min or max endpoint, that endpoint is **bold** (e.g. **67** - 69);
  - otherwise the range is followed by the bold parenthesised value (e.g. 67 - 70 **(69)**).

This is a UI-only change — the required `wing_length` / `weight` data was already fetched by `fetchPageOfBirds`. The shared `SpTable` powers both the standard and group-scoped species pages, so both get the columns.

## Implementation

- `app/models/measurement-range.ts` — pure `deriveMeasurementRange` producing an `empty` / `single` / `range` (optionally with a `dominant`) descriptor.
- `app/components/MeasurementRangeCell.tsx` — renders that descriptor as JSX (blank / value / range / bold endpoint / bold parenthesised aside).
- `app/components/SpTable.tsx` — new Wing/Weight columns wired to the model and renderer.

## Tests

- Model unit tests (USE algorithm): usual, count structure, null handling, and the wing dominant-value branches (endpoint, aside, no-majority, even-split, disabled).
- `MeasurementRangeCell` render tests for every variant.
- Extended `SpIndividualsTab` integration test asserting the columns render and a real fixture bird shows `74 - 80 (75)` with the dominant value bold.

`npm run qa` passes (lint 0 errors, type-check clean, 479 app tests).

## Assumptions

- Column placement: Wing and Weight are inserted after **Sex**, grouping the measurement columns together and before the date columns.
- "Dominant value" is read as the median value held by a *strict* majority (> 50%) of records; a plurality that is not a majority does not qualify.
- The dominant-value emphasis applies to **wing only** (weight uses a plain range), matching the ticket wording.
- Range cells are not meaningfully sortable (they hold structured values); clicking their headers is a no-op-style sort rather than a crash. Sorting these columns was out of scope for the ticket.

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)