### PR TITLE
feat: combine second and third best day highlights (#388)

### DIFF
--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -295,6 +295,92 @@ describe('SessionHighlights', () => {
 		]);
 	});
 
+	async function renderSingleHighlight(highlight: SessionHighlight) {
+		const { fetchSessionHighlights } =
+			await import('@/app/actions/session-highlights');
+		vi.mocked(fetchSessionHighlights).mockResolvedValue([highlight]);
+		render(<SessionHighlights date="2024-09-15" viewedGroupId={1} />);
+		await waitFor(() => {
+			expect(screen.getByRole('heading', { name: 'Highlights' })).toBeDefined();
+		});
+		return screen.getByTestId('session-highlights').querySelectorAll('li');
+	}
+
+	function placementHighlight(
+		placementRank: 2 | 3,
+		species: { name: string; isJoint: boolean }[],
+		value?: number
+	): SessionHighlight {
+		return {
+			type: 'combined-species-placement-record',
+			sortValue: familySortValue('scoped-record'),
+			placementRank,
+			species,
+			...(value === undefined ? {} : { value })
+		};
+	}
+
+	it('renders a combined strict 2nd-best placement with its shared count', async () => {
+		const items = await renderSingleHighlight(
+			placementHighlight(
+				2,
+				[
+					{ name: 'Dunnock', isJoint: false },
+					{ name: 'Whitethroat', isJoint: false }
+				],
+				6
+			)
+		);
+		expect(items[0].textContent).toBe(
+			'Second best day for Dunnock and Whitethroat ever — 6 birds'
+		);
+	});
+
+	it('renders a combined all-joint 2nd-best placement without a count', async () => {
+		const items = await renderSingleHighlight(
+			placementHighlight(2, [
+				{ name: 'Dunnock', isJoint: true },
+				{ name: 'Whitethroat', isJoint: true }
+			])
+		);
+		expect(items[0].textContent).toBe(
+			'Joint second best day for Dunnock and Whitethroat ever'
+		);
+	});
+
+	it('renders a mixed 2nd-best placement, flagging the joint species inline', async () => {
+		const items = await renderSingleHighlight(
+			placementHighlight(
+				2,
+				[
+					{ name: 'Dunnock', isJoint: false },
+					{ name: 'Whitethroat', isJoint: true }
+				],
+				6
+			)
+		);
+		expect(items[0].textContent).toBe(
+			'Second best day for Dunnock and (tied second) Whitethroat ever — 6 birds'
+		);
+	});
+
+	it('comma-joins three merged species and phrases the third-best rank', async () => {
+		const items = await renderSingleHighlight(
+			placementHighlight(
+				3,
+				[
+					{ name: 'Dunnock', isJoint: false },
+					{ name: 'Whitethroat', isJoint: false },
+					{ name: 'Wren', isJoint: false }
+				],
+				4
+			)
+		);
+		expect(items[0].textContent).toBe(
+			'Third best day for Dunnock, Whitethroat and Wren ever — 4 birds'
+		);
+	});
+
 	it('renders weight record sentences', async () => {
 		const weightHighlight: SessionHighlight = {
 			type: 'weight-record',

--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -308,31 +308,25 @@ describe('SessionHighlights', () => {
 
 	function placementHighlight(
 		placementRank: 2 | 3,
-		species: { name: string; isJoint: boolean }[],
-		value?: number
+		species: { name: string; isJoint: boolean }[]
 	): SessionHighlight {
 		return {
 			type: 'combined-species-placement-record',
 			sortValue: familySortValue('scoped-record'),
 			placementRank,
-			species,
-			...(value === undefined ? {} : { value })
+			species
 		};
 	}
 
-	it('renders a combined strict 2nd-best placement with its shared count', async () => {
+	it('renders a combined strict 2nd-best placement without a count', async () => {
 		const items = await renderSingleHighlight(
-			placementHighlight(
-				2,
-				[
-					{ name: 'Dunnock', isJoint: false },
-					{ name: 'Whitethroat', isJoint: false }
-				],
-				6
-			)
+			placementHighlight(2, [
+				{ name: 'Dunnock', isJoint: false },
+				{ name: 'Whitethroat', isJoint: false }
+			])
 		);
 		expect(items[0].textContent).toBe(
-			'Second best day for Dunnock and Whitethroat ever — 6 birds'
+			'Second best day for Dunnock and Whitethroat ever'
 		);
 	});
 
@@ -350,34 +344,26 @@ describe('SessionHighlights', () => {
 
 	it('renders a mixed 2nd-best placement, flagging the joint species inline', async () => {
 		const items = await renderSingleHighlight(
-			placementHighlight(
-				2,
-				[
-					{ name: 'Dunnock', isJoint: false },
-					{ name: 'Whitethroat', isJoint: true }
-				],
-				6
-			)
+			placementHighlight(2, [
+				{ name: 'Dunnock', isJoint: false },
+				{ name: 'Whitethroat', isJoint: true }
+			])
 		);
 		expect(items[0].textContent).toBe(
-			'Second best day for Dunnock and (tied second) Whitethroat ever — 6 birds'
+			'Second best day for Dunnock and (tied second) Whitethroat ever'
 		);
 	});
 
 	it('comma-joins three merged species and phrases the third-best rank', async () => {
 		const items = await renderSingleHighlight(
-			placementHighlight(
-				3,
-				[
-					{ name: 'Dunnock', isJoint: false },
-					{ name: 'Whitethroat', isJoint: false },
-					{ name: 'Wren', isJoint: false }
-				],
-				4
-			)
+			placementHighlight(3, [
+				{ name: 'Dunnock', isJoint: false },
+				{ name: 'Whitethroat', isJoint: false },
+				{ name: 'Wren', isJoint: false }
+			])
 		);
 		expect(items[0].textContent).toBe(
-			'Third best day for Dunnock, Whitethroat and Wren ever — 4 birds'
+			'Third best day for Dunnock, Whitethroat and Wren ever'
 		);
 	});
 

--- a/app/components/session-highlight-renderers.tsx
+++ b/app/components/session-highlight-renderers.tsx
@@ -7,6 +7,7 @@ import type {
 	CombinedOnlyOfYearHighlight,
 	CombinedSessionTotalRecordHighlight,
 	CombinedSpeciesCountRecordHighlight,
+	CombinedSpeciesPlacementRecordHighlight,
 	CombinedWeightRecordHighlight,
 	FirstEverSpeciesHighlight,
 	FirstOfYearSpeciesHighlight,
@@ -161,6 +162,41 @@ function buildCombinedSpeciesCountRecordSentence(
 ): string {
 	const speciesList = buildSpeciesList(highlight.speciesNames);
 	return `Highest ${speciesList} counts ${buildOfYearPhrase(highlight)}`;
+}
+
+const PLACEMENT_RANK_WORD: Record<2 | 3, string> = {
+	2: 'second best',
+	3: 'third best'
+};
+const PLACEMENT_TIED_WORD: Record<2 | 3, string> = {
+	2: 'tied second',
+	3: 'tied third'
+};
+
+// "Second best day for Dunnock and Whitethroat ever — 6 birds" and its variants:
+// several all-time 2nd/3rd-best species records folded into one line. An all-joint
+// group leads with "Joint" and drops the count; a mixed group leads plain and flags
+// each joint species inline ("(tied second) Whitethroat"); the count only shows when
+// every part agreed on it (carried on the highlight, absent otherwise).
+function buildCombinedSpeciesPlacementRecordSentence(
+	highlight: CombinedSpeciesPlacementRecordHighlight
+): string {
+	const { placementRank, species, value } = highlight;
+	const rankWord = PLACEMENT_RANK_WORD[placementRank];
+	const allJoint = species.every((entry) => entry.isJoint);
+	const descriptor = allJoint
+		? `Joint ${rankWord} day`
+		: `${rankWord[0].toUpperCase()}${rankWord.slice(1)} day`;
+	const tiedWord = PLACEMENT_TIED_WORD[placementRank];
+	// An all-joint group's "Joint" prefix covers every species, so no inline flags;
+	// a mixed group flags only the joint species, leaving the strict ones bare.
+	const speciesNames = allJoint
+		? species.map((entry) => entry.name)
+		: species.map((entry) =>
+				entry.isJoint ? `(${tiedWord}) ${entry.name}` : entry.name
+			);
+	const sentence = `${descriptor} for ${buildSpeciesList(speciesNames)} ever`;
+	return value === undefined ? sentence : `${sentence} — ${value} birds`;
 }
 
 function buildSpeciesCountRecordSentence(
@@ -393,7 +429,9 @@ const HIGHLIGHT_RENDERERS: {
 	'combined-first-of-year': (highlight) =>
 		renderSentence(buildCombinedFirstOfYearSentence(highlight)),
 	'combined-species-count-record': (highlight) =>
-		renderSentence(buildCombinedSpeciesCountRecordSentence(highlight))
+		renderSentence(buildCombinedSpeciesCountRecordSentence(highlight)),
+	'combined-species-placement-record': (highlight) =>
+		renderSentence(buildCombinedSpeciesPlacementRecordSentence(highlight))
 };
 
 export function renderHighlight(highlight: SessionHighlight): ReactElement {

--- a/app/components/session-highlight-renderers.tsx
+++ b/app/components/session-highlight-renderers.tsx
@@ -173,15 +173,15 @@ const PLACEMENT_TIED_WORD: Record<2 | 3, string> = {
 	3: 'tied third'
 };
 
-// "Second best day for Dunnock and Whitethroat ever — 6 birds" and its variants:
-// several all-time 2nd/3rd-best species records folded into one line. An all-joint
-// group leads with "Joint" and drops the count; a mixed group leads plain and flags
-// each joint species inline ("(tied second) Whitethroat"); the count only shows when
-// every part agreed on it (carried on the highlight, absent otherwise).
+// "Second best day for Dunnock and Whitethroat ever" and its variants: several
+// all-time 2nd/3rd-best species records folded into one line. A combined line
+// never shows a count (only a lone unmerged placement does). An all-joint group
+// leads with "Joint"; a mixed group leads plain and flags each joint species
+// inline ("(tied second) Whitethroat").
 function buildCombinedSpeciesPlacementRecordSentence(
 	highlight: CombinedSpeciesPlacementRecordHighlight
 ): string {
-	const { placementRank, species, value } = highlight;
+	const { placementRank, species } = highlight;
 	const rankWord = PLACEMENT_RANK_WORD[placementRank];
 	const allJoint = species.every((entry) => entry.isJoint);
 	const descriptor = allJoint
@@ -195,8 +195,7 @@ function buildCombinedSpeciesPlacementRecordSentence(
 		: species.map((entry) =>
 				entry.isJoint ? `(${tiedWord}) ${entry.name}` : entry.name
 			);
-	const sentence = `${descriptor} for ${buildSpeciesList(speciesNames)} ever`;
-	return value === undefined ? sentence : `${sentence} — ${value} birds`;
+	return `${descriptor} for ${buildSpeciesList(speciesNames)} ever`;
 }
 
 function buildSpeciesCountRecordSentence(

--- a/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
+++ b/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
@@ -717,7 +717,7 @@ describe('combineSpeciesPlacementRecords (Comb-4)', () => {
 		expect(combineSpeciesPlacementRecords([lone])).toEqual([lone]);
 	});
 
-	it('merges two strict 2nd-best records, keeping a shared count', () => {
+	it('merges two strict 2nd-best records into a countless line', () => {
 		const combined = combineSpeciesPlacementRecords([
 			secondBest('Dunnock', 6),
 			secondBest('Whitethroat', 6)
@@ -733,13 +733,14 @@ describe('combineSpeciesPlacementRecords (Comb-4)', () => {
 				species: [
 					{ name: 'Dunnock', isJoint: false },
 					{ name: 'Whitethroat', isJoint: false }
-				],
-				value: 6
+				]
 			}
 		]);
+		// A combined line never carries a count, even when the parts agree on it
+		expect(combined[0]).not.toHaveProperty('value');
 	});
 
-	it('drops the count when every merged placement is joint', () => {
+	it('carries each species joint flag through the merge', () => {
 		const combined = combineSpeciesPlacementRecords([
 			secondBest('Dunnock', 6, true),
 			secondBest('Whitethroat', 6, true)
@@ -760,7 +761,7 @@ describe('combineSpeciesPlacementRecords (Comb-4)', () => {
 		]);
 	});
 
-	it('flags each joint species and keeps the shared count in a mixed group', () => {
+	it('flags each joint species in a mixed group, still without a count', () => {
 		const combined = combineSpeciesPlacementRecords([
 			secondBest('Dunnock', 6, false),
 			secondBest('Whitethroat', 6, true)
@@ -772,13 +773,13 @@ describe('combineSpeciesPlacementRecords (Comb-4)', () => {
 				species: [
 					{ name: 'Dunnock', isJoint: false },
 					{ name: 'Whitethroat', isJoint: true }
-				],
-				value: 6
+				]
 			})
 		]);
+		expect(combined[0]).not.toHaveProperty('value');
 	});
 
-	it('drops the count when merged placements disagree on it', () => {
+	it('drops the count even when merged placements disagree on it', () => {
 		const combined = combineSpeciesPlacementRecords([
 			secondBest('Dunnock', 6),
 			secondBest('Blue Tit', 15)

--- a/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
+++ b/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
@@ -4,6 +4,7 @@ import {
 	combineFirstOfYearHighlights,
 	combineOnlyOfYearHighlights,
 	combineSessionTotalRecords,
+	combineSpeciesPlacementRecords,
 	combineWeightRecords,
 	combineYearSpeciesCounts,
 	orderBySortValue,
@@ -689,7 +690,184 @@ describe('combineYearSpeciesCounts (Comb-3)', () => {
 	});
 });
 
-describe('combineFirstEverHighlights (Comb-4)', () => {
+describe('combineSpeciesPlacementRecords (Comb-4)', () => {
+	// Shorthands for all-time 2nd/3rd best-day placement records
+	function secondBest(
+		speciesName: string,
+		value: number,
+		isJointPlacement = false
+	): SpeciesCountRecordHighlight {
+		return speciesCountRecord(speciesName, 'all-time', value, {
+			placementRank: 2,
+			isJointPlacement
+		});
+	}
+	function thirdBest(
+		speciesName: string,
+		value: number
+	): SpeciesCountRecordHighlight {
+		return speciesCountRecord(speciesName, 'all-time', value, {
+			placementRank: 3,
+			isJointPlacement: false
+		});
+	}
+
+	it('leaves a lone placement record unchanged', () => {
+		const lone = secondBest('Dunnock', 6);
+		expect(combineSpeciesPlacementRecords([lone])).toEqual([lone]);
+	});
+
+	it('merges two strict 2nd-best records, keeping a shared count', () => {
+		const combined = combineSpeciesPlacementRecords([
+			secondBest('Dunnock', 6),
+			secondBest('Whitethroat', 6)
+		]);
+		expect(combined).toEqual([
+			{
+				type: 'combined-species-placement-record',
+				sortValue: combinedSortValue([
+					secondBest('Dunnock', 6),
+					secondBest('Whitethroat', 6)
+				]),
+				placementRank: 2,
+				species: [
+					{ name: 'Dunnock', isJoint: false },
+					{ name: 'Whitethroat', isJoint: false }
+				],
+				value: 6
+			}
+		]);
+	});
+
+	it('drops the count when every merged placement is joint', () => {
+		const combined = combineSpeciesPlacementRecords([
+			secondBest('Dunnock', 6, true),
+			secondBest('Whitethroat', 6, true)
+		]);
+		expect(combined).toEqual([
+			{
+				type: 'combined-species-placement-record',
+				sortValue: combinedSortValue([
+					secondBest('Dunnock', 6, true),
+					secondBest('Whitethroat', 6, true)
+				]),
+				placementRank: 2,
+				species: [
+					{ name: 'Dunnock', isJoint: true },
+					{ name: 'Whitethroat', isJoint: true }
+				]
+			}
+		]);
+	});
+
+	it('flags each joint species and keeps the shared count in a mixed group', () => {
+		const combined = combineSpeciesPlacementRecords([
+			secondBest('Dunnock', 6, false),
+			secondBest('Whitethroat', 6, true)
+		]);
+		expect(combined).toEqual([
+			expect.objectContaining({
+				type: 'combined-species-placement-record',
+				placementRank: 2,
+				species: [
+					{ name: 'Dunnock', isJoint: false },
+					{ name: 'Whitethroat', isJoint: true }
+				],
+				value: 6
+			})
+		]);
+	});
+
+	it('drops the count when merged placements disagree on it', () => {
+		const combined = combineSpeciesPlacementRecords([
+			secondBest('Dunnock', 6),
+			secondBest('Blue Tit', 15)
+		]);
+		expect(combined).toEqual([
+			expect.objectContaining({
+				type: 'combined-species-placement-record',
+				species: [
+					{ name: 'Dunnock', isJoint: false },
+					{ name: 'Blue Tit', isJoint: false }
+				]
+			})
+		]);
+		expect(combined[0]).not.toHaveProperty('value');
+	});
+
+	it('merges 2nd- and 3rd-best records into separate lines', () => {
+		const combined = combineSpeciesPlacementRecords([
+			secondBest('Dunnock', 6),
+			secondBest('Whitethroat', 6),
+			thirdBest('Wren', 4),
+			thirdBest('Robin', 4)
+		]);
+		expect(
+			combined.map((highlight) =>
+				highlight.type === 'combined-species-placement-record'
+					? [highlight.type, highlight.placementRank]
+					: [highlight.type]
+			)
+		).toEqual([
+			['combined-species-placement-record', 2],
+			['combined-species-placement-record', 3]
+		]);
+	});
+
+	it('lists three merged species in source order', () => {
+		const combined = combineSpeciesPlacementRecords([
+			secondBest('Dunnock', 6),
+			secondBest('Whitethroat', 6),
+			secondBest('Blackcap', 6)
+		]);
+		expect(combined).toEqual([
+			expect.objectContaining({
+				species: [
+					{ name: 'Dunnock', isJoint: false },
+					{ name: 'Whitethroat', isJoint: false },
+					{ name: 'Blackcap', isJoint: false }
+				]
+			})
+		]);
+	});
+
+	it('takes the list position of the first record of its rank', () => {
+		const combined = combineSpeciesPlacementRecords([
+			secondBest('Dunnock', 6),
+			weightRecord,
+			secondBest('Whitethroat', 6)
+		]);
+		expect(combined.map((highlight) => highlight.type)).toEqual([
+			'combined-species-placement-record',
+			'weight-record'
+		]);
+	});
+
+	it('never merges strict records, this-year records or record-equalling ties', () => {
+		const strictRecord = speciesCountRecord('Reed Warbler', 'all-time', 30);
+		const thisYear = speciesCountRecord('Chiffchaff', 'this-year', 5);
+		const jointFirst = speciesCountRecord('Blackcap', 'all-time', 24, {
+			placementRank: 1,
+			isJointPlacement: true
+		});
+		const pool = [strictRecord, thisYear, jointFirst];
+		expect(combineSpeciesPlacementRecords(pool)).toEqual(pool);
+	});
+
+	it('is a noop on unrelated highlights', () => {
+		const pool = [rareSpecies, weightRecord];
+		expect(combineSpeciesPlacementRecords(pool)).toEqual(pool);
+	});
+
+	it('does not mutate the input list', () => {
+		const pool = [secondBest('Dunnock', 6), secondBest('Whitethroat', 6)];
+		const snapshot = [...pool];
+		combineSpeciesPlacementRecords(pool);
+		expect(pool).toEqual(snapshot);
+	});
+});
+
+describe('combineFirstEverHighlights (Comb-5)', () => {
 	it('leaves a single first-ever highlight unchanged', () => {
 		const only = firstEver('Firecrest', false);
 		expect(combineFirstEverHighlights([only])).toEqual([only]);
@@ -791,7 +969,7 @@ describe('combineFirstEverHighlights (Comb-4)', () => {
 	});
 });
 
-describe('combineFirstOfYearHighlights (Comb-5)', () => {
+describe('combineFirstOfYearHighlights (Comb-6)', () => {
 	it('leaves a single first-of-year highlight unchanged', () => {
 		const only = firstOfYear('Robin', false);
 		expect(combineFirstOfYearHighlights([only])).toEqual([only]);
@@ -887,7 +1065,7 @@ describe('combineFirstOfYearHighlights (Comb-5)', () => {
 	});
 });
 
-describe('combineWeightRecords (Comb-6)', () => {
+describe('combineWeightRecords (Comb-7)', () => {
 	// weightRecord is a Blue Tit heaviest all-time 1st; build the pieces from it
 	const heaviestThisYear: WeightRecordHighlight = {
 		...weightRecord,
@@ -1103,6 +1281,44 @@ describe('runHighlightMachine', () => {
 			// first-ever (0.8 + 0.2 = 1.0) above first-of-year (0.6 + 0.1 = 0.7)
 			['combined-first-ever', "Blackbird+Blackcap+Cetti's Warbler"],
 			['combined-first-of-year', 'Chiffchaff+Whitethroat'],
+			['weight-record']
+		]);
+	});
+
+	it('folds several 2nd/3rd best-day placements into one line per rank', () => {
+		const pool: SessionHighlight[] = [
+			speciesCountRecord('Dunnock', 'all-time', 6, {
+				placementRank: 2,
+				isJointPlacement: false
+			}),
+			speciesCountRecord('Whitethroat', 'all-time', 6, {
+				placementRank: 2,
+				isJointPlacement: true
+			}),
+			speciesCountRecord('Wren', 'all-time', 4, {
+				placementRank: 3,
+				isJointPlacement: false
+			}),
+			speciesCountRecord('Robin', 'all-time', 4, {
+				placementRank: 3,
+				isJointPlacement: false
+			}),
+			weightRecord
+		];
+		const machined = runHighlightMachine(pool);
+		expect(
+			machined.map((highlight) =>
+				highlight.type === 'combined-species-placement-record'
+					? [
+							highlight.type,
+							highlight.placementRank,
+							highlight.species.map((entry) => entry.name).join('+')
+						]
+					: [highlight.type]
+			)
+		).toEqual([
+			['combined-species-placement-record', 2, 'Dunnock+Whitethroat'],
+			['combined-species-placement-record', 3, 'Wren+Robin'],
 			['weight-record']
 		]);
 	});

--- a/app/models/highlight-refinement-machine/combine-first-ever-highlights.ts
+++ b/app/models/highlight-refinement-machine/combine-first-ever-highlights.ts
@@ -11,7 +11,7 @@ function isFirstEver(
 	return highlight.type === 'first-ever-species' && !highlight.isOnlyRecord;
 }
 
-// Comb-4: multiple "First ever <species> record(s)" highlights merge into one
+// Comb-5: multiple "First ever <species> record(s)" highlights merge into one
 // "First ever A, B and C records" line listing every species. One first-ever
 // highlight is left as-is; "Only <species> records ever" (isOnlyRecord)
 // highlights are never merged. The combined line always reads "records" (plural)

--- a/app/models/highlight-refinement-machine/combine-first-of-year-highlights.ts
+++ b/app/models/highlight-refinement-machine/combine-first-of-year-highlights.ts
@@ -11,7 +11,7 @@ function isFirstOfYear(
 	return highlight.type === 'first-of-year-species' && !highlight.isOnlyRecord;
 }
 
-// Comb-5: multiple "First <species> record(s) of the year" highlights merge into
+// Comb-6: multiple "First <species> record(s) of the year" highlights merge into
 // one "First A, B and C records of the year" line listing every species. One
 // first-of-year highlight is left as-is; "Only ... of the year" (isOnlyRecord)
 // highlights combine separately (Comb-2). The combined line always reads

--- a/app/models/highlight-refinement-machine/combine-species-placement-records.ts
+++ b/app/models/highlight-refinement-machine/combine-species-placement-records.ts
@@ -1,0 +1,88 @@
+import {
+	combinedSortValue,
+	type CombinedSpeciesPlacementRecordHighlight,
+	type SessionHighlight,
+	type SpeciesCountRecordHighlight
+} from '@/app/models/session-highlights';
+
+// An all-time species-count record that placed 2nd or 3rd — the "Second/Third
+// best day for X ever" lines. Strict records, "record-equalling" all-time ties
+// (placementRank 1) and this-year records are excluded: only genuine 2nd/3rd
+// placements merge here.
+type PlacementRecord = SpeciesCountRecordHighlight & { placementRank: 2 | 3 };
+
+function isPlacementRecord(
+	highlight: SessionHighlight
+): highlight is PlacementRecord {
+	return (
+		highlight.type === 'species-count-record' &&
+		(highlight.placementRank === 2 || highlight.placementRank === 3)
+	);
+}
+
+// Merges one rank's placements into a single line. The count survives only when
+// every part shares it and the group isn't all-joint: an all-joint group drops
+// the count (each part could sit against a different tied value), a mixed or
+// all-strict group keeps a count the whole list agrees on.
+function combinePlacementGroup(
+	group: PlacementRecord[]
+): CombinedSpeciesPlacementRecordHighlight {
+	const allJoint = group.every((record) => record.isJointPlacement === true);
+	const [firstValue] = group.map((record) => record.value);
+	const sharedValue = group.every((record) => record.value === firstValue)
+		? firstValue
+		: undefined;
+	return {
+		type: 'combined-species-placement-record',
+		sortValue: combinedSortValue(group),
+		placementRank: group[0].placementRank,
+		species: group.map((record) => ({
+			name: record.speciesName,
+			isJoint: record.isJointPlacement === true
+		})),
+		...(!allJoint && sharedValue !== undefined ? { value: sharedValue } : {})
+	};
+}
+
+// Comb: multiple all-time "Second/Third best day for <species> ever" records
+// merge into one line per rank — "Second best day for A and B ever — N birds".
+// 2nd-best and 3rd-best records merge separately (a rank never mixes with the
+// other), and a rank with only one placement is left unchanged. Each combined
+// line takes the position of the first record of its rank.
+export function combineSpeciesPlacementRecords(
+	highlights: SessionHighlight[]
+): SessionHighlight[] {
+	const groupByRank = new Map<2 | 3, PlacementRecord[]>();
+	for (const highlight of highlights) {
+		if (!isPlacementRecord(highlight)) continue;
+		const group = groupByRank.get(highlight.placementRank) ?? [];
+		group.push(highlight);
+		groupByRank.set(highlight.placementRank, group);
+	}
+	// Only ranks holding at least two placements merge
+	const mergingRanks = new Set(
+		[...groupByRank]
+			.filter(([, group]) => group.length >= 2)
+			.map(([rank]) => rank)
+	);
+	if (mergingRanks.size === 0) return highlights;
+
+	const insertedRanks = new Set<2 | 3>();
+	const result: SessionHighlight[] = [];
+	for (const highlight of highlights) {
+		if (
+			isPlacementRecord(highlight) &&
+			mergingRanks.has(highlight.placementRank)
+		) {
+			// Emit the combined line in place of the rank's first record; drop the rest
+			if (insertedRanks.has(highlight.placementRank)) continue;
+			insertedRanks.add(highlight.placementRank);
+			result.push(
+				combinePlacementGroup(groupByRank.get(highlight.placementRank)!)
+			);
+			continue;
+		}
+		result.push(highlight);
+	}
+	return result;
+}

--- a/app/models/highlight-refinement-machine/combine-species-placement-records.ts
+++ b/app/models/highlight-refinement-machine/combine-species-placement-records.ts
@@ -20,18 +20,12 @@ function isPlacementRecord(
 	);
 }
 
-// Merges one rank's placements into a single line. The count survives only when
-// every part shares it and the group isn't all-joint: an all-joint group drops
-// the count (each part could sit against a different tied value), a mixed or
-// all-strict group keeps a count the whole list agrees on.
+// Merges one rank's placements into a single line. A combined line never carries
+// a count — the merged species can differ on it, so the per-species count is only
+// meaningful on a lone unmerged placement.
 function combinePlacementGroup(
 	group: PlacementRecord[]
 ): CombinedSpeciesPlacementRecordHighlight {
-	const allJoint = group.every((record) => record.isJointPlacement === true);
-	const [firstValue] = group.map((record) => record.value);
-	const sharedValue = group.every((record) => record.value === firstValue)
-		? firstValue
-		: undefined;
 	return {
 		type: 'combined-species-placement-record',
 		sortValue: combinedSortValue(group),
@@ -39,16 +33,16 @@ function combinePlacementGroup(
 		species: group.map((record) => ({
 			name: record.speciesName,
 			isJoint: record.isJointPlacement === true
-		})),
-		...(!allJoint && sharedValue !== undefined ? { value: sharedValue } : {})
+		}))
 	};
 }
 
-// Comb: multiple all-time "Second/Third best day for <species> ever" records
-// merge into one line per rank — "Second best day for A and B ever — N birds".
-// 2nd-best and 3rd-best records merge separately (a rank never mixes with the
-// other), and a rank with only one placement is left unchanged. Each combined
-// line takes the position of the first record of its rank.
+// Comb-4: multiple all-time "Second/Third best day for <species> ever" records
+// merge into one line per rank — "Second best day for A and B ever" (the count
+// is dropped; only a lone unmerged placement keeps its "— N birds"). 2nd-best
+// and 3rd-best records merge separately (a rank never mixes with the other), and
+// a rank with only one placement is left unchanged. Each combined line takes the
+// position of the first record of its rank.
 export function combineSpeciesPlacementRecords(
 	highlights: SessionHighlight[]
 ): SessionHighlight[] {

--- a/app/models/highlight-refinement-machine/combine-weight-records.ts
+++ b/app/models/highlight-refinement-machine/combine-weight-records.ts
@@ -11,7 +11,7 @@ function isWeightRecord(
 	return highlight.type === 'weight-record';
 }
 
-// Comb-6: reconcile a species' this-year and all-time weight records for the
+// Comb-7: reconcile a species' this-year and all-time weight records for the
 // same extreme. Derivation emits a this-year weight only for an outright leader
 // (a 1st place), so every this-year weight is a "heaviest/lightest of the year".
 // When the same species+extreme also holds an all-time placement:

--- a/app/models/highlight-refinement-machine/index.ts
+++ b/app/models/highlight-refinement-machine/index.ts
@@ -7,6 +7,7 @@ import { combineOnlyOfYearHighlights } from './combine-only-of-year-highlights';
 import { combineFirstEverHighlights } from './combine-first-ever-highlights';
 import { combineFirstOfYearHighlights } from './combine-first-of-year-highlights';
 import { combineYearSpeciesCounts } from './combine-year-species-counts';
+import { combineSpeciesPlacementRecords } from './combine-species-placement-records';
 import { combineWeightRecords } from './combine-weight-records';
 import { orderBySortValue } from './order-by-sort-value';
 
@@ -18,6 +19,7 @@ export { combineOnlyOfYearHighlights } from './combine-only-of-year-highlights';
 export { combineFirstEverHighlights } from './combine-first-ever-highlights';
 export { combineFirstOfYearHighlights } from './combine-first-of-year-highlights';
 export { combineYearSpeciesCounts } from './combine-year-species-counts';
+export { combineSpeciesPlacementRecords } from './combine-species-placement-records';
 export { combineWeightRecords } from './combine-weight-records';
 export { orderBySortValue } from './order-by-sort-value';
 
@@ -37,9 +39,10 @@ const RULES: HighlightRule[] = [
 	combineSessionTotalRecords, // Comb-1
 	combineOnlyOfYearHighlights, // Comb-2
 	combineYearSpeciesCounts, // Comb-3
-	combineFirstEverHighlights, // Comb-4
-	combineFirstOfYearHighlights, // Comb-5
-	combineWeightRecords, // Comb-6
+	combineSpeciesPlacementRecords, // Comb-4
+	combineFirstEverHighlights, // Comb-5
+	combineFirstOfYearHighlights, // Comb-6
+	combineWeightRecords, // Comb-7
 	orderBySortValue // Ord-1
 ];
 

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -376,12 +376,13 @@ export type CombinedSpeciesCountRecordHighlight = {
 
 // Multiple all-time 2nd- or 3rd-best-day species-count records that share a
 // placement rank, merged by the machine's combine pass into one line listing
-// every species — "Second best day for Dunnock and Whitethroat ever — 6 birds".
-// Only the all-time placements merge (this-year records combine separately); 1st
-// places and record-equalling ties are never included. The count shows only when
-// every part shares the same value and the group isn't all-joint — an all-joint
-// group leads with "Joint" and drops the count, while a mixed group leads plain
-// and flags each joint species inline ("(tied second) Whitethroat").
+// every species — "Second best day for Dunnock and Whitethroat ever". Only the
+// all-time placements merge (this-year records combine separately); 1st places
+// and record-equalling ties are never included. A combined line never carries a
+// count (the merged species may differ on it) — the per-species count survives
+// only on a single, unmerged placement. An all-joint group leads with "Joint",
+// while a mixed group leads plain and flags each joint species inline ("(tied
+// second) Whitethroat").
 export type CombinedSpeciesPlacementRecordHighlight = {
 	type: 'combined-species-placement-record';
 	sortValue: SortValue;
@@ -390,9 +391,6 @@ export type CombinedSpeciesPlacementRecordHighlight = {
 	// Each merged species with its own joint flag, in the order the source
 	// highlights appeared
 	species: { name: string; isJoint: boolean }[];
-	// The shared bird count, present only when every part has the same count and
-	// the group is not all-joint; omitted when the count is discarded
-	value?: number;
 };
 
 // A this-year weight record (always a 1st place) merged with the same species'

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -374,6 +374,27 @@ export type CombinedSpeciesCountRecordHighlight = {
 	isCurrentYear: boolean;
 };
 
+// Multiple all-time 2nd- or 3rd-best-day species-count records that share a
+// placement rank, merged by the machine's combine pass into one line listing
+// every species — "Second best day for Dunnock and Whitethroat ever — 6 birds".
+// Only the all-time placements merge (this-year records combine separately); 1st
+// places and record-equalling ties are never included. The count shows only when
+// every part shares the same value and the group isn't all-joint — an all-joint
+// group leads with "Joint" and drops the count, while a mixed group leads plain
+// and flags each joint species inline ("(tied second) Whitethroat").
+export type CombinedSpeciesPlacementRecordHighlight = {
+	type: 'combined-species-placement-record';
+	sortValue: SortValue;
+	// The shared placement rank of every merged species (2nd or 3rd best)
+	placementRank: 2 | 3;
+	// Each merged species with its own joint flag, in the order the source
+	// highlights appeared
+	species: { name: string; isJoint: boolean }[];
+	// The shared bird count, present only when every part has the same count and
+	// the group is not all-joint; omitted when the count is discarded
+	value?: number;
+};
+
 // A this-year weight record (always a 1st place) merged with the same species'
 // all-time placement for the *same* extreme, when that all-time placement is a
 // 2nd/3rd (a lesser record that the year headline sits on top of). Rendered as a
@@ -421,6 +442,7 @@ export type SessionHighlight =
 	| CombinedFirstEverHighlight
 	| CombinedFirstOfYearHighlight
 	| CombinedSpeciesCountRecordHighlight
+	| CombinedSpeciesPlacementRecordHighlight
 	| CombinedWeightRecordHighlight;
 
 type DayTotals = {


### PR DESCRIPTION
## What this covers

Implements [#388](https://github.com/wheresrhys/totf/issues/388): fold multiple all-time "Second/Third best day for X ever" species-count records into a single line per placement rank.

New machine rule **`combineSpeciesPlacementRecords`** (Comb-4), a new `CombinedSpeciesPlacementRecordHighlight` type, and its renderer.

| Input (2+ records merged) | Output |
|---|---|
| Two strict 2nd-bests | `Second best day for Dunnock and Whitethroat ever` |
| Two joint 2nd-bests | `Joint second best day for Dunnock and Whitethroat ever` |
| Mixed (one strict, one joint) | `Second best day for Dunnock and (tied second) Whitethroat ever` |
| 3+ species | comma-joined: `... Dunnock, Whitethroat and Wren ...` |
| **Single, unmerged** 2nd-best | keeps its count: `Second best day for Dunnock ever — 6 birds` |

**Count rule:** a combined line never shows a count (the merged species can differ on it). The `— N birds` count survives only on a single, unmerged placement — handled by the existing standalone `species-count-record` renderer.

2nd-best and 3rd-best records merge into **separate** lines (a rank never mixes with the other). The rule shifts the numbering of the following combine rules (First-ever → Comb-5, First-of-year → Comb-6, Weight → Comb-7).

## Design decisions / assumptions (subagent mode)

- **Joint annotation is a prefix `(tied second) X`**, matching the ticket's exact wording (`Dunnock and (tied second) Whitethroat`), not a suffix.
- **Scope: encounter-count records only.** Juvenile placement records (`species-juv-count-record`) share the same shape but the ticket only references species counts; left out per YAGNI. Easy to extend later if wanted.
- **Only genuine 2nd/3rd placements merge** — strict all-time records, "record-equalling" all-time ties (placementRank 1) and this-year records are excluded. (Joint 3rds never exist — derivation suppresses them.)
- **Ordering between the combined 2nd- and 3rd-best lines** follows existing behaviour: individual placements already share one sortValue, so relative order is insertion order. Not changed here.

## Tests (all green — `npm run qa`, 543 passed)

- `combineSpeciesPlacementRecords` unit block: lone record noop, strict merge (no count), joint flags carried through, mixed group flags joints, count dropped even when parts disagree, 2nd/3rd separate lines, 3-species order, list position, never-merge exclusions, noop, no-mutation.
- Full-machine test folding 2nd + 3rd placements end to end.
- Renderer/component tests asserting the exact copy for every variant (all-strict, all-joint, mixed, comma/third-best) — none carry a count.

Closes #388