### PR TITLE
feat: heaviest/lightest bird of the year weight highlights

### DIFF
--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -263,10 +263,13 @@ describe('SessionHighlights', () => {
 				type: 'weight-record',
 				sortValue: familySortValue('scoped-record'),
 				speciesName: 'Blue Tit',
+				scope: 'all-time',
 				extreme: 'heaviest',
 				weight: 13.1,
 				placementRank: 1,
-				isJointPlacement: false
+				isJointPlacement: false,
+				year: 2024,
+				isCurrentYear: false
 			}
 		];
 		const { fetchSessionHighlights } =
@@ -297,10 +300,13 @@ describe('SessionHighlights', () => {
 			type: 'weight-record',
 			sortValue: familySortValue('scoped-record'),
 			speciesName: 'Blue Tit',
+			scope: 'all-time',
 			extreme: 'heaviest',
 			weight: 13.1,
 			placementRank: 1,
-			isJointPlacement: false
+			isJointPlacement: false,
+			year: 2024,
+			isCurrentYear: false
 		};
 		const { fetchSessionHighlights } =
 			await import('@/app/actions/session-highlights');

--- a/app/components/session-highlight-renderers.tsx
+++ b/app/components/session-highlight-renderers.tsx
@@ -305,17 +305,23 @@ function buildWeightRecordSentence(highlight: WeightRecordHighlight): string {
 	const extremeWord = WEIGHT_RECORD_EXTREME_WORD[extreme];
 	// "heaviest" / "2nd-heaviest" / "3rd-heaviest"
 	const rankedExtreme = `${WEIGHT_PLACEMENT_PREFIX[placementRank]}${extremeWord}`;
+	// All-time reads "ever weighed"; this-year reads "weighed this year" while the
+	// year is current, otherwise "weighed in <year>".
+	const periodPhrase =
+		highlight.scope === 'all-time'
+			? 'ever weighed'
+			: `weighed ${highlight.isCurrentYear ? 'this year' : `in ${highlight.year}`}`;
 	// A joint placement leads with "Joint"; otherwise the sentence opens with
 	// the extreme word, which is only capitalised when a rank prefix (a digit)
 	// isn't already sitting in front of it
 	if (isJointPlacement) {
-		return `Joint ${rankedExtreme} ${speciesName} ever weighed — ${weight}g`;
+		return `Joint ${rankedExtreme} ${speciesName} ${periodPhrase} — ${weight}g`;
 	}
 	const descriptor =
 		placementRank === 1
 			? `${extremeWord[0].toUpperCase()}${extremeWord.slice(1)}`
 			: rankedExtreme;
-	return `${descriptor} ${speciesName} ever weighed — ${weight}g`;
+	return `${descriptor} ${speciesName} ${periodPhrase} — ${weight}g`;
 }
 
 // ---- renderers ----

--- a/app/components/session-highlight-renderers.tsx
+++ b/app/components/session-highlight-renderers.tsx
@@ -7,6 +7,7 @@ import type {
 	CombinedOnlyOfYearHighlight,
 	CombinedSessionTotalRecordHighlight,
 	CombinedSpeciesCountRecordHighlight,
+	CombinedWeightRecordHighlight,
 	FirstEverSpeciesHighlight,
 	FirstOfYearSpeciesHighlight,
 	LongAbsenceRetrapHighlight,
@@ -324,6 +325,25 @@ function buildWeightRecordSentence(highlight: WeightRecordHighlight): string {
 	return `${descriptor} ${speciesName} ${periodPhrase} — ${weight}g`;
 }
 
+// "Heaviest Blue Tit weighed in 2024 (2nd heaviest ever) — 13.1g": the this-year
+// claim leads, the all-time placement (always 2nd/3rd) rides in parentheses. Both
+// the headline and the parenthetical can be joint.
+function buildCombinedWeightRecordSentence(
+	highlight: CombinedWeightRecordHighlight
+): string {
+	const extremeWord = WEIGHT_RECORD_EXTREME_WORD[highlight.extreme];
+	const yearPhrase = highlight.isCurrentYear
+		? 'this year'
+		: `in ${highlight.year}`;
+	const headline = highlight.thisYearIsJoint
+		? `Joint ${extremeWord}`
+		: `${extremeWord[0].toUpperCase()}${extremeWord.slice(1)}`;
+	// "2nd heaviest ever" — a space, unlike the hyphenated standalone weight lines
+	const allTimeRankWord = highlight.allTimeRank === 2 ? '2nd' : '3rd';
+	const parenthetical = `(${highlight.allTimeIsJoint ? 'joint ' : ''}${allTimeRankWord} ${extremeWord} ever)`;
+	return `${headline} ${highlight.speciesName} weighed ${yearPhrase} ${parenthetical} — ${highlight.weight}g`;
+}
+
 // ---- renderers ----
 
 type HighlightRenderer<T extends SessionHighlight['type']> = (
@@ -362,6 +382,8 @@ const HIGHLIGHT_RENDERERS: {
 		renderSentence(buildLongAbsenceRetrapSentence(highlight)),
 	'weight-record': (highlight) =>
 		renderSentence(buildWeightRecordSentence(highlight)),
+	'combined-weight-record': (highlight) =>
+		renderSentence(buildCombinedWeightRecordSentence(highlight)),
 	'combined-session-total-record': (highlight) =>
 		renderSentence(buildCombinedSessionTotalRecordSentence(highlight)),
 	'combined-only-of-year': (highlight) =>

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -13,6 +13,7 @@ import {
 	scopedSortValue,
 	juvSortValue,
 	familySortValue,
+	combinedSortValue,
 	type FirstEverSpeciesHighlight,
 	type FirstOfYearSpeciesHighlight,
 	type LongAbsenceRetrapHighlight,
@@ -24,6 +25,7 @@ import {
 	type SpeciesCountRecordHighlight,
 	type SpeciesJuvCountRecordHighlight,
 	type WeightRecordHighlight,
+	type CombinedWeightRecordHighlight,
 	type SessionStatsData
 } from '../session-highlights';
 import { renderHighlight } from '@/app/components/session-highlight-renderers';
@@ -2305,6 +2307,73 @@ describe('render — weight-record', () => {
 				})
 			)
 		).toBe('Joint heaviest Blue Tit weighed this year — 13.1g');
+	});
+});
+
+// ---- render — combined-weight-record ----
+
+function makeCombinedWeightHighlight(
+	overrides: Partial<HighlightFields<CombinedWeightRecordHighlight>> = {}
+): CombinedWeightRecordHighlight {
+	return {
+		type: 'combined-weight-record',
+		sortValue: combinedSortValue([
+			{ sortValue: familySortValue('weight-record') },
+			{ sortValue: familySortValue('weight-record') }
+		]),
+		speciesName: BLUE_TIT,
+		extreme: 'heaviest',
+		weight: 13.1,
+		year: 2024,
+		isCurrentYear: false,
+		thisYearIsJoint: false,
+		allTimeRank: 2,
+		allTimeIsJoint: false,
+		...overrides
+	};
+}
+
+describe('render — combined-weight-record', () => {
+	it('leads with the year claim and carries the all-time placement in parens', () => {
+		expect(renderedText(makeCombinedWeightHighlight())).toBe(
+			'Heaviest Blue Tit weighed in 2024 (2nd heaviest ever) — 13.1g'
+		);
+	});
+
+	it('uses "this year" while the year is current', () => {
+		expect(
+			renderedText(makeCombinedWeightHighlight({ isCurrentYear: true }))
+		).toBe('Heaviest Blue Tit weighed this year (2nd heaviest ever) — 13.1g');
+	});
+
+	it('renders a 3rd-ever placement', () => {
+		expect(renderedText(makeCombinedWeightHighlight({ allTimeRank: 3 }))).toBe(
+			'Heaviest Blue Tit weighed in 2024 (3rd heaviest ever) — 13.1g'
+		);
+	});
+
+	it('renders the lightest extreme symmetrically', () => {
+		expect(
+			renderedText(
+				makeCombinedWeightHighlight({ extreme: 'lightest', weight: 9.8 })
+			)
+		).toBe('Lightest Blue Tit weighed in 2024 (2nd lightest ever) — 9.8g');
+	});
+
+	it('marks a joint year leader with "Joint"', () => {
+		expect(
+			renderedText(makeCombinedWeightHighlight({ thisYearIsJoint: true }))
+		).toBe(
+			'Joint heaviest Blue Tit weighed in 2024 (2nd heaviest ever) — 13.1g'
+		);
+	});
+
+	it('marks a joint all-time placement inside the parens', () => {
+		expect(
+			renderedText(makeCombinedWeightHighlight({ allTimeIsJoint: true }))
+		).toBe(
+			'Heaviest Blue Tit weighed in 2024 (joint 2nd heaviest ever) — 13.1g'
+		);
 	});
 });
 

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -1875,10 +1875,14 @@ function weightRow(
 	};
 }
 
-function deriveWeights(results: StatsPerDayAndSpeciesResult[]) {
+function deriveWeights(
+	results: StatsPerDayAndSpeciesResult[],
+	today = PAST_PERIOD_TODAY
+) {
 	return deriveWeightRecordBreakers({
 		date: SESSION_DATE,
-		stats: statsFor(results)
+		stats: statsFor(results),
+		today
 	});
 }
 
@@ -1896,10 +1900,13 @@ describe('deriveWeightRecordBreakers', () => {
 			type: 'weight-record',
 			sortValue: familySortValue('weight-record'),
 			speciesName: BLUE_TIT,
+			scope: 'all-time',
 			extreme: 'heaviest',
 			weight: 13.1,
 			placementRank: 1,
-			isJointPlacement: false
+			isJointPlacement: false,
+			year: 2024,
+			isCurrentYear: false
 		});
 	});
 
@@ -1916,10 +1923,13 @@ describe('deriveWeightRecordBreakers', () => {
 			type: 'weight-record',
 			sortValue: familySortValue('weight-record'),
 			speciesName: BLUE_TIT,
+			scope: 'all-time',
 			extreme: 'lightest',
 			weight: 9.8,
 			placementRank: 1,
-			isJointPlacement: false
+			isJointPlacement: false,
+			year: 2024,
+			isCurrentYear: false
 		});
 	});
 
@@ -1937,10 +1947,13 @@ describe('deriveWeightRecordBreakers', () => {
 			type: 'weight-record',
 			sortValue: familySortValue('weight-record'),
 			speciesName: BLUE_TIT,
+			scope: 'all-time',
 			extreme: 'heaviest',
 			weight: 13.1,
 			placementRank: 2,
-			isJointPlacement: false
+			isJointPlacement: false,
+			year: 2024,
+			isCurrentYear: false
 		});
 	});
 
@@ -1992,10 +2005,13 @@ describe('deriveWeightRecordBreakers', () => {
 			type: 'weight-record',
 			sortValue: familySortValue('weight-record'),
 			speciesName: BLUE_TIT,
+			scope: 'all-time',
 			extreme: 'heaviest',
 			weight: 13.1,
 			placementRank: 1,
-			isJointPlacement: true
+			isJointPlacement: true,
+			year: 2024,
+			isCurrentYear: false
 		});
 	});
 
@@ -2060,6 +2076,121 @@ describe('deriveWeightRecordBreakers', () => {
 		]);
 		expect(highlights).toEqual([]);
 	});
+
+	describe('this-year scope', () => {
+		it('reports a this-year heaviest 1st once the year clears the weighed threshold', () => {
+			// Three weighed birds this year (across other days), and the session's
+			// max beats them — heaviest of the year
+			const highlights = deriveWeights([
+				weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+				weightRow(PRIOR_SUMMER_THIS_YEAR, BLUE_TIT, {
+					weighedBirds: 3,
+					minWeight: 10.5,
+					maxWeight: 12.5
+				})
+			]);
+			expect(highlights).toContainEqual({
+				type: 'weight-record',
+				sortValue: familySortValue('weight-record'),
+				speciesName: BLUE_TIT,
+				scope: 'this-year',
+				extreme: 'heaviest',
+				weight: 13.1,
+				placementRank: 1,
+				isJointPlacement: false,
+				year: 2024,
+				isCurrentYear: false
+			});
+		});
+
+		it('reports a this-year lightest 1st when the session min beats every day this year', () => {
+			const highlights = deriveWeights([
+				weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 9.8, maxWeight: 12 }),
+				weightRow(PRIOR_SUMMER_THIS_YEAR, BLUE_TIT, {
+					weighedBirds: 3,
+					minWeight: 10.2,
+					maxWeight: 13.0
+				})
+			]);
+			expect(highlights).toContainEqual(
+				expect.objectContaining({
+					scope: 'this-year',
+					extreme: 'lightest',
+					weight: 9.8,
+					placementRank: 1
+				})
+			);
+		});
+
+		it('does not report a this-year 2nd/3rd placement — only a first place', () => {
+			// A prior day this year is heavier, so the session is only 2nd heaviest
+			// of the year; the this-year scope reports only first places
+			const highlights = deriveWeights([
+				weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+				weightRow(PRIOR_SUMMER_THIS_YEAR, BLUE_TIT, {
+					weighedBirds: 3,
+					minWeight: 10.5,
+					maxWeight: 14.0
+				})
+			]);
+			expect(
+				highlights.filter((highlight) => highlight.scope === 'this-year')
+			).toEqual([]);
+		});
+
+		it('suppresses this-year highlights until the year clears the weighed threshold', () => {
+			// Only two weighed birds this year (across other days) — below the
+			// threshold — so no this-year highlight even though the session leads
+			const highlights = deriveWeights([
+				weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+				weightRow(PRIOR_SUMMER_THIS_YEAR, BLUE_TIT, {
+					weighedBirds: 2,
+					minWeight: 10.5,
+					maxWeight: 12.5
+				})
+			]);
+			expect(
+				highlights.filter((highlight) => highlight.scope === 'this-year')
+			).toEqual([]);
+		});
+
+		it('flags a joint this-year 1st when another day this year matches the extreme', () => {
+			const highlights = deriveWeights([
+				weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+				weightRow(PRIOR_SUMMER_THIS_YEAR, BLUE_TIT, {
+					weighedBirds: 3,
+					minWeight: 10.5,
+					maxWeight: 13.1
+				})
+			]);
+			expect(highlights).toContainEqual(
+				expect.objectContaining({
+					scope: 'this-year',
+					extreme: 'heaviest',
+					weight: 13.1,
+					placementRank: 1,
+					isJointPlacement: true
+				})
+			);
+		});
+
+		it('produces both all-time and this-year highlights when the session leads both', () => {
+			// Every comparison day is this year, so the session's heaviest leads
+			// both scopes — derivation yields both (the machine later drops the
+			// narrower one)
+			const scopes = deriveWeights([
+				weightRow(SESSION_DATE, BLUE_TIT, { minWeight: 11, maxWeight: 13.1 }),
+				weightRow(PRIOR_SUMMER_THIS_YEAR, BLUE_TIT, {
+					weighedBirds: 3,
+					minWeight: 10.5,
+					maxWeight: 12.5
+				})
+			])
+				.filter((highlight) => highlight.extreme === 'heaviest')
+				.map((highlight) => highlight.scope);
+			expect(scopes).toEqual(['all-time', 'this-year']);
+		});
+	});
 });
 
 // ---- render — weight-record ----
@@ -2071,10 +2202,13 @@ function makeWeightHighlight(
 		type: 'weight-record',
 		sortValue: familySortValue('weight-record'),
 		speciesName: BLUE_TIT,
+		scope: 'all-time',
 		extreme: 'heaviest',
 		weight: 13.1,
 		placementRank: 1,
 		isJointPlacement: false,
+		year: 2024,
+		isCurrentYear: false,
 		...overrides
 	};
 }
@@ -2126,6 +2260,51 @@ describe('render — weight-record', () => {
 				})
 			)
 		).toBe('Joint 2nd-heaviest Blue Tit ever weighed — 12.9g');
+	});
+
+	it('renders heaviest-of-the-year copy while the year is current', () => {
+		expect(
+			renderedText(
+				makeWeightHighlight({ scope: 'this-year', isCurrentYear: true })
+			)
+		).toBe('Heaviest Blue Tit weighed this year — 13.1g');
+	});
+
+	it('renders heaviest-in-year copy once the year is past', () => {
+		expect(
+			renderedText(
+				makeWeightHighlight({
+					scope: 'this-year',
+					year: 2024,
+					isCurrentYear: false
+				})
+			)
+		).toBe('Heaviest Blue Tit weighed in 2024 — 13.1g');
+	});
+
+	it('renders lightest-of-the-year copy', () => {
+		expect(
+			renderedText(
+				makeWeightHighlight({
+					scope: 'this-year',
+					extreme: 'lightest',
+					weight: 9.8,
+					isCurrentYear: true
+				})
+			)
+		).toBe('Lightest Blue Tit weighed this year — 9.8g');
+	});
+
+	it('renders joint heaviest-of-the-year copy', () => {
+		expect(
+			renderedText(
+				makeWeightHighlight({
+					scope: 'this-year',
+					isJointPlacement: true,
+					isCurrentYear: true
+				})
+			)
+		).toBe('Joint heaviest Blue Tit weighed this year — 13.1g');
 	});
 });
 

--- a/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
+++ b/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
@@ -4,6 +4,7 @@ import {
 	combineFirstOfYearHighlights,
 	combineOnlyOfYearHighlights,
 	combineSessionTotalRecords,
+	combineWeightRecords,
 	combineYearSpeciesCounts,
 	orderBySortValue,
 	removeBusiestSinceWhenBusiestRecordHeld,
@@ -279,34 +280,17 @@ describe('removeNarrowerScopeSpeciesRecords (Rem-2)', () => {
 	});
 
 	it('is a noop on non-species-record highlights', () => {
-		const pool = [busiestSince, rareSpecies];
+		// Weight records are reconciled by combineWeightRecords (Comb-6), not here
+		const pool = [busiestSince, weightRecord];
 		expect(removeNarrowerScopeSpeciesRecords(pool)).toEqual(pool);
 	});
 
-	it('drops a this-year weight record when the species holds an all-time one for the same extreme', () => {
-		const allTime = weightRecord; // Blue Tit heaviest, all-time
-		const removed = removeNarrowerScopeSpeciesRecords([
-			allTime,
-			{ ...weightRecord, scope: 'this-year' }
-		]);
-		expect(removed).toEqual([allTime]);
-	});
-
-	it('keeps weight records for different extremes of the same species', () => {
-		// A heaviest all-time and a lightest this-year are keyed separately, so
-		// neither collapses the other
-		const heaviestAllTime = weightRecord;
-		const lightestThisYear: WeightRecordHighlight = {
-			...weightRecord,
-			scope: 'this-year',
-			extreme: 'lightest',
-			weight: 9.8
-		};
-		const removed = removeNarrowerScopeSpeciesRecords([
-			heaviestAllTime,
-			lightestThisYear
-		]);
-		expect(removed).toEqual([heaviestAllTime, lightestThisYear]);
+	it('leaves this-year and all-time weight records untouched (handled by Comb-6)', () => {
+		const pool = [
+			weightRecord,
+			{ ...weightRecord, scope: 'this-year' as const }
+		];
+		expect(removeNarrowerScopeSpeciesRecords(pool)).toEqual(pool);
 	});
 });
 
@@ -903,6 +887,107 @@ describe('combineFirstOfYearHighlights (Comb-5)', () => {
 	});
 });
 
+describe('combineWeightRecords (Comb-6)', () => {
+	// weightRecord is a Blue Tit heaviest all-time 1st; build the pieces from it
+	const heaviestThisYear: WeightRecordHighlight = {
+		...weightRecord,
+		scope: 'this-year'
+	};
+	const heaviestAllTime2nd: WeightRecordHighlight = {
+		...weightRecord,
+		scope: 'all-time',
+		placementRank: 2
+	};
+	const heaviestAllTime3rd: WeightRecordHighlight = {
+		...weightRecord,
+		scope: 'all-time',
+		placementRank: 3
+	};
+
+	it('merges a this-year 1st with an all-time 2nd for the same species+extreme', () => {
+		const combined = combineWeightRecords([
+			heaviestAllTime2nd,
+			heaviestThisYear
+		]);
+		expect(combined).toEqual([
+			{
+				type: 'combined-weight-record',
+				sortValue: combinedSortValue([heaviestThisYear, heaviestAllTime2nd]),
+				speciesName: 'Blue Tit',
+				extreme: 'heaviest',
+				weight: 13.1,
+				year: 2024,
+				isCurrentYear: false,
+				thisYearIsJoint: false,
+				allTimeRank: 2,
+				allTimeIsJoint: false
+			}
+		]);
+	});
+
+	it('merges with an all-time 3rd, carrying the rank through', () => {
+		const combined = combineWeightRecords([
+			heaviestAllTime3rd,
+			heaviestThisYear
+		]);
+		expect(combined).toEqual([
+			expect.objectContaining({
+				type: 'combined-weight-record',
+				allTimeRank: 3
+			})
+		]);
+	});
+
+	it('keeps the all-time line and drops the this-year one when the all-time is a 1st', () => {
+		// Being the heaviest ever subsumes the year claim — no combined line
+		const combined = combineWeightRecords([weightRecord, heaviestThisYear]);
+		expect(combined).toEqual([weightRecord]);
+	});
+
+	it('leaves a this-year 1st untouched when the species has no all-time placement', () => {
+		expect(combineWeightRecords([heaviestThisYear])).toEqual([
+			heaviestThisYear
+		]);
+	});
+
+	it('matches on extreme — a this-year heaviest is not merged with an all-time lightest', () => {
+		const lightestAllTime2nd: WeightRecordHighlight = {
+			...weightRecord,
+			extreme: 'lightest',
+			weight: 9.8,
+			placementRank: 2
+		};
+		const pool = [lightestAllTime2nd, heaviestThisYear];
+		expect(combineWeightRecords(pool)).toEqual(pool);
+	});
+
+	it('carries the joint flags from each part', () => {
+		const combined = combineWeightRecords([
+			{ ...heaviestAllTime2nd, isJointPlacement: true },
+			{ ...heaviestThisYear, isJointPlacement: true }
+		]);
+		expect(combined).toEqual([
+			expect.objectContaining({
+				thisYearIsJoint: true,
+				allTimeIsJoint: true,
+				allTimeRank: 2
+			})
+		]);
+	});
+
+	it('is a noop when there are no this-year weight records', () => {
+		const pool = [weightRecord, rareSpecies];
+		expect(combineWeightRecords(pool)).toEqual(pool);
+	});
+
+	it('does not mutate the input list', () => {
+		const pool = [heaviestAllTime2nd, heaviestThisYear];
+		const snapshot = [...pool];
+		combineWeightRecords(pool);
+		expect(pool).toEqual(snapshot);
+	});
+});
+
 // ---- Full machine ----
 
 describe('runHighlightMachine', () => {
@@ -1019,6 +1104,17 @@ describe('runHighlightMachine', () => {
 			['combined-first-ever', "Blackbird+Blackcap+Cetti's Warbler"],
 			['combined-first-of-year', 'Chiffchaff+Whitethroat'],
 			['weight-record']
+		]);
+	});
+
+	it('merges a this-year weight leader with its all-time placement into one line', () => {
+		const pool: SessionHighlight[] = [
+			{ ...weightRecord, scope: 'all-time', placementRank: 2 },
+			{ ...weightRecord, scope: 'this-year', placementRank: 1 }
+		];
+		const machined = runHighlightMachine(pool);
+		expect(machined.map((highlight) => highlight.type)).toEqual([
+			'combined-weight-record'
 		]);
 	});
 });

--- a/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
+++ b/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
@@ -170,10 +170,13 @@ const weightRecord: WeightRecordHighlight = {
 	type: 'weight-record',
 	sortValue: familySortValue('weight-record'),
 	speciesName: 'Blue Tit',
+	scope: 'all-time',
 	extreme: 'heaviest',
 	weight: 13.1,
 	placementRank: 1,
-	isJointPlacement: false
+	isJointPlacement: false,
+	year: 2024,
+	isCurrentYear: false
 };
 
 // ---- Removal rules ----
@@ -276,8 +279,34 @@ describe('removeNarrowerScopeSpeciesRecords (Rem-2)', () => {
 	});
 
 	it('is a noop on non-species-record highlights', () => {
-		const pool = [busiestSince, weightRecord];
+		const pool = [busiestSince, rareSpecies];
 		expect(removeNarrowerScopeSpeciesRecords(pool)).toEqual(pool);
+	});
+
+	it('drops a this-year weight record when the species holds an all-time one for the same extreme', () => {
+		const allTime = weightRecord; // Blue Tit heaviest, all-time
+		const removed = removeNarrowerScopeSpeciesRecords([
+			allTime,
+			{ ...weightRecord, scope: 'this-year' }
+		]);
+		expect(removed).toEqual([allTime]);
+	});
+
+	it('keeps weight records for different extremes of the same species', () => {
+		// A heaviest all-time and a lightest this-year are keyed separately, so
+		// neither collapses the other
+		const heaviestAllTime = weightRecord;
+		const lightestThisYear: WeightRecordHighlight = {
+			...weightRecord,
+			scope: 'this-year',
+			extreme: 'lightest',
+			weight: 9.8
+		};
+		const removed = removeNarrowerScopeSpeciesRecords([
+			heaviestAllTime,
+			lightestThisYear
+		]);
+		expect(removed).toEqual([heaviestAllTime, lightestThisYear]);
 	});
 });
 
@@ -287,10 +316,13 @@ describe('removeCountAndWeightHighlightsForRareSpecies (Rem-3)', () => {
 		type: 'weight-record',
 		sortValue: familySortValue('weight-record'),
 		speciesName: 'Wryneck',
+		scope: 'all-time',
 		extreme: 'heaviest',
 		weight: 30.2,
 		placementRank: 1,
-		isJointPlacement: false
+		isJointPlacement: false,
+		year: 2024,
+		isCurrentYear: false
 	};
 
 	it("drops the rare species' own count and weight highlights", () => {
@@ -931,10 +963,13 @@ describe('runHighlightMachine', () => {
 			type: 'weight-record',
 			sortValue: familySortValue('weight-record'),
 			speciesName: 'Wryneck',
+			scope: 'all-time',
 			extreme: 'heaviest',
 			weight: 30.2,
 			placementRank: 1,
-			isJointPlacement: false
+			isJointPlacement: false,
+			year: 2024,
+			isCurrentYear: false
 		};
 		const pool: SessionHighlight[] = [
 			rareSpecies, // Wryneck

--- a/app/models/highlight-refinement-machine/combine-weight-records.ts
+++ b/app/models/highlight-refinement-machine/combine-weight-records.ts
@@ -1,0 +1,85 @@
+import {
+	combinedSortValue,
+	type CombinedWeightRecordHighlight,
+	type SessionHighlight,
+	type WeightRecordHighlight
+} from '@/app/models/session-highlights';
+
+function isWeightRecord(
+	highlight: SessionHighlight
+): highlight is WeightRecordHighlight {
+	return highlight.type === 'weight-record';
+}
+
+// Comb-6: reconcile a species' this-year and all-time weight records for the
+// same extreme. Derivation emits a this-year weight only for an outright leader
+// (a 1st place), so every this-year weight is a "heaviest/lightest of the year".
+// When the same species+extreme also holds an all-time placement:
+//   - all-time 1st: being the heaviest ever subsumes the year claim, so keep the
+//     plain all-time line and drop the this-year one.
+//   - all-time 2nd/3rd: merge into one line — the year claim is the headline, the
+//     all-time placement rides along in parentheses ("... (2nd heaviest ever)").
+// A this-year weight with no matching all-time placement is left untouched (it
+// stays a plain "heaviest of the year" line). Weight records are deliberately not
+// deduped by Rem-2; all scope reconciliation for weights happens here.
+export function combineWeightRecords(
+	highlights: SessionHighlight[]
+): SessionHighlight[] {
+	const thisYearWeights = highlights.filter(
+		(highlight) => isWeightRecord(highlight) && highlight.scope === 'this-year'
+	) as WeightRecordHighlight[];
+	if (thisYearWeights.length === 0) return highlights;
+
+	const removed = new Set<SessionHighlight>();
+	const combinedByThisYear = new Map<
+		WeightRecordHighlight,
+		CombinedWeightRecordHighlight
+	>();
+	for (const thisYear of thisYearWeights) {
+		const allTime = highlights.find(
+			(highlight) =>
+				isWeightRecord(highlight) &&
+				highlight.scope === 'all-time' &&
+				highlight.speciesName === thisYear.speciesName &&
+				highlight.extreme === thisYear.extreme
+		) as WeightRecordHighlight | undefined;
+		if (!allTime) continue; // no all-time placement — leave the year line as-is
+		if (allTime.placementRank === 1) {
+			// The all-time 1st already says everything the year line would; drop it
+			removed.add(thisYear);
+			continue;
+		}
+		// all-time 2nd/3rd — fold both into one combined line
+		removed.add(thisYear);
+		removed.add(allTime);
+		combinedByThisYear.set(thisYear, {
+			type: 'combined-weight-record',
+			sortValue: combinedSortValue([thisYear, allTime]),
+			speciesName: thisYear.speciesName,
+			extreme: thisYear.extreme,
+			weight: thisYear.weight,
+			year: thisYear.year,
+			isCurrentYear: thisYear.isCurrentYear,
+			thisYearIsJoint: thisYear.isJointPlacement,
+			allTimeRank: allTime.placementRank,
+			allTimeIsJoint: allTime.isJointPlacement
+		});
+	}
+	if (removed.size === 0) return highlights;
+
+	// Each combined line takes the position of the this-year highlight it replaces;
+	// the removed all-time part just drops out.
+	const result: SessionHighlight[] = [];
+	for (const highlight of highlights) {
+		const combined = isWeightRecord(highlight)
+			? combinedByThisYear.get(highlight)
+			: undefined;
+		if (combined) {
+			result.push(combined);
+			continue;
+		}
+		if (removed.has(highlight)) continue;
+		result.push(highlight);
+	}
+	return result;
+}

--- a/app/models/highlight-refinement-machine/index.ts
+++ b/app/models/highlight-refinement-machine/index.ts
@@ -7,6 +7,7 @@ import { combineOnlyOfYearHighlights } from './combine-only-of-year-highlights';
 import { combineFirstEverHighlights } from './combine-first-ever-highlights';
 import { combineFirstOfYearHighlights } from './combine-first-of-year-highlights';
 import { combineYearSpeciesCounts } from './combine-year-species-counts';
+import { combineWeightRecords } from './combine-weight-records';
 import { orderBySortValue } from './order-by-sort-value';
 
 export { removeBusiestSinceWhenBusiestRecordHeld } from './remove-busiest-since-when-busiest-record-held';
@@ -17,6 +18,7 @@ export { combineOnlyOfYearHighlights } from './combine-only-of-year-highlights';
 export { combineFirstEverHighlights } from './combine-first-ever-highlights';
 export { combineFirstOfYearHighlights } from './combine-first-of-year-highlights';
 export { combineYearSpeciesCounts } from './combine-year-species-counts';
+export { combineWeightRecords } from './combine-weight-records';
 export { orderBySortValue } from './order-by-sort-value';
 
 type HighlightRule = (highlights: SessionHighlight[]) => SessionHighlight[];
@@ -37,6 +39,7 @@ const RULES: HighlightRule[] = [
 	combineYearSpeciesCounts, // Comb-3
 	combineFirstEverHighlights, // Comb-4
 	combineFirstOfYearHighlights, // Comb-5
+	combineWeightRecords, // Comb-6
 	orderBySortValue // Ord-1
 ];
 

--- a/app/models/highlight-refinement-machine/remove-narrower-scope-species-records.ts
+++ b/app/models/highlight-refinement-machine/remove-narrower-scope-species-records.ts
@@ -6,9 +6,12 @@ import {
 // The per-species record families this rule dedups by scope. Each is keyed
 // independently, so a species holding both an encounter record and a juvenile
 // record keeps the broadest of each — they aren't collapsed into one another.
+// Weight records are included too: the two extremes are keyed separately, so a
+// species can hold a heaviest and a lightest record and keep the broadest of each.
 const SCOPED_SPECIES_RECORD_TYPES = [
 	'species-count-record',
-	'species-juv-count-record'
+	'species-juv-count-record',
+	'weight-record'
 ] as const;
 type ScopedSpeciesRecordType = (typeof SCOPED_SPECIES_RECORD_TYPES)[number];
 
@@ -22,17 +25,22 @@ function isScopedSpeciesRecord(
 
 // Rem-2: when one species holds records at more than one scope, keep only the
 // broadest — a narrower-scope record is subsumed by the broader one (e.g. drop
-// "the most this year" when the same species holds a 2nd-best-ever placement).
-// Applied per record family (encounter counts, juvenile counts): a species can
-// still hold one of each.
+// "the most this year" when the same species holds a 2nd-best-ever placement, or
+// "heaviest of the year" when it holds an all-time weight placement). Applied per
+// record family (encounter counts, juvenile counts, each weight extreme): a
+// species can still hold one of each.
 export function removeNarrowerScopeSpeciesRecords(
 	highlights: SessionHighlight[]
 ): SessionHighlight[] {
-	// Keyed by "<type>|<species>" so each family is deduped independently
+	// Keyed by "<type>|<species>" (plus the extreme for weight records) so each
+	// family is deduped independently
 	const broadestScopeRankByKey = new Map<string, number>();
 	const keyFor = (
 		highlight: Extract<SessionHighlight, { type: ScopedSpeciesRecordType }>
-	) => `${highlight.type}|${highlight.speciesName}`;
+	) =>
+		highlight.type === 'weight-record'
+			? `${highlight.type}|${highlight.speciesName}|${highlight.extreme}`
+			: `${highlight.type}|${highlight.speciesName}`;
 	for (const highlight of highlights) {
 		if (!isScopedSpeciesRecord(highlight)) continue;
 		const rank = SCOPE_BREADTH_RANK.get(highlight.scope)!;

--- a/app/models/highlight-refinement-machine/remove-narrower-scope-species-records.ts
+++ b/app/models/highlight-refinement-machine/remove-narrower-scope-species-records.ts
@@ -6,12 +6,12 @@ import {
 // The per-species record families this rule dedups by scope. Each is keyed
 // independently, so a species holding both an encounter record and a juvenile
 // record keeps the broadest of each — they aren't collapsed into one another.
-// Weight records are included too: the two extremes are keyed separately, so a
-// species can hold a heaviest and a lightest record and keep the broadest of each.
+// Weight records are handled separately (combineWeightRecords): a this-year
+// weight is merged with its all-time placement rather than dropped, so it is
+// deliberately not deduped here.
 const SCOPED_SPECIES_RECORD_TYPES = [
 	'species-count-record',
-	'species-juv-count-record',
-	'weight-record'
+	'species-juv-count-record'
 ] as const;
 type ScopedSpeciesRecordType = (typeof SCOPED_SPECIES_RECORD_TYPES)[number];
 
@@ -25,22 +25,17 @@ function isScopedSpeciesRecord(
 
 // Rem-2: when one species holds records at more than one scope, keep only the
 // broadest — a narrower-scope record is subsumed by the broader one (e.g. drop
-// "the most this year" when the same species holds a 2nd-best-ever placement, or
-// "heaviest of the year" when it holds an all-time weight placement). Applied per
-// record family (encounter counts, juvenile counts, each weight extreme): a
-// species can still hold one of each.
+// "the most this year" when the same species holds a 2nd-best-ever placement).
+// Applied per record family (encounter counts, juvenile counts): a species can
+// still hold one of each.
 export function removeNarrowerScopeSpeciesRecords(
 	highlights: SessionHighlight[]
 ): SessionHighlight[] {
-	// Keyed by "<type>|<species>" (plus the extreme for weight records) so each
-	// family is deduped independently
+	// Keyed by "<type>|<species>" so each family is deduped independently
 	const broadestScopeRankByKey = new Map<string, number>();
 	const keyFor = (
 		highlight: Extract<SessionHighlight, { type: ScopedSpeciesRecordType }>
-	) =>
-		highlight.type === 'weight-record'
-			? `${highlight.type}|${highlight.speciesName}|${highlight.extreme}`
-			: `${highlight.type}|${highlight.speciesName}`;
+	) => `${highlight.type}|${highlight.speciesName}`;
 	for (const highlight of highlights) {
 		if (!isScopedSpeciesRecord(highlight)) continue;
 		const rank = SCOPE_BREADTH_RANK.get(highlight.scope)!;

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -287,14 +287,22 @@ export type WeightRecordHighlight = {
 	type: 'weight-record';
 	sortValue: SortValue;
 	speciesName: string;
+	// The scope the placement is ranked over. All-time reports the top three
+	// placements; this-year reports only a first place (see deriveWeightRecordBreakers).
+	scope: RecordScope;
 	extreme: WeightRecordExtreme;
 	// The session's weight for this extreme, in grams
 	weight: number;
-	// Where the session's weight ranks across every day the species was weighed
-	// (1 = heaviest/lightest ever, capped at the top 3)
+	// Where the session's weight ranks across every day in scope the species was
+	// weighed (1 = heaviest/lightest, capped at the top 3; always 1 for this-year)
 	placementRank: 1 | 2 | 3;
 	// True when another day's extreme exactly matches the session's weight
 	isJointPlacement: boolean;
+	// The session's calendar year — used by the this-year copy. 'this year' copy
+	// is only correct while the session's year is still current; otherwise the
+	// sentence uses the absolute year. Carried (but unused) for all-time.
+	year: number;
+	isCurrentYear: boolean;
 };
 
 // A combined session-total record: a session that holds both the busiest
@@ -1103,57 +1111,78 @@ function deriveWeightPlacement(
 	return resolvePlacement(betterDays, otherWeights.includes(sessionWeight));
 }
 
-// Weight placements are inherently all-time — a species' heaviest/lightest bird
-// this session is ranked against every other day it was weighed, including
-// later days (which can demote a placement). A placement needs the species to
-// have been weighed at least three times across those other days.
+// A species' heaviest/lightest bird this session is ranked against every other
+// day in scope it was weighed, including later days (which can demote a
+// placement). A placement needs the species to have been weighed at least three
+// times across those other days in scope.
+//
+// All-time reports the full top-three placements. The this-year scope turns on
+// once the species has crossed the same weighed-encounter threshold within the
+// year, but reports only a first place — a heaviest/lightest of the year is
+// worth a line, a lesser within-year placement is not.
 export function deriveWeightRecordBreakers({
 	date,
-	stats
+	stats,
+	today = new Date()
 }: {
 	date: string;
 	stats: SessionStatsData;
+	today?: Date;
 }): WeightRecordHighlight[] {
+	const sessionDate = new Date(date);
 	const sessionRows = stats.daySpeciesStats.filter(
 		(row) => row.visit_date === date && row.weighed_birds_count > 0
 	);
 	if (sessionRows.length === 0) return [];
 
+	const sharedFields = {
+		year: sessionDate.getFullYear(),
+		isCurrentYear: sessionDate.getFullYear() === today.getFullYear()
+	};
+
 	const highlights: WeightRecordHighlight[] = [];
 	for (const sessionRow of sessionRows) {
-		const otherWeighedRows = stats.daySpeciesStats.filter(
-			(row) =>
-				row.species_name === sessionRow.species_name &&
-				row.visit_date !== date &&
-				row.weighed_birds_count > 0
-		);
-		const otherWeighedEncounters = otherWeighedRows.reduce(
-			(total, row) => total + row.weighed_birds_count,
-			0
-		);
-		if (otherWeighedEncounters < MIN_WEIGHED_ENCOUNTERS_FOR_RECORD) continue;
+		for (const scope of RECORD_SCOPES) {
+			const scopeMatcher = getScopeMatcher(scope, sessionDate);
+			const otherWeighedRows = stats.daySpeciesStats.filter(
+				(row) =>
+					row.species_name === sessionRow.species_name &&
+					row.visit_date !== date &&
+					row.weighed_birds_count > 0 &&
+					scopeMatcher(row.visit_date)
+			);
+			const otherWeighedEncounters = otherWeighedRows.reduce(
+				(total, row) => total + row.weighed_birds_count,
+				0
+			);
+			if (otherWeighedEncounters < MIN_WEIGHED_ENCOUNTERS_FOR_RECORD) continue;
 
-		for (const extreme of WEIGHT_RECORD_EXTREMES) {
-			const isHeaviest = extreme === 'heaviest';
-			const sessionWeight = isHeaviest
-				? sessionRow.max_weight
-				: sessionRow.min_weight;
-			const otherWeights = otherWeighedRows.map((row) =>
-				isHeaviest ? row.max_weight : row.min_weight
-			);
-			const placement = deriveWeightPlacement(
-				sessionWeight,
-				otherWeights,
-				isHeaviest
-			);
-			if (placement) {
+			for (const extreme of WEIGHT_RECORD_EXTREMES) {
+				const isHeaviest = extreme === 'heaviest';
+				const sessionWeight = isHeaviest
+					? sessionRow.max_weight
+					: sessionRow.min_weight;
+				const otherWeights = otherWeighedRows.map((row) =>
+					isHeaviest ? row.max_weight : row.min_weight
+				);
+				const placement = deriveWeightPlacement(
+					sessionWeight,
+					otherWeights,
+					isHeaviest
+				);
+				if (!placement) continue;
+				// This-year only headlines an outright leader; lesser within-year
+				// placements aren't worth a line.
+				if (scope === 'this-year' && placement.placementRank !== 1) continue;
 				highlights.push({
 					type: 'weight-record',
 					sortValue: familySortValue('weight-record'),
 					speciesName: sessionRow.species_name,
+					scope,
 					extreme,
 					weight: sessionWeight,
-					...placement
+					...placement,
+					...sharedFields
 				});
 			}
 		}

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -374,6 +374,33 @@ export type CombinedSpeciesCountRecordHighlight = {
 	isCurrentYear: boolean;
 };
 
+// A this-year weight record (always a 1st place) merged with the same species'
+// all-time placement for the *same* extreme, when that all-time placement is a
+// 2nd/3rd (a lesser record that the year headline sits on top of). Rendered as a
+// single line: the this-year claim as the headline, the all-time placement in
+// parentheses — "Heaviest Blue Tit weighed in 2024 (2nd heaviest ever) — 13.1g".
+// The two source highlights share one session bird, so a single weight applies.
+// An all-time *1st* is never merged this way — being the heaviest ever subsumes
+// the year claim, so that case keeps the plain all-time line instead.
+export type CombinedWeightRecordHighlight = {
+	type: 'combined-weight-record';
+	sortValue: SortValue;
+	speciesName: string;
+	extreme: WeightRecordExtreme;
+	// The shared session weight, in grams
+	weight: number;
+	year: number;
+	// 'this year' copy is only correct while the session's year is still current;
+	// otherwise the sentence uses the absolute year
+	isCurrentYear: boolean;
+	// True when another day this year ties the session's extreme (joint 1st)
+	thisYearIsJoint: boolean;
+	// The all-time placement folded into the parenthetical — always 2nd or 3rd
+	allTimeRank: 2 | 3;
+	// True when another day ever ties the session's extreme at that placement
+	allTimeIsJoint: boolean;
+};
+
 // The discriminated union the highlight machine's passes and the client
 // renderers both operate over. Highlights are plain serializable data so they
 // can cross the server-action -> client boundary; rendering happens client
@@ -393,7 +420,8 @@ export type SessionHighlight =
 	| CombinedOnlyOfYearHighlight
 	| CombinedFirstEverHighlight
 	| CombinedFirstOfYearHighlight
-	| CombinedSpeciesCountRecordHighlight;
+	| CombinedSpeciesCountRecordHighlight
+	| CombinedWeightRecordHighlight;
 
 type DayTotals = {
 	date: string;


### PR DESCRIPTION
## What this covers

Implements #386. Once a species crosses the same weighed-encounter threshold that turns on all-time weight highlights (`MIN_WEIGHED_ENCOUNTERS_FOR_RECORD`) *within a single year*, the app now generates a this-year weight highlight for that species — but only for a **first-placed** heaviest/lightest bird.

### Weight highlights gain a this-year scope
- **`WeightRecordHighlight`** gains `scope` (`all-time` | `this-year`) plus `year` / `isCurrentYear`.
- **`deriveWeightRecordBreakers`** loops over both record scopes:
  - `all-time` — unchanged: full top-three placements, ranked against every other weighed day.
  - `this-year` — gates on the same weighed-encounter threshold counted *within the session's year*, and emits **only rank 1** (heaviest/lightest of the year). Joint first places are kept.
- **Renderer** phrases the year copy: `Heaviest Blue Tit weighed this year — 13.1g` while the year is current, `weighed in 2024` once it is past.

### This-year + all-time are combined, not suppressed
When a species is the heaviest/lightest *of the year* **and** also holds an all-time placement for the same extreme, the two lines merge into one:

> `Heaviest Blue Tit weighed in 2024 (2nd heaviest ever) — 13.1g`

- New **Comb-6 rule `combineWeightRecords`** reconciles a species' this-year (always a 1st) and all-time weight records per extreme:
  - all-time **2nd/3rd** → merge into a `combined-weight-record` (year claim as headline, all-time placement in parentheses).
  - all-time **1st** → keep the plain all-time line, drop the this-year one (being the heaviest ever subsumes the year claim).
  - **no all-time placement** → leave the plain "heaviest of the year" line.
- Weight records are **no longer deduped by Rem-2** (`removeNarrowerScopeSpeciesRecords`); all weight scope reconciliation now lives in Comb-6.
- New **`CombinedWeightRecordHighlight`** type + renderer. Headline and parenthetical both support joint placements (`Joint heaviest …`, `… (joint 2nd heaviest ever)`); lightest handled symmetrically.

### Rendered copy
| case | sentence |
|---|---|
| all-time 1st | `Heaviest Blue Tit ever weighed — 13.1g` |
| this-year 1st, no all-time placement (current year) | `Heaviest Blue Tit weighed this year — 13.1g` |
| this-year 1st, no all-time placement (past year) | `Heaviest Blue Tit weighed in 2024 — 13.1g` |
| this-year 1st **+ all-time 2nd** | `Heaviest Blue Tit weighed in 2024 (2nd heaviest ever) — 13.1g` |
| this-year 1st **+ all-time 3rd** | `Heaviest Blue Tit weighed in 2024 (3rd heaviest ever) — 13.1g` |
| joint variants | `Joint heaviest …` / `… (joint 2nd heaviest ever)` |

### Tests
- `deriveWeightRecordBreakers > this-year scope`: first-placed heaviest/lightest once the year clears the threshold; suppresses 2nd/3rd within-year placements; suppresses below-threshold years; joint firsts; produces both all-time and this-year highlights when the session leads both.
- `combineWeightRecords (Comb-6)`: merges this-year 1st with all-time 2nd/3rd; keeps all-time and drops this-year when all-time is a 1st; leaves this-year alone with no all-time placement; matches on extreme; carries joint flags; noop with no this-year weights; no mutation. Plus a full-machine integration test.
- `render — weight-record` (this-year copy) and `render — combined-weight-record` (all six copy variants).
- `npm run qa` green (0 errors); app + integration + e2e suites pass via the git hooks.

### Assumptions
- The "threshold used by the logic that turns on all-time weight highlight generation" is `MIN_WEIGHED_ENCOUNTERS_FOR_RECORD` (3), applied — as the all-time gate is — to the count of weighed birds across *other* days in the year (session excluded). The same constant is reused.
- "Only generate for first placed" = `placementRank === 1` (joint firsts included).
- An all-time **1st** for the same extreme is not combined — the ever record already says everything the year line would, so the plain all-time line stands and the this-year line is dropped.

Closes #386