### PR TITLE
fix: report first-of-year species on the first session of the year

### DIFF
--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -156,11 +156,14 @@ describe('fetchSessionHighlights', () => {
 		// Robin is a rare species here (seen on only 2 days ever), so the machine's
 		// rare-species suppression (Rem-3) drops Robin's own count/weight lines
 		// (its species record). Session-wide records — busiest session, quietest
-		// since — are not tied to the rare species and survive.
+		// since — are not tied to the rare species and survive. This is also the
+		// first session of 2024 (the only prior session is 2022), so Robin — last
+		// seen in 2022 — is first of the year; that trailing line survives too.
 		expect(sentencesOf(highlights)).toEqual([
 			'Rarely recorded — Robin seen on only 2 days ever',
 			'Busiest session ever — 74 birds',
-			'Quietest session since 1 May 2022 — 74 birds'
+			'Quietest session since 1 May 2022 — 74 birds',
+			'Only Robin records of 2024'
 		]);
 	});
 

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -1519,14 +1519,25 @@ describe('deriveFirstOfYearSpecies', () => {
 		]);
 	});
 
-	it("returns empty for the group's first session of the year", () => {
-		// Prior sessions exist, but none this year — every species would be
-		// first of the year, so suppress all
+	it("reports first-of-year species on the group's first session of the year", () => {
+		// Prior sessions exist, but none this year — the first session of the
+		// year is the spring-arrival roll-call, so returning species are still
+		// reported (the combine rule collapses a long list into one line)
 		const highlights = deriveFirstOfYear([
 			speciesRow(SESSION_DATE, FIRECREST, 1),
 			speciesRow(PRIOR_SUMMER_OTHER_YEAR, FIRECREST, 2)
 		]);
-		expect(highlights).toEqual([]);
+		expect(highlights).toEqual([
+			{
+				type: 'first-of-year-species',
+				sortValue: familySortValue('first-of-year-species'),
+				speciesName: FIRECREST,
+				year: 2024,
+				isCurrentYear: false,
+				multipleIndividualsRecorded: false,
+				isOnlyRecord: true
+			}
+		]);
 	});
 
 	it('returns empty when every species was already seen this year', () => {

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -1012,9 +1012,11 @@ export function deriveFirstEverSpecies({
 
 // Returns a highlight for each species seen for the first time this calendar
 // year on this session. First-ever species are excluded (the broader
-// first-ever highlight covers them), and the group's first session of the
-// year is suppressed entirely (every species would trivially be first of
-// the year).
+// first-ever highlight covers them). The first session of the year is the
+// spring-arrival roll-call — every returning species is genuinely first of the
+// year there, so those highlights are kept, not suppressed; the combine rule
+// collapses the resulting list into a single "First A, B and C of the year"
+// line.
 export function deriveFirstOfYearSpecies({
 	date,
 	stats,
@@ -1029,11 +1031,6 @@ export function deriveFirstOfYearSpecies({
 	);
 	if (sessionRows.length === 0) return [];
 	const yearPrefix = `${date.slice(0, 4)}-`;
-	// Suppress on the group's first session of the year
-	const priorSessionDatesThisYear = stats.sessionDates.filter(
-		(sessionDate) => sessionDate.startsWith(yearPrefix) && sessionDate < date
-	);
-	if (priorSessionDatesThisYear.length === 0) return [];
 	const year = Number(date.slice(0, 4));
 	return sessionRows
 		.filter((sessionRow) => {


### PR DESCRIPTION
## What this covers

Fixes [#389](https://github.com/wheresrhys/totf/issues/389): the first session of any year showed no "first of the year" highlights (e.g. https://totf-blue.vercel.app/group/1/session/2023-04-15).

## Root cause

`deriveFirstOfYearSpecies` (`app/models/session-highlights.ts`) began with a whole-session guard that returned `[]` whenever the group had no prior session in the session's year — i.e. on the first session of the year. The rationale (from the original feature) was that "every species would trivially qualify". But:

- The first session of the year is precisely the spring-arrival roll-call; a returning species caught there is genuinely its first record of the year — exactly the highlight ringers care about.
- The per-species filter directly below already excludes first-ever species (`priorDates.length > 0`), so only genuine returning species qualify.
- The combine rule (`combine-first-of-year-highlights`) already collapses a long list into a single "First A, B and C of the year" line, so there was no wall-of-highlights problem to suppress.

The fix removes the whole-session suppression; the per-species logic and combine rule do the rest.

## Changes

- `app/models/session-highlights.ts` — drop the first-session-of-year suppression block; update the doc comment.
- `app/models/__tests__/session-highlights.test.ts` — the "returns empty for the group's first session of the year" test now asserts the first-of-year highlight is produced.
- `app/actions/__tests__/session-highlights.test.ts` — the end-to-end `fetchSessionHighlights` fixture (whose session is the first of its year) now surfaces the extra "Only Robin records of 2024" line; expectation and comment updated.

## Assumptions (subagent mode)

- The ticket's intent is to restore first-of-year highlights on the first session of the year, rather than to keep them suppressed. This is an editorial call; the combine rule keeps the output compact, and first-of-year is a trailing (low-priority) family so it never dominates.
- No change was made to the rare-species suppression rule: a rare species that is also first-of-year keeps both lines (different families). Left as-is to stay within the ticket's scope.

## Testing

`npm run qa` (lint + type-check + 543 app tests) passes. The action test drives the full fetch → derive → machine → render pipeline and confirms the new line appears.

Closes #389