### PR TITLE
feat(db): add juv_count to stats_per_day_and_species (#384, PR 1/2)

### DIFF
--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -38,6 +38,7 @@ function statsRow(
 		species_name,
 		visit_date,
 		encounter_count,
+		juv_count: 0,
 		weighed_birds_count: 0,
 		min_weight: 0,
 		max_weight: 0
@@ -217,6 +218,7 @@ describe('fetchSessionHighlights', () => {
 					species_name: 'Blue Tit',
 					visit_date: SESSION_DATE,
 					encounter_count: 5,
+					juv_count: 0,
 					weighed_birds_count: 5,
 					min_weight: 11,
 					max_weight: 13.1
@@ -225,6 +227,7 @@ describe('fetchSessionHighlights', () => {
 					species_name: 'Blue Tit',
 					visit_date: '2022-05-01',
 					encounter_count: 4,
+					juv_count: 0,
 					weighed_birds_count: 4,
 					min_weight: 10.5,
 					max_weight: 13.0

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -65,6 +65,7 @@ function dayRows(
 			species_name,
 			visit_date: date,
 			encounter_count,
+			juv_count: 0,
 			weighed_birds_count: 0,
 			min_weight: 0,
 			max_weight: 0
@@ -521,6 +522,7 @@ function speciesRow(
 		visit_date: date,
 		species_name: species,
 		encounter_count: count,
+		juv_count: 0,
 		weighed_birds_count: 0,
 		min_weight: 0,
 		max_weight: 0
@@ -1516,6 +1518,7 @@ function weightRow(
 		visit_date: date,
 		species_name: species,
 		encounter_count: weighedBirds,
+		juv_count: 0,
 		weighed_birds_count: weighedBirds,
 		min_weight: minWeight,
 		max_weight: maxWeight

--- a/supabase/__tests__/rpc-functions.test.ts
+++ b/supabase/__tests__/rpc-functions.test.ts
@@ -663,6 +663,7 @@ describe('Postgres RPC integration tests', () => {
 				species_name: 'Robin',
 				visit_date: '2021-06-20',
 				encounter_count: 1,
+				juv_count: 0,
 				weighed_birds_count: 1,
 				min_weight: 18.5,
 				max_weight: 18.5,
@@ -671,6 +672,7 @@ describe('Postgres RPC integration tests', () => {
 				species_name: 'Wren',
 				visit_date: '2021-06-20',
 				encounter_count: 1,
+				juv_count: 0,
 				weighed_birds_count: 1,
 				min_weight: 9,
 				max_weight: 9,
@@ -690,6 +692,7 @@ describe('Postgres RPC integration tests', () => {
 				species_name: 'Robin',
 				visit_date: '2022-06-15',
 				encounter_count: 6,
+				juv_count: 0,
 				weighed_birds_count: 6,
 				min_weight: 16.5,
 				max_weight: 20.5,
@@ -709,6 +712,7 @@ describe('Postgres RPC integration tests', () => {
 				species_name: 'Chaffinch',
 				visit_date: '2023-06-01',
 				encounter_count: 2,
+				juv_count: 0,
 				weighed_birds_count: 2,
 				min_weight: 18.5,
 				max_weight: 20,
@@ -717,6 +721,7 @@ describe('Postgres RPC integration tests', () => {
 				species_name: 'Robin',
 				visit_date: '2023-06-01',
 				encounter_count: 1,
+				juv_count: 0,
 				weighed_birds_count: 1,
 				min_weight: 18.5,
 				max_weight: 18.5,
@@ -829,6 +834,7 @@ describe('Postgres RPC integration tests', () => {
 					species_name: 'Robin',
 					visit_date: '2098-06-01',
 					encounter_count: 2,
+					juv_count: 0,
 					weighed_birds_count: 1,
 					min_weight: 15,
 					max_weight: 15,
@@ -846,9 +852,108 @@ describe('Postgres RPC integration tests', () => {
 					species_name: 'Robin',
 					visit_date: '2098-06-02',
 					encounter_count: 1,
+					juv_count: 0,
 					weighed_birds_count: 0,
 					min_weight: null,
 					max_weight: null,
+				});
+			});
+		});
+
+		describe('juvenile encounters', () => {
+			// Seed encounters carry no juveniles, so insert Delta-group encounters
+			// (three juvenile + two adult Robins on one day) and clean up after.
+			let deltaId: number;
+			let deltaClient: SupabaseClient;
+			let locationId: number;
+			let sessionId: number;
+			let birdIds: number[];
+
+			beforeAll(async () => {
+				deltaId = await getGroupIdByName('Delta');
+				deltaClient = await getAuthenticatedSupabaseClientForGroup(deltaId);
+
+				const { data: species } = await supabase
+					.from('Species')
+					.select('id')
+					.eq('species_name', 'Robin')
+					.single();
+
+				const { data: location, error: locationError } = await deltaClient
+					.from('Locations')
+					.insert({
+						location_name: 'Juv Stats Test Location',
+						ringing_group_id: deltaId,
+					})
+					.select('id')
+					.single();
+				if (locationError) throw locationError;
+				locationId = location!.id;
+
+				const { data: session, error: sessionError } = await deltaClient
+					.from('Sessions')
+					.insert({ visit_date: '2099-06-01', location_id: locationId })
+					.select('id')
+					.single();
+				if (sessionError) throw sessionError;
+				sessionId = session!.id;
+
+				const birds = await Promise.all(
+					['JUVTEST1', 'JUVTEST2', 'JUVTEST3', 'JUVTEST4', 'JUVTEST5'].map(
+						(ringNo) =>
+							deltaClient
+								.from('Birds')
+								.insert({ ring_no: ringNo, species_id: species!.id })
+								.select('id')
+								.single()
+					)
+				);
+				birds.forEach(({ error }) => {
+					if (error) throw error;
+				});
+				birdIds = birds.map(({ data }) => data!.id);
+
+				const baseEncounter = {
+					capture_time: '10:00:00',
+					scheme: 'BTO',
+					sex: 'M',
+					age_code: 1,
+					record_type: 'N',
+					session_id: sessionId,
+				};
+				const { error: encountersError } = await deltaClient
+					.from('Encounters')
+					.insert([
+						{ ...baseEncounter, bird_id: birdIds[0], is_juv: true },
+						{ ...baseEncounter, bird_id: birdIds[1], is_juv: true },
+						{ ...baseEncounter, bird_id: birdIds[2], is_juv: true },
+						{ ...baseEncounter, bird_id: birdIds[3], is_juv: false },
+						{ ...baseEncounter, bird_id: birdIds[4], is_juv: false },
+					]);
+				if (encountersError) throw encountersError;
+			});
+
+			afterAll(() => {
+				execSync(
+					`psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -c '` +
+						`DELETE FROM "Encounters" WHERE bird_id IN (${birdIds.join(', ')});` +
+						`DELETE FROM "Birds" WHERE id IN (${birdIds.join(', ')});` +
+						`DELETE FROM "Sessions" WHERE id = ${sessionId};` +
+						`DELETE FROM "Locations" WHERE id = ${locationId};'`
+				);
+			});
+
+			it('counts only juvenile encounters in juv_count, all encounters in encounter_count', async () => {
+				const { data, error } = await deltaClient.rpc('stats_per_day_and_species', {
+					ringing_group_filter: deltaId,
+				});
+				expect(error).toBeNull();
+				const row = data!.find((row) => row.visit_date === '2099-06-01');
+				expect(row).toMatchObject({
+					species_name: 'Robin',
+					visit_date: '2099-06-01',
+					encounter_count: 5,
+					juv_count: 3,
 				});
 			});
 		});

--- a/supabase/schema/schemas/public/functions/stats_per_day_and_species.sql
+++ b/supabase/schema/schemas/public/functions/stats_per_day_and_species.sql
@@ -2,6 +2,7 @@ CREATE FUNCTION public.stats_per_day_and_species (ringing_group_filter bigint) R
 	species_name text,
 	visit_date date,
 	encounter_count bigint,
+	juv_count bigint,
 	weighed_birds_count bigint,
 	min_weight numeric,
 	max_weight numeric
@@ -15,6 +16,7 @@ BEGIN
     sp.species_name AS species_name,
     sess.visit_date AS visit_date,
     COUNT(e.*) AS encounter_count,
+    COUNT(e.*) FILTER (WHERE e.is_juv) AS juv_count,
     COUNT(e.*) FILTER (WHERE e.weight IS NOT NULL) AS weighed_birds_count,
     MIN(e.weight::numeric) AS min_weight,
     MAX(e.weight::numeric) AS max_weight

--- a/types/supabase.types.ts
+++ b/types/supabase.types.ts
@@ -422,6 +422,7 @@ export type Database = {
         Args: { ringing_group_filter: number }
         Returns: {
           encounter_count: number
+          juv_count: number
           max_weight: number
           min_weight: number
           species_name: string


### PR DESCRIPTION
## What this covers

PR 1 of 2 for the new **"Most juvs"** session highlights ([#384](https://github.com/wheresrhys/totf/issues/384)).

This is the DB-layer groundwork: it adds a per-day-per-species juvenile encounter count to the `stats_per_day_and_species` RPC so the highlight-derivation layer (PR 2) has juvenile totals to work with.

- Add `juv_count bigint` to `stats_per_day_and_species` — `COUNT(*) FILTER (WHERE e.is_juv)`.
- Regenerate `types/supabase.types.ts`.
- Generated migration `20260719102919_feature_384_most_juvs_highlights_1_db.sql` (return-type change ⇒ drop + recreate, expected).
- Extend the RPC integration tests: add `juv_count` to the existing exact-row assertions and add a dedicated "juvenile encounters" case (3 juv + 2 adult ⇒ `juv_count: 3`, `encounter_count: 5`).
- Default `juv_count: 0` in the app-test stats-row builders so the whole repo still type-checks; the highlight logic that consumes it lands in PR 2.

## Testing

- `npm run qa` — pass (467 app tests; only pre-existing lint warnings).
- `npm run test:integration -- rpc-functions` — pass (50 tests).

## Notes / assumptions

- "Juvenile" = `Encounters.is_juv` (set by the importer when the age code ends in `J`). No new column needed.
- Does not close #384 — the highlights themselves ship in PR 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)