### PR TITLE
fix: correct season preposition in session-total and counts highlights (#378)

### DIFF
--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -316,4 +316,109 @@ describe('SessionHighlights', () => {
 		expect(items.length).toBe(1);
 		expect(items[0].textContent).toBe('Heaviest Blue Tit ever weighed — 13.1g');
 	});
+
+	describe('season preposition', () => {
+		it('renders session-total-record past season with "of"', async () => {
+			const highlight: SessionHighlight = {
+				type: 'session-total-record',
+				metric: 'encounters',
+				scope: 'this-season',
+				value: 74,
+				...periodFields,
+				isCurrentSeason: false
+			};
+			const { fetchSessionHighlights } =
+				await import('@/app/actions/session-highlights');
+			vi.mocked(fetchSessionHighlights).mockResolvedValue([highlight]);
+			render(<SessionHighlights date="2024-09-15" viewedGroupId={1} />);
+			await waitFor(() => {
+				expect(
+					screen.getByRole('heading', { name: 'Highlights' })
+				).toBeDefined();
+			});
+			const items = screen
+				.getByTestId('session-highlights')
+				.querySelectorAll('li');
+			expect(items[0].textContent).toBe(
+				'Busiest session of autumn 2024 — 74 birds'
+			);
+		});
+
+		it('renders combined-session-total-record past season with "of"', async () => {
+			const highlight: SessionHighlight = {
+				type: 'combined-session-total-record',
+				scope: 'this-season',
+				encounterValue: 74,
+				speciesValue: 18,
+				...periodFields,
+				isCurrentSeason: false
+			};
+			const { fetchSessionHighlights } =
+				await import('@/app/actions/session-highlights');
+			vi.mocked(fetchSessionHighlights).mockResolvedValue([highlight]);
+			render(<SessionHighlights date="2024-09-15" viewedGroupId={1} />);
+			await waitFor(() => {
+				expect(
+					screen.getByRole('heading', { name: 'Highlights' })
+				).toBeDefined();
+			});
+			const items = screen
+				.getByTestId('session-highlights')
+				.querySelectorAll('li');
+			expect(items[0].textContent).toBe(
+				'Busiest and most varied session of autumn 2024 — 74 birds from 18 species'
+			);
+		});
+
+		it('renders combined-species-count-record past season with "of"', async () => {
+			const highlight: SessionHighlight = {
+				type: 'combined-species-count-record',
+				scope: 'this-season',
+				speciesNames: ['Blackcap', 'Wren'],
+				...periodFields,
+				isCurrentSeason: false
+			};
+			const { fetchSessionHighlights } =
+				await import('@/app/actions/session-highlights');
+			vi.mocked(fetchSessionHighlights).mockResolvedValue([highlight]);
+			render(<SessionHighlights date="2024-09-15" viewedGroupId={1} />);
+			await waitFor(() => {
+				expect(
+					screen.getByRole('heading', { name: 'Highlights' })
+				).toBeDefined();
+			});
+			const items = screen
+				.getByTestId('session-highlights')
+				.querySelectorAll('li');
+			expect(items[0].textContent).toBe(
+				'Highest Blackcap and Wren counts of autumn 2024'
+			);
+		});
+
+		it('renders species-count-record past season with "in" (unchanged)', async () => {
+			const highlight: SessionHighlight = {
+				type: 'species-count-record',
+				speciesName: 'Reed Warbler',
+				scope: 'this-season',
+				value: 12,
+				...periodFields,
+				isCurrentSeason: false
+			};
+			const { fetchSessionHighlights } =
+				await import('@/app/actions/session-highlights');
+			vi.mocked(fetchSessionHighlights).mockResolvedValue([highlight]);
+			render(<SessionHighlights date="2024-09-15" viewedGroupId={1} />);
+			await waitFor(() => {
+				expect(
+					screen.getByRole('heading', { name: 'Highlights' })
+				).toBeDefined();
+			});
+			const items = screen
+				.getByTestId('session-highlights')
+				.querySelectorAll('li');
+			expect(items[0].textContent).toBe(
+				'Record day for Reed Warbler — 12 caught, the most in autumn 2024'
+			);
+		});
+	});
 });

--- a/app/components/session-highlight-renderers.tsx
+++ b/app/components/session-highlight-renderers.tsx
@@ -42,9 +42,13 @@ type PeriodFields = {
 // Returns null for all-time and any-season, which each family phrases differently.
 // yearPreposition: 'in' for species-count ("the most in 2024"),
 //                  'of' for session-total ("Busiest session of 2024")
+// seasonPreposition: 'in' for species-count ("the most in autumn 2024"),
+//                    'of' for session-total ("Busiest session of autumn 2024")
+//                        and combined-species-count ("Highest Blackcap counts of autumn 2024")
 function buildCurrentPeriodScopePhrase(
 	fields: PeriodFields,
-	yearPreposition: 'in' | 'of' = 'in'
+	yearPreposition: 'in' | 'of' = 'in',
+	seasonPreposition: 'in' | 'of' = 'in'
 ): string | null {
 	switch (fields.scope) {
 		case 'this-year':
@@ -54,7 +58,7 @@ function buildCurrentPeriodScopePhrase(
 		case 'this-season':
 			return fields.isCurrentSeason
 				? `this ${fields.seasonName}`
-				: `in ${fields.seasonPeriodLabel}`;
+				: `${seasonPreposition} ${fields.seasonPeriodLabel}`;
 		default:
 			return null;
 	}
@@ -80,7 +84,11 @@ function buildSessionTotalRecordSentence(
 	if (highlight.recordEqualledYearsAgo !== undefined) {
 		return `${descriptor} session for ${buildYearsAgoCopy(highlight.recordEqualledYearsAgo)} — ${valueCopy}`;
 	}
-	const currentPeriodPhrase = buildCurrentPeriodScopePhrase(highlight, 'of');
+	const currentPeriodPhrase = buildCurrentPeriodScopePhrase(
+		highlight,
+		'of',
+		'of'
+	);
 	if (currentPeriodPhrase !== null) {
 		return `${descriptor} session ${currentPeriodPhrase} — ${valueCopy}`;
 	}
@@ -98,7 +106,11 @@ function buildCombinedSessionTotalRecordSentence(
 	highlight: CombinedSessionTotalRecordHighlight
 ): string {
 	const valueCopy = `${highlight.encounterValue} birds from ${highlight.speciesValue} species`;
-	const currentPeriodPhrase = buildCurrentPeriodScopePhrase(highlight, 'of');
+	const currentPeriodPhrase = buildCurrentPeriodScopePhrase(
+		highlight,
+		'of',
+		'of'
+	);
 	if (currentPeriodPhrase !== null) {
 		return `Busiest and most varied session ${currentPeriodPhrase} — ${valueCopy}`;
 	}
@@ -162,7 +174,7 @@ function buildCombinedSpeciesCountRecordSentence(
 			? buildOfYearPhrase(highlight)
 			: highlight.isCurrentSeason
 				? `this ${highlight.seasonName}`
-				: `in ${highlight.seasonPeriodLabel}`;
+				: `of ${highlight.seasonPeriodLabel}`;
 	return `Highest ${speciesList} counts ${periodPhrase}`;
 }
 

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -529,7 +529,7 @@ describe('render — session-total-record', () => {
 
 	it('renders this-season busiest copy with the season period for a past session', () => {
 		expect(renderedText(makeHighlight({ scope: 'this-season' }))).toBe(
-			'Busiest session in autumn 2024 — 74 birds'
+			'Busiest session of autumn 2024 — 74 birds'
 		);
 	});
 
@@ -542,7 +542,7 @@ describe('render — session-total-record', () => {
 					seasonPeriodLabel: 'winter 2023/24'
 				})
 			)
-		).toBe('Busiest session in winter 2023/24 — 74 birds');
+		).toBe('Busiest session of winter 2023/24 — 74 birds');
 	});
 
 	it('renders most-varied copy for the species metric', () => {
@@ -2050,7 +2050,7 @@ describe('render — combined-species-count-record', () => {
 				isCurrentSeason: false,
 				speciesNames: ['Robin', 'Dunnock']
 			})
-		).toBe('Highest Robin and Dunnock counts in summer 2026');
+		).toBe('Highest Robin and Dunnock counts of summer 2026');
 	});
 });
 


### PR DESCRIPTION
## Summary

- Extends `buildCurrentPeriodScopePhrase` with a `seasonPreposition` parameter (mirroring the existing `yearPreposition`) so each highlight family chooses its own preposition for past-season phrasing
- `session-total-record` and `combined-session-total-record`: past season now reads "of {season}" (e.g. "Busiest session of autumn 2024") instead of "in {season}"
- `combined-species-count-record`: past season now reads "of {season}" (e.g. "Highest Blackcap and Wren counts of autumn 2024") instead of "in {season}"
- `species-count-record`: left unchanged — continues to use "in {season}" (consistent with "in 2024" for past year)

## Test plan

- [ ] New `describe('season preposition')` block in `SessionHighlights.test.tsx` with four integration tests:
  - session-total-record past season → "Busiest session of autumn 2024"
  - combined-session-total-record past season → "Busiest and most varied session of autumn 2024"
  - combined-species-count-record past season → "Highest Blackcap and Wren counts of autumn 2024"
  - species-count-record past season → still "the most in autumn 2024" (regression guard)
- [ ] Updated existing assertions in `app/models/__tests__/session-highlights.test.ts` for the two previously-"in" session-total test cases and one combined-species-count-record test case
- [ ] All 483 tests pass; `npm run qa` clean (warnings are pre-existing)

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)