### PR TITLE
feat: "Most juvs" session highlights (#384, PR 2/2)

### DIFF
--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -8,8 +8,10 @@ import {
 	deriveLongAbsenceRetraps,
 	deriveRareSpecies,
 	deriveSessionTotalRecords,
+	deriveSessionTotalJuvRecords,
 	deriveSinceHighlights,
 	deriveSpeciesRecords,
+	deriveSpeciesJuvRecords,
 	deriveWeightRecordBreakers,
 	type SessionHighlight,
 	type SessionStatsData
@@ -107,8 +109,10 @@ export async function fetchSessionHighlights({
 	]);
 	const highlightPool = [
 		...deriveSessionTotalRecords({ date, stats }),
+		...deriveSessionTotalJuvRecords({ date, stats }),
 		...deriveSinceHighlights({ date, stats }),
 		...deriveSpeciesRecords({ date, stats }),
+		...deriveSpeciesJuvRecords({ date, stats }),
 		...deriveFirstEverSpecies({ date, stats }),
 		...deriveFirstOfYearSpecies({ date, stats }),
 		...deriveRareSpecies({ date, stats }),

--- a/app/components/session-highlight-renderers.tsx
+++ b/app/components/session-highlight-renderers.tsx
@@ -15,9 +15,11 @@ import type {
 	SessionHighlight,
 	SessionTotalMetric,
 	SessionTotalRecordHighlight,
+	SessionTotalJuvRecordHighlight,
 	SinceComparisonHighlight,
 	SinceComparisonKind,
 	SpeciesCountRecordHighlight,
+	SpeciesJuvCountRecordHighlight,
 	WeightRecordExtreme,
 	WeightRecordHighlight
 } from '@/app/models/session-highlights';
@@ -75,6 +77,23 @@ function buildSessionTotalRecordSentence(
 	}
 	// Remaining case: all-time (this-year handled above)
 	return `${descriptor} session ever — ${valueCopy}`;
+}
+
+// "Most juveniles ever — N juvs" / "Most juveniles this year — N juvs" /
+// "Most juveniles for N years — N juvs". The session-total juvenile counterpart
+// to buildSessionTotalRecordSentence, phrasing the scope the same way.
+function buildSessionTotalJuvRecordSentence(
+	highlight: SessionTotalJuvRecordHighlight
+): string {
+	const valueCopy = `${highlight.value} juvs`;
+	if (highlight.recordEqualledYearsAgo !== undefined) {
+		return `Most juveniles for ${buildYearsAgoCopy(highlight.recordEqualledYearsAgo)} — ${valueCopy}`;
+	}
+	const currentPeriodPhrase = buildCurrentPeriodScopePhrase(highlight, 'of');
+	if (currentPeriodPhrase !== null) {
+		return `Most juveniles ${currentPeriodPhrase} — ${valueCopy}`;
+	}
+	return `Most juveniles ever — ${valueCopy}`;
 }
 
 // "Busiest and most varied session <period> — N birds from M species".
@@ -170,6 +189,39 @@ function buildSpeciesCountRecordSentence(
 			? `the most ${currentPeriodPhrase}`
 			: 'the most ever';
 	return `Record day for ${speciesName} — ${valueCopy}, ${mostPhrase}`;
+}
+
+// The per-species juvenile counterpart to buildSpeciesCountRecordSentence,
+// sharing its record / for-N-years tie / 1st-2nd-3rd placement shape but
+// phrased around juveniles: "Most juvenile Robins ever — N caught",
+// "Second best day for juvenile Robins ever — N caught".
+function buildSpeciesJuvCountRecordSentence(
+	highlight: SpeciesJuvCountRecordHighlight
+): string {
+	const { speciesName, value } = highlight;
+	const valueCopy = `${value} caught`;
+	const juvSpeciesPhrase = `juvenile ${speciesName}`;
+	if (highlight.recordEqualledYearsAgo !== undefined) {
+		return `Record-equalling day for ${juvSpeciesPhrase} — ${valueCopy}, most for ${buildYearsAgoCopy(highlight.recordEqualledYearsAgo)}`;
+	}
+	if (highlight.placementRank !== undefined) {
+		const rankCopy = { 1: 'best', 2: 'second best', 3: 'third best' }[
+			highlight.placementRank
+		];
+		const jointPrefix = highlight.isJointPlacement ? 'Joint ' : '';
+		// Non-joint placements open the sentence, so capitalise the ordinal;
+		// with a "Joint " prefix the ordinal stays mid-sentence and lowercase.
+		const placementCopy = jointPrefix
+			? rankCopy
+			: rankCopy.charAt(0).toUpperCase() + rankCopy.slice(1);
+		return `${jointPrefix}${placementCopy} day for ${juvSpeciesPhrase} ever — ${value} birds`;
+	}
+	const currentPeriodPhrase = buildCurrentPeriodScopePhrase(highlight);
+	const mostPhrase =
+		currentPeriodPhrase !== null
+			? `the most ${currentPeriodPhrase}`
+			: 'the most ever';
+	return `Most ${juvSpeciesPhrase} — ${valueCopy}, ${mostPhrase}`;
 }
 
 function buildSpeciesRecordsPhrase(
@@ -286,10 +338,14 @@ const HIGHLIGHT_RENDERERS: {
 } = {
 	'session-total-record': (highlight) =>
 		renderSentence(buildSessionTotalRecordSentence(highlight)),
+	'session-total-juv-record': (highlight) =>
+		renderSentence(buildSessionTotalJuvRecordSentence(highlight)),
 	'since-comparison': (highlight) =>
 		renderSentence(buildSinceComparisonSentence(highlight)),
 	'species-count-record': (highlight) =>
 		renderSentence(buildSpeciesCountRecordSentence(highlight)),
+	'species-juv-count-record': (highlight) =>
+		renderSentence(buildSpeciesJuvCountRecordSentence(highlight)),
 	'first-ever-species': (highlight) =>
 		renderSentence(buildFirstEverSpeciesSentence(highlight)),
 	'first-of-year-species': (highlight) =>

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -5,10 +5,13 @@ import {
 	deriveFirstOfYearSpecies,
 	deriveRareSpecies,
 	deriveSessionTotalRecords,
+	deriveSessionTotalJuvRecords,
 	deriveSinceHighlights,
 	deriveSpeciesRecords,
+	deriveSpeciesJuvRecords,
 	deriveWeightRecordBreakers,
 	scopedSortValue,
+	juvSortValue,
 	familySortValue,
 	type FirstEverSpeciesHighlight,
 	type FirstOfYearSpeciesHighlight,
@@ -16,8 +19,10 @@ import {
 	type RareSpeciesHighlight,
 	type SessionHighlight,
 	type SessionTotalRecordHighlight,
+	type SessionTotalJuvRecordHighlight,
 	type SinceComparisonHighlight,
 	type SpeciesCountRecordHighlight,
+	type SpeciesJuvCountRecordHighlight,
 	type WeightRecordHighlight,
 	type SessionStatsData
 } from '../session-highlights';
@@ -972,6 +977,351 @@ describe('render — species-count-record', () => {
 				})
 			)
 		).toBe('Joint second best day for Reed Warbler ever — 8 birds');
+	});
+});
+
+// ---- juvenile highlights ----
+
+// A per-day-per-species row carrying a juvenile count (and a matching encounter
+// count, always >= the juv count so the data is internally consistent).
+function juvRow(
+	date: string,
+	species: string,
+	juvCount: number,
+	encounterCount = juvCount
+): StatsPerDayAndSpeciesResult {
+	return {
+		visit_date: date,
+		species_name: species,
+		encounter_count: encounterCount,
+		juv_count: juvCount,
+		weighed_birds_count: 0,
+		min_weight: 0,
+		max_weight: 0
+	};
+}
+
+function deriveTotalJuvs(
+	results: StatsPerDayAndSpeciesResult[],
+	today = PAST_PERIOD_TODAY
+) {
+	return deriveSessionTotalJuvRecords({
+		date: SESSION_DATE,
+		stats: statsForSpecies(results),
+		today
+	});
+}
+
+function deriveSpeciesJuvs(
+	results: StatsPerDayAndSpeciesResult[],
+	today = PAST_PERIOD_TODAY
+) {
+	return deriveSpeciesJuvRecords({
+		date: SESSION_DATE,
+		stats: statsForSpecies(results),
+		today
+	});
+}
+
+describe('deriveSessionTotalJuvRecords', () => {
+	it('reports a most-juveniles record when the session juv total beats every day in scope', () => {
+		const highlights = deriveTotalJuvs([
+			juvRow(SESSION_DATE, ROBIN, 12),
+			juvRow(SESSION_DATE, REED_WARBLER, 8),
+			juvRow(PRIOR_SUMMER_OTHER_YEAR, ROBIN, 5)
+		]);
+		expect(highlights).toContainEqual({
+			type: 'session-total-juv-record',
+			sortValue: juvSortValue('juv-session-total', 'all-time'),
+			scope: 'all-time',
+			value: 20,
+			year: 2024,
+			isCurrentYear: false
+		});
+	});
+
+	it('sums juveniles across species for the session total', () => {
+		const highlights = deriveTotalJuvs([
+			juvRow(SESSION_DATE, ROBIN, 3),
+			juvRow(SESSION_DATE, REED_WARBLER, 4),
+			juvRow(PRIOR_SUMMER_OTHER_YEAR, ROBIN, 6)
+		]);
+		// 3 + 4 = 7 beats the prior day's 6
+		expect(highlights).toContainEqual(
+			expect.objectContaining({ scope: 'all-time', value: 7 })
+		);
+	});
+
+	it('returns nothing when the session has no juveniles', () => {
+		const highlights = deriveTotalJuvs([
+			juvRow(SESSION_DATE, ROBIN, 0, 40),
+			juvRow(PRIOR_SUMMER_OTHER_YEAR, ROBIN, 0, 5)
+		]);
+		expect(highlights).toHaveLength(0);
+	});
+
+	it('reports only the broadest scope when the session is a record in every scope', () => {
+		const highlights = deriveTotalJuvs([
+			juvRow(SESSION_DATE, ROBIN, 20),
+			juvRow(PRIOR_SUMMER_OTHER_YEAR, ROBIN, 10),
+			juvRow(PRIOR_SUMMER_THIS_YEAR, ROBIN, 8)
+		]);
+		expect(highlights).toHaveLength(1);
+		expect(highlights[0].scope).toBe('all-time');
+	});
+
+	it('reports this-year when the all-time record is beaten but this year is not', () => {
+		const highlights = deriveTotalJuvs([
+			juvRow(SESSION_DATE, ROBIN, 20),
+			juvRow(PRIOR_SUMMER_OTHER_YEAR, ROBIN, 30), // beats all-time
+			juvRow(PRIOR_SUMMER_THIS_YEAR, ROBIN, 10) // this year, lower
+		]);
+		expect(highlights).toHaveLength(1);
+		expect(highlights[0].scope).toBe('this-year');
+	});
+
+	it('reports an all-time tie older than a year as a for-N-years record', () => {
+		const highlights = deriveTotalJuvs([
+			juvRow(SESSION_DATE, ROBIN, 12),
+			juvRow(PRIOR_AUTUMN_OTHER_YEAR, ROBIN, 12) // 2021 — 3 years ago
+		]);
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				scope: 'all-time',
+				value: 12,
+				recordEqualledYearsAgo: 3
+			})
+		);
+	});
+
+	it('treats a tie held only by a later day as unreportable', () => {
+		const highlights = deriveTotalJuvs([
+			juvRow(SESSION_DATE, ROBIN, 12),
+			juvRow(LATER_DAY, ROBIN, 12)
+		]);
+		expect(highlights).toHaveLength(0);
+	});
+
+	it('sets the current-year flag from the injected today', () => {
+		const highlights = deriveTotalJuvs(
+			[
+				juvRow(SESSION_DATE, ROBIN, 12),
+				juvRow(PRIOR_SUMMER_OTHER_YEAR, ROBIN, 5)
+			],
+			new Date('2024-10-20')
+		);
+		expect(highlights[0].isCurrentYear).toBe(true);
+	});
+});
+
+describe('deriveSpeciesJuvRecords', () => {
+	it('reports the broadest scope achieved per species', () => {
+		const highlights = deriveSpeciesJuvs([
+			juvRow(SESSION_DATE, REED_WARBLER, 10),
+			juvRow(PRIOR_SUMMER_OTHER_YEAR, REED_WARBLER, 5)
+		]);
+		expect(highlights).toHaveLength(1);
+		expect(highlights[0]).toMatchObject({
+			type: 'species-juv-count-record',
+			speciesName: REED_WARBLER,
+			scope: 'all-time',
+			value: 10
+		});
+	});
+
+	it('only produces a highlight when the juv count is greater than 4', () => {
+		// A session juv count of exactly 4 is below the threshold
+		const atThreshold = deriveSpeciesJuvs([
+			juvRow(SESSION_DATE, REED_WARBLER, 4),
+			juvRow(PRIOR_SUMMER_OTHER_YEAR, REED_WARBLER, 2)
+		]);
+		expect(atThreshold).toHaveLength(0);
+		// 5 clears it
+		const aboveThreshold = deriveSpeciesJuvs([
+			juvRow(SESSION_DATE, REED_WARBLER, 5),
+			juvRow(PRIOR_SUMMER_OTHER_YEAR, REED_WARBLER, 2)
+		]);
+		expect(aboveThreshold).toHaveLength(1);
+	});
+
+	it('requires the species to appear on another day in scope', () => {
+		const highlights = deriveSpeciesJuvs([
+			juvRow(SESSION_DATE, REED_WARBLER, 10),
+			juvRow(PRIOR_SUMMER_OTHER_YEAR, ROBIN, 8)
+		]);
+		expect(highlights.map((h) => h.speciesName)).not.toContain(REED_WARBLER);
+	});
+
+	it('demotes the session to a placement when a later day has a higher juv count', () => {
+		const highlights = deriveSpeciesJuvs([
+			juvRow(SESSION_DATE, REED_WARBLER, 10),
+			juvRow(PRIOR_SUMMER_OTHER_YEAR, REED_WARBLER, 5),
+			juvRow(LATER_DAY, REED_WARBLER, 100)
+		]);
+		expect(highlights).toHaveLength(1);
+		expect(highlights[0]).toMatchObject({
+			speciesName: REED_WARBLER,
+			scope: 'all-time',
+			value: 10,
+			placementRank: 2,
+			isJointPlacement: false
+		});
+	});
+
+	it('reports an all-time tie older than a year as a for-N-years record', () => {
+		const highlights = deriveSpeciesJuvs([
+			juvRow(SESSION_DATE, REED_WARBLER, 10),
+			juvRow(PRIOR_AUTUMN_OTHER_YEAR, REED_WARBLER, 10) // 3 years ago
+		]);
+		expect(highlights).toContainEqual(
+			expect.objectContaining({
+				speciesName: REED_WARBLER,
+				scope: 'all-time',
+				value: 10,
+				recordEqualledYearsAgo: 3
+			})
+		);
+	});
+
+	it('reports an all-time tie under a year old as a joint best day', () => {
+		const highlights = deriveSpeciesJuvs([
+			juvRow(SESSION_DATE, REED_WARBLER, 10),
+			juvRow(PRIOR_SUMMER_THIS_YEAR, REED_WARBLER, 10) // < 1 year
+		]);
+		expect(highlights).toHaveLength(1);
+		expect(highlights[0]).toMatchObject({
+			placementRank: 1,
+			isJointPlacement: true
+		});
+	});
+
+	it('reports multiple species juv records from one session', () => {
+		const highlights = deriveSpeciesJuvs([
+			juvRow(SESSION_DATE, REED_WARBLER, 10),
+			juvRow(SESSION_DATE, ROBIN, 8),
+			juvRow(PRIOR_SUMMER_OTHER_YEAR, REED_WARBLER, 5),
+			juvRow(PRIOR_SUMMER_OTHER_YEAR, ROBIN, 3)
+		]);
+		const speciesNames = highlights.map((h) => h.speciesName);
+		expect(speciesNames).toContain(REED_WARBLER);
+		expect(speciesNames).toContain(ROBIN);
+	});
+});
+
+// ---- render — session-total-juv-record ----
+
+function makeTotalJuvHighlight(
+	overrides: Partial<HighlightFields<SessionTotalJuvRecordHighlight>>
+): SessionTotalJuvRecordHighlight {
+	const fields = {
+		scope: 'all-time' as const,
+		value: 20,
+		year: 2024,
+		isCurrentYear: false,
+		...overrides
+	};
+	return {
+		type: 'session-total-juv-record',
+		sortValue: juvSortValue('juv-session-total', fields.scope),
+		...fields
+	};
+}
+
+describe('render — session-total-juv-record', () => {
+	it('renders all-time copy', () => {
+		expect(renderedText(makeTotalJuvHighlight({}))).toBe(
+			'Most juveniles ever — 20 juvs'
+		);
+	});
+
+	it('renders current-year this-year copy', () => {
+		expect(
+			renderedText(
+				makeTotalJuvHighlight({ scope: 'this-year', isCurrentYear: true })
+			)
+		).toBe('Most juveniles this year — 20 juvs');
+	});
+
+	it('renders past-year this-year copy with the year', () => {
+		expect(renderedText(makeTotalJuvHighlight({ scope: 'this-year' }))).toBe(
+			'Most juveniles of 2024 — 20 juvs'
+		);
+	});
+
+	it('renders for-N-years copy for an all-time tie', () => {
+		expect(
+			renderedText(makeTotalJuvHighlight({ recordEqualledYearsAgo: 3 }))
+		).toBe('Most juveniles for 3 years — 20 juvs');
+	});
+});
+
+// ---- render — species-juv-count-record ----
+
+function makeSpeciesJuvHighlight(
+	overrides: Partial<HighlightFields<SpeciesJuvCountRecordHighlight>>
+): SpeciesJuvCountRecordHighlight {
+	const fields = {
+		speciesName: 'Reed Warbler',
+		scope: 'all-time' as const,
+		value: 12,
+		year: 2024,
+		isCurrentYear: false,
+		...overrides
+	};
+	return {
+		type: 'species-juv-count-record',
+		sortValue: juvSortValue('juv-species-count', fields.scope),
+		...fields
+	};
+}
+
+describe('render — species-juv-count-record', () => {
+	it('renders all-time copy', () => {
+		expect(renderedText(makeSpeciesJuvHighlight({}))).toBe(
+			'Most juvenile Reed Warbler — 12 caught, the most ever'
+		);
+	});
+
+	it('renders current-year this-year copy', () => {
+		expect(
+			renderedText(
+				makeSpeciesJuvHighlight({ scope: 'this-year', isCurrentYear: true })
+			)
+		).toBe('Most juvenile Reed Warbler — 12 caught, the most this year');
+	});
+
+	it('renders past-year this-year copy with the year', () => {
+		expect(renderedText(makeSpeciesJuvHighlight({ scope: 'this-year' }))).toBe(
+			'Most juvenile Reed Warbler — 12 caught, the most in 2024'
+		);
+	});
+
+	it('renders record-equalling for-N-years copy', () => {
+		expect(
+			renderedText(makeSpeciesJuvHighlight({ recordEqualledYearsAgo: 2 }))
+		).toBe(
+			'Record-equalling day for juvenile Reed Warbler — 12 caught, most for 2 years'
+		);
+	});
+
+	it('renders second-best placement copy', () => {
+		expect(
+			renderedText(
+				makeSpeciesJuvHighlight({
+					placementRank: 2,
+					isJointPlacement: false,
+					value: 8
+				})
+			)
+		).toBe('Second best day for juvenile Reed Warbler ever — 8 birds');
+	});
+
+	it('renders joint best placement copy', () => {
+		expect(
+			renderedText(
+				makeSpeciesJuvHighlight({ placementRank: 1, isJointPlacement: true })
+			)
+		).toBe('Joint best day for juvenile Reed Warbler ever — 12 birds');
 	});
 });
 

--- a/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
+++ b/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
@@ -13,6 +13,7 @@ import {
 import {
 	combinedSortValue,
 	familySortValue,
+	juvSortValue,
 	scopedSortValue,
 	type FirstEverSpeciesHighlight,
 	type FirstOfYearSpeciesHighlight,
@@ -24,6 +25,7 @@ import {
 	type SessionTotalRecordHighlight,
 	type SinceComparisonHighlight,
 	type SpeciesCountRecordHighlight,
+	type SpeciesJuvCountRecordHighlight,
 	type WeightRecordHighlight
 } from '@/app/models/session-highlights';
 
@@ -56,6 +58,23 @@ function speciesCountRecord(
 	return {
 		type: 'species-count-record',
 		sortValue: scopedSortValue(scope, 1),
+		speciesName,
+		scope,
+		value,
+		...periodFields,
+		...extra
+	};
+}
+
+function speciesJuvCountRecord(
+	speciesName: string,
+	scope: RecordScope,
+	value: number,
+	extra: Partial<SpeciesJuvCountRecordHighlight> = {}
+): SpeciesJuvCountRecordHighlight {
+	return {
+		type: 'species-juv-count-record',
+		sortValue: juvSortValue('juv-species-count', scope),
 		speciesName,
 		scope,
 		value,
@@ -218,6 +237,27 @@ describe('removeNarrowerScopeSpeciesRecords (Rem-2)', () => {
 			allTime
 		]);
 		expect(removed).toEqual([allTime]);
+	});
+
+	it('drops a this-year juv record when the species holds an all-time juv record', () => {
+		const allTime = speciesJuvCountRecord('Reed Warbler', 'all-time', 12);
+		const removed = removeNarrowerScopeSpeciesRecords([
+			allTime,
+			speciesJuvCountRecord('Reed Warbler', 'this-year', 12)
+		]);
+		expect(removed).toEqual([allTime]);
+	});
+
+	it('keeps an encounter record and a juv record for the same species', () => {
+		// The two families are deduped independently — a species can hold one of
+		// each, so neither collapses the other
+		const encounterRecord = speciesCountRecord('Reed Warbler', 'all-time', 30);
+		const juvRecord = speciesJuvCountRecord('Reed Warbler', 'all-time', 12);
+		const removed = removeNarrowerScopeSpeciesRecords([
+			encounterRecord,
+			juvRecord
+		]);
+		expect(removed).toEqual([encounterRecord, juvRecord]);
 	});
 
 	it('is a noop on non-species-record highlights', () => {

--- a/app/models/highlight-refinement-machine/remove-narrower-scope-species-records.ts
+++ b/app/models/highlight-refinement-machine/remove-narrower-scope-species-records.ts
@@ -3,26 +3,48 @@ import {
 	type SessionHighlight
 } from '@/app/models/session-highlights';
 
+// The per-species record families this rule dedups by scope. Each is keyed
+// independently, so a species holding both an encounter record and a juvenile
+// record keeps the broadest of each — they aren't collapsed into one another.
+const SCOPED_SPECIES_RECORD_TYPES = [
+	'species-count-record',
+	'species-juv-count-record'
+] as const;
+type ScopedSpeciesRecordType = (typeof SCOPED_SPECIES_RECORD_TYPES)[number];
+
+function isScopedSpeciesRecord(
+	highlight: SessionHighlight
+): highlight is Extract<SessionHighlight, { type: ScopedSpeciesRecordType }> {
+	return (SCOPED_SPECIES_RECORD_TYPES as readonly string[]).includes(
+		highlight.type
+	);
+}
+
 // Rem-2: when one species holds records at more than one scope, keep only the
 // broadest — a narrower-scope record is subsumed by the broader one (e.g. drop
 // "the most this year" when the same species holds a 2nd-best-ever placement).
+// Applied per record family (encounter counts, juvenile counts): a species can
+// still hold one of each.
 export function removeNarrowerScopeSpeciesRecords(
 	highlights: SessionHighlight[]
 ): SessionHighlight[] {
-	const broadestScopeRankBySpecies = new Map<string, number>();
+	// Keyed by "<type>|<species>" so each family is deduped independently
+	const broadestScopeRankByKey = new Map<string, number>();
+	const keyFor = (
+		highlight: Extract<SessionHighlight, { type: ScopedSpeciesRecordType }>
+	) => `${highlight.type}|${highlight.speciesName}`;
 	for (const highlight of highlights) {
-		if (highlight.type !== 'species-count-record') continue;
+		if (!isScopedSpeciesRecord(highlight)) continue;
 		const rank = SCOPE_BREADTH_RANK.get(highlight.scope)!;
-		const currentBroadest = broadestScopeRankBySpecies.get(
-			highlight.speciesName
-		);
+		const key = keyFor(highlight);
+		const currentBroadest = broadestScopeRankByKey.get(key);
 		if (currentBroadest === undefined || rank < currentBroadest) {
-			broadestScopeRankBySpecies.set(highlight.speciesName, rank);
+			broadestScopeRankByKey.set(key, rank);
 		}
 	}
 	return highlights.filter((highlight) => {
-		if (highlight.type !== 'species-count-record') return true;
-		const broadestRank = broadestScopeRankBySpecies.get(highlight.speciesName)!;
+		if (!isScopedSpeciesRecord(highlight)) return true;
+		const broadestRank = broadestScopeRankByKey.get(keyFor(highlight))!;
 		return SCOPE_BREADTH_RANK.get(highlight.scope)! === broadestRank;
 	});
 }

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -35,13 +35,19 @@ export const SCOPE_BREADTH_RANK = new Map(
 // Families in editorial priority order, highest first. An "only ever" record
 // (the species' sole record in the data) heads the list, then plain first-ever,
 // rare-species and long-absence-retrap — all promoted above scoped records —
-// then the scoped records themselves, then the trailing context families.
+// then the scoped records themselves, then the juvenile-count records, then the
+// trailing context families. Juvenile records sit just below the general
+// scoped records: they're the same kind of "record" line but a more niche
+// measure, so they follow rather than interleave with the encounter/species
+// records.
 export const HIGHLIGHT_FAMILIES = [
 	'only-ever-species',
 	'first-ever-species',
 	'rare-species',
 	'long-absence-retrap',
 	'scoped-record',
+	'juv-session-total',
+	'juv-species-count',
 	'since-comparison',
 	'first-of-year-species',
 	'weight-record'
@@ -93,6 +99,17 @@ export function scopedSortValue(
 	};
 }
 
+// Juvenile-count records live in their own families ('juv-session-total' and
+// 'juv-species-count'), each with two scopes. Within a juv family, order by
+// temporal breadth alone — all-time (2) above this-year (1) — since every
+// member shares the family's single conceptual measure.
+export function juvSortValue(
+	family: 'juv-session-total' | 'juv-species-count',
+	scope: RecordScope
+): SortValue {
+	return { family, orderWithinFamily: temporalPoints(scope) };
+}
+
 // Combining bumps the merged line above the parts it absorbed, by a step that
 // grows with how many highlights were merged — a session with many merged
 // records ranks its combined line higher. Every part of a combine shares a
@@ -136,6 +153,45 @@ export type SessionTotalRecordHighlight = {
 
 export type SpeciesCountRecordHighlight = {
 	type: 'species-count-record';
+	sortValue: SortValue;
+	speciesName: string;
+	scope: RecordScope;
+	value: number;
+	year: number;
+	// 'this year' copy is only correct while the session's year is still current;
+	// otherwise the sentence uses the absolute year
+	isCurrentYear: boolean;
+	// Set only for all-time ties where the equalled record is over a year old
+	recordEqualledYearsAgo?: number;
+	// Set only for all-time placements: 1 for a tie with the current record
+	// under a year old, 2/3 for days ranking behind the record
+	placementRank?: 1 | 2 | 3;
+	// True when a prior day matches the session's count exactly
+	isJointPlacement?: boolean;
+};
+
+// The session's total juvenile count across all species, ranked against every
+// other day in scope — the juvenile counterpart to a session-total record.
+// Strict record or (all-time only) a tie that has stood for a year or more.
+export type SessionTotalJuvRecordHighlight = {
+	type: 'session-total-juv-record';
+	sortValue: SortValue;
+	scope: RecordScope;
+	value: number;
+	year: number;
+	// 'this year' copy is only correct while the session's year is still current;
+	// otherwise the sentence uses the absolute year
+	isCurrentYear: boolean;
+	// Set only for all-time ties where the equalled record is over a year old
+	recordEqualledYearsAgo?: number;
+};
+
+// The most juveniles of one species this session, ranked against every other
+// day in scope — the juvenile counterpart to a species-count record, sharing
+// the same 1st/2nd/3rd placement logic. Only produced when the session's juv
+// count for the species exceeds MIN_NOTABLE_JUV_COUNT.
+export type SpeciesJuvCountRecordHighlight = {
+	type: 'species-juv-count-record';
 	sortValue: SortValue;
 	speciesName: string;
 	scope: RecordScope;
@@ -316,8 +372,10 @@ export type CombinedSpeciesCountRecordHighlight = {
 // side (app/components/session-highlight-renderers.tsx).
 export type SessionHighlight =
 	| SessionTotalRecordHighlight
+	| SessionTotalJuvRecordHighlight
 	| SinceComparisonHighlight
 	| SpeciesCountRecordHighlight
+	| SpeciesJuvCountRecordHighlight
 	| FirstEverSpeciesHighlight
 	| FirstOfYearSpeciesHighlight
 	| RareSpeciesHighlight
@@ -333,6 +391,7 @@ type DayTotals = {
 	date: string;
 	encounters: number;
 	species: number;
+	juvs: number;
 };
 
 // Highlights compare the session against every other session in scope,
@@ -343,16 +402,18 @@ export function buildDayTotals({
 }: SessionStatsData): DayTotals[] {
 	const totalsByDate = new Map<string, DayTotals>();
 	for (const date of sessionDates) {
-		totalsByDate.set(date, { date, encounters: 0, species: 0 });
+		totalsByDate.set(date, { date, encounters: 0, species: 0, juvs: 0 });
 	}
 	for (const row of daySpeciesStats) {
 		const dayTotals = totalsByDate.get(row.visit_date) ?? {
 			date: row.visit_date,
 			encounters: 0,
-			species: 0
+			species: 0,
+			juvs: 0
 		};
 		dayTotals.encounters += row.encounter_count;
 		dayTotals.species += 1;
+		dayTotals.juvs += row.juv_count;
 		totalsByDate.set(row.visit_date, dayTotals);
 	}
 	return [...totalsByDate.values()];
@@ -435,6 +496,74 @@ export function deriveSessionTotalRecords({
 			// beaten or unreportable tie at this scope — a narrower scope may
 			// exclude the offending day and still hold a strict record
 		}
+	}
+	return highlights;
+}
+
+// The session's total juvenile count, ranked against every other day in scope.
+// Mirrors deriveSessionTotalRecords for the single 'juvs' measure: a strict
+// record at the broadest scope it holds, or an all-time tie that has stood a
+// year or more. A session with no juveniles is never a record (a "most juvs
+// ever — 0" line is meaningless), so a zero total is skipped.
+export function deriveSessionTotalJuvRecords({
+	date,
+	stats,
+	today = new Date()
+}: {
+	date: string;
+	stats: SessionStatsData;
+	today?: Date;
+}): SessionTotalJuvRecordHighlight[] {
+	const sessionDate = new Date(date);
+	const dayTotals = buildDayTotals(stats);
+	const currentDay = dayTotals.find((day) => day.date === date);
+	if (!currentDay) return [];
+	const sessionValue = currentDay.juvs;
+	// No juveniles this session — nothing to report
+	if (sessionValue === 0) return [];
+
+	const highlights: SessionTotalJuvRecordHighlight[] = [];
+	for (const scope of RECORD_SCOPES) {
+		const scopeMatcher = getScopeMatcher(scope, sessionDate);
+		const otherDaysInScope = dayTotals.filter(
+			(day) => day.date !== date && scopeMatcher(day.date)
+		);
+		// A record is only meaningful against at least one other session
+		if (otherDaysInScope.length === 0) continue;
+		const bestOtherValue = Math.max(...otherDaysInScope.map((day) => day.juvs));
+		const baseHighlight = {
+			type: 'session-total-juv-record',
+			sortValue: juvSortValue('juv-session-total', scope),
+			scope,
+			value: sessionValue,
+			year: sessionDate.getFullYear(),
+			isCurrentYear: sessionDate.getFullYear() === today.getFullYear()
+		} satisfies SessionTotalJuvRecordHighlight;
+		if (sessionValue > bestOtherValue) {
+			highlights.push(baseHighlight);
+			break;
+		}
+		if (sessionValue === bestOtherValue && scope === 'all-time') {
+			// The for-N-years copy describes how long the record stood, so only
+			// prior tied days count — a later-only tie is unreportable
+			const mostRecentPriorTieDate = otherDaysInScope
+				.filter((day) => day.juvs === bestOtherValue && day.date < date)
+				.map((day) => day.date)
+				.sort()
+				.at(-1);
+			if (mostRecentPriorTieDate !== undefined) {
+				const recordEqualledYearsAgo = differenceInYears(
+					sessionDate,
+					new Date(mostRecentPriorTieDate)
+				);
+				if (recordEqualledYearsAgo >= 1) {
+					highlights.push({ ...baseHighlight, recordEqualledYearsAgo });
+					break;
+				}
+			}
+		}
+		// beaten or unreportable tie at this scope — a narrower scope may still
+		// hold a strict record
 	}
 	return highlights;
 }
@@ -661,6 +790,106 @@ export function deriveSpeciesRecords({
 				const placement = deriveAllTimePlacement(
 					sessionValue,
 					otherRowsInScope.map((row) => row.encounter_count)
+				);
+				if (placement) {
+					highlights.push({ ...baseHighlight, ...placement });
+					// no break — a narrower scope may still hold a strict record,
+					// reported alongside the placement
+				}
+			}
+			// beaten at this scope — a narrower scope may exclude the
+			// offending day and still hold a strict record
+		}
+	}
+	return highlights;
+}
+
+// A per-species juvenile count is only worth a "most juvs" line once it clears
+// this threshold — the session must have caught strictly more than this many
+// juveniles of the species (i.e. 5+) for a highlight to be produced.
+export const MIN_NOTABLE_JUV_COUNT = 4;
+
+// The most juveniles of one species this session, ranked against every other
+// day in scope. Mirrors deriveSpeciesRecords (same strict-record / all-time
+// tie / 1st-2nd-3rd placement logic) over the 'juvs' measure, but gates on
+// MIN_NOTABLE_JUV_COUNT rather than the single-bird rule — a handful of
+// juveniles is common and unremarkable.
+export function deriveSpeciesJuvRecords({
+	date,
+	stats,
+	today = new Date()
+}: {
+	date: string;
+	stats: SessionStatsData;
+	today?: Date;
+}): SpeciesJuvCountRecordHighlight[] {
+	const sessionDate = new Date(date);
+	const sessionRows = stats.daySpeciesStats.filter(
+		(row) => row.visit_date === date
+	);
+	if (sessionRows.length === 0) return [];
+
+	const sharedFields = {
+		year: sessionDate.getFullYear(),
+		isCurrentYear: sessionDate.getFullYear() === today.getFullYear()
+	};
+
+	const highlights: SpeciesJuvCountRecordHighlight[] = [];
+	for (const sessionRow of sessionRows) {
+		const { species_name: speciesName, juv_count: sessionValue } = sessionRow;
+		// Only notable once the session clears the juvenile-count threshold
+		if (sessionValue <= MIN_NOTABLE_JUV_COUNT) continue;
+		for (const scope of RECORD_SCOPES) {
+			const scopeMatcher = getScopeMatcher(scope, sessionDate);
+			const otherRowsInScope = stats.daySpeciesStats.filter(
+				(row) =>
+					row.species_name === speciesName &&
+					row.visit_date !== date &&
+					scopeMatcher(row.visit_date)
+			);
+			// A record requires the species to appear on at least one other day
+			if (otherRowsInScope.length === 0) continue;
+			const bestOtherValue = Math.max(
+				...otherRowsInScope.map((row) => row.juv_count)
+			);
+			const baseHighlight = {
+				type: 'species-juv-count-record',
+				sortValue: juvSortValue('juv-species-count', scope),
+				speciesName,
+				scope,
+				value: sessionValue,
+				...sharedFields
+			} satisfies SpeciesJuvCountRecordHighlight;
+			if (sessionValue > bestOtherValue) {
+				highlights.push(baseHighlight);
+				break;
+			}
+			if (sessionValue === bestOtherValue && scope === 'all-time') {
+				// The for-N-years copy describes how long the record stood, so
+				// only prior tied days count towards it; a tie held only by a
+				// later day still reads as a joint best day
+				const mostRecentPriorTieDate = otherRowsInScope
+					.filter(
+						(row) => row.juv_count === bestOtherValue && row.visit_date < date
+					)
+					.map((row) => row.visit_date)
+					.sort()
+					.at(-1);
+				const recordEqualledYearsAgo =
+					mostRecentPriorTieDate === undefined
+						? 0
+						: differenceInYears(sessionDate, new Date(mostRecentPriorTieDate));
+				highlights.push(
+					recordEqualledYearsAgo >= 1
+						? { ...baseHighlight, recordEqualledYearsAgo }
+						: { ...baseHighlight, placementRank: 1, isJointPlacement: true }
+				);
+				break;
+			}
+			if (scope === 'all-time') {
+				const placement = deriveAllTimePlacement(
+					sessionValue,
+					otherRowsInScope.map((row) => row.juv_count)
 				);
 				if (placement) {
 					highlights.push({ ...baseHighlight, ...placement });


### PR DESCRIPTION
## What this covers

PR 2 of 2 for the new **"Most juvs"** session highlights ([#384](https://github.com/wheresrhys/totf/issues/384)). Builds on PR 1 (#399), which added `juv_count` to the `stats_per_day_and_species` RPC.

> Based on `feature/384-most-juvs-highlights/1-db` — retarget to `main` once PR 1 merges.

Adds two new highlight families, derived from the per-day-per-species juvenile counts:

- **`session-total-juv-record`** — the session's total juveniles across all species, ranked against every other day. All-time + this-year, with the standard strict-record / for-N-years-tie pattern (mirrors `deriveSessionTotalRecords`). A session with no juveniles produces nothing.
  - Copy: `Most juveniles ever — N juvs` / `… this year …` / `… of 2024 …` / `Most juveniles for N years — N juvs`.
- **`species-juv-count-record`** — the most juveniles of one species this session, ranked against every other day. All-time + this-year, sharing the species-count record's **1st/2nd/3rd placement** logic. Only produced when the session's juv count for the species is **greater than 4** (`MIN_NOTABLE_JUV_COUNT = 4`).
  - Copy: `Most juvenile Reed Warbler — N caught, the most ever` / placements: `Second best day for juvenile Reed Warbler ever — N birds` / etc.

### Ordering & machine

- Two new families (`juv-session-total`, `juv-species-count`) sit just below the general `scoped-record` family in the editorial order — same kind of "record" line, more niche measure. Within a juv family, all-time outranks this-year.
- The narrower-scope removal rule (`removeNarrowerScopeSpeciesRecords`) now dedups **each per-species record family independently**, so a species can hold both an encounter record and a juvenile record without one collapsing the other.

## Tests

- `deriveSessionTotalJuvRecords` and `deriveSpeciesJuvRecords` derive tests (records, scopes, ties, placements, the >4 gate, cross-species totals).
- Renderer copy tests for both new variants.
- Machine tests: juv records dedupe by scope; encounter + juv records for one species both survive.
- `npm run qa` — pass (494 app tests; only pre-existing lint warnings).

## Assumptions

- **"Juvenile"** = `Encounters.is_juv` (set on import when the age code ends in `J`).
- **">4"** is applied to the **session's own** per-species juvenile count (the entry gate), matching the "only create a highlight if the count is greater than 4" wording. The session-total juvenile figure has no such gate beyond being non-zero (mirrors the existing session-total records, which have no threshold).
- New families placed **below** the general scoped records rather than interleaved — juveniles are a secondary measure, so they read after the headline busiest/most-varied/species records. Easy to reorder in `HIGHLIGHT_FAMILIES` if a different priority is preferred.

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)