### PR TITLE
feat: combine first/only and rarely-recorded highlights into a MEGA

### DIFF
--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -158,12 +158,13 @@ describe('fetchSessionHighlights', () => {
 		// (its species record). Session-wide records — busiest session, quietest
 		// since — are not tied to the rare species and survive. This is also the
 		// first session of 2024 (the only prior session is 2022), so Robin — last
-		// seen in 2022 — is first of the year; that trailing line survives too.
+		// seen in 2022 — is first (in fact only) of the year. That "only of year"
+		// line and Robin's rare-species line fold together (Comb-0) into a single
+		// MEGA headline that leads the list.
 		expect(sentencesOf(highlights)).toEqual([
-			'Rarely recorded — Robin seen on only 2 days ever',
+			'MEGA — Only Robin records of 2024 (only 2 records ever)',
 			'Busiest session ever — 74 birds',
-			'Quietest session since 1 May 2022 — 74 birds',
-			'Only Robin records of 2024'
+			'Quietest session since 1 May 2022 — 74 birds'
 		]);
 	});
 
@@ -277,14 +278,16 @@ describe('fetchSessionHighlights', () => {
 	});
 
 	it('includes rare-species highlights in the fan-out', async () => {
+		// Both Firecrest days fall in the session's year, so it is not first of the
+		// year — the rare-species line stands alone rather than folding into a MEGA
 		rpcPages = [
 			[
 				statsRow('Firecrest', SESSION_DATE, 1),
-				statsRow('Firecrest', '2022-05-01', 1)
+				statsRow('Firecrest', '2024-05-01', 1)
 			]
 		];
 		sessionPages = [
-			[{ visit_date: '2022-05-01' }, { visit_date: SESSION_DATE }]
+			[{ visit_date: '2024-05-01' }, { visit_date: SESSION_DATE }]
 		];
 		const fetchSessionHighlights = await importFetchSessionHighlights();
 		const highlights = await fetchSessionHighlights({
@@ -292,7 +295,7 @@ describe('fetchSessionHighlights', () => {
 			viewedGroupId: GROUP_ID
 		});
 		expect(sentencesOf(highlights)).toContain(
-			'Rarely recorded — Firecrest seen on only 2 days ever'
+			'MEGA — Firecrest seen on only 2 days ever'
 		);
 	});
 

--- a/app/components/__tests__/SessionHighlights.test.tsx
+++ b/app/components/__tests__/SessionHighlights.test.tsx
@@ -188,7 +188,81 @@ describe('SessionHighlights', () => {
 			.querySelectorAll('li');
 		expect(items.length).toBe(1);
 		expect(items[0].textContent).toBe(
-			'Rarely recorded — Firecrest seen on only 2 days ever'
+			'MEGA — Firecrest seen on only 2 days ever'
+		);
+	});
+
+	it('renders a MEGA line for an only-of-year record folded with rarity', async () => {
+		const items = await renderSingleHighlight({
+			type: 'mega-species',
+			sortValue: familySortValue('mega-species'),
+			base: {
+				type: 'first-of-year-species',
+				sortValue: familySortValue('first-of-year-species'),
+				speciesName: 'Meadow Pipit',
+				year: 2023,
+				isCurrentYear: false,
+				multipleIndividualsRecorded: true,
+				isOnlyRecord: true
+			},
+			totalSessionDays: 3
+		});
+		expect(items[0].textContent).toBe(
+			'MEGA — Only Meadow Pipit records of 2023 (only 3 records ever)'
+		);
+	});
+
+	it('renders a MEGA line for a first-of-year record folded with rarity', async () => {
+		const items = await renderSingleHighlight({
+			type: 'mega-species',
+			sortValue: familySortValue('mega-species'),
+			base: {
+				type: 'first-of-year-species',
+				sortValue: familySortValue('first-of-year-species'),
+				speciesName: 'Meadow Pipit',
+				year: 2023,
+				isCurrentYear: false,
+				multipleIndividualsRecorded: true,
+				isOnlyRecord: false
+			},
+			totalSessionDays: 3
+		});
+		expect(items[0].textContent).toBe(
+			'MEGA — First Meadow Pipit records of 2023 (only 3 records ever)'
+		);
+	});
+
+	it('renders a MEGA line for an only-ever record without a rarity note', async () => {
+		const items = await renderSingleHighlight({
+			type: 'mega-species',
+			sortValue: familySortValue('mega-species'),
+			base: {
+				type: 'first-ever-species',
+				sortValue: familySortValue('only-ever-species'),
+				speciesName: 'Meadow Pipit',
+				multipleIndividualsRecorded: false,
+				isOnlyRecord: true
+			},
+			totalSessionDays: 1
+		});
+		expect(items[0].textContent).toBe('MEGA — Only Meadow Pipit record ever');
+	});
+
+	it('renders a MEGA line for a first-ever record, counting the other occasions', async () => {
+		const items = await renderSingleHighlight({
+			type: 'mega-species',
+			sortValue: familySortValue('mega-species'),
+			base: {
+				type: 'first-ever-species',
+				sortValue: familySortValue('first-ever-species'),
+				speciesName: 'Meadow Pipit',
+				multipleIndividualsRecorded: false,
+				isOnlyRecord: false
+			},
+			totalSessionDays: 3
+		});
+		expect(items[0].textContent).toBe(
+			'MEGA — First Meadow Pipit ever (only recorded on 2 other occasions)'
 		);
 	});
 

--- a/app/components/session-highlight-renderers.tsx
+++ b/app/components/session-highlight-renderers.tsx
@@ -12,6 +12,7 @@ import type {
 	FirstEverSpeciesHighlight,
 	FirstOfYearSpeciesHighlight,
 	LongAbsenceRetrapHighlight,
+	MegaSpeciesHighlight,
 	RareSpeciesHighlight,
 	RecordScope,
 	SessionHighlight,
@@ -284,7 +285,30 @@ function buildFirstOfYearSpeciesSentence(
 }
 
 function buildRareSpeciesSentence(highlight: RareSpeciesHighlight): string {
-	return `Rarely recorded — ${highlight.speciesName} seen on only ${highlight.totalSessionDays} days ever`;
+	return `MEGA — ${highlight.speciesName} seen on only ${highlight.totalSessionDays} days ever`;
+}
+
+// A MEGA line folds a first/only record together with the same species' rarity.
+// The first/only line is the headline; the rarity rides in a parenthetical,
+// except for an "only ... ever" record, which already implies maximal rarity.
+//   of-year: "MEGA — Only Meadow Pipit records of 2023 (only 3 records ever)"
+//   first ever: "MEGA — First Meadow Pipit ever (only recorded on 2 other occasions)"
+//   only ever: "MEGA — Only Meadow Pipit record ever" (no rarity note)
+function buildMegaSpeciesSentence(highlight: MegaSpeciesHighlight): string {
+	const { base, totalSessionDays } = highlight;
+	if (base.type === 'first-of-year-species') {
+		// The of-year headline stays as-is; the all-time rarity rides alongside it
+		return `MEGA — ${buildFirstOfYearSpeciesSentence(base)} (only ${totalSessionDays} records ever)`;
+	}
+	if (base.isOnlyRecord) {
+		// "Only ... ever" is the species' sole record — already maximally rare
+		return `MEGA — ${buildFirstEverSpeciesSentence(base)}`;
+	}
+	// "First ... ever": this session is the earliest of the few days the species
+	// appears, so the rarity note counts the other occasions
+	const otherOccasions = totalSessionDays - 1;
+	const occasionsWord = otherOccasions === 1 ? 'occasion' : 'occasions';
+	return `MEGA — First ${base.speciesName} ever (only recorded on ${otherOccasions} other ${occasionsWord})`;
 }
 
 function buildLongAbsenceRetrapSentence(
@@ -413,6 +437,8 @@ const HIGHLIGHT_RENDERERS: {
 		renderSentence(buildFirstOfYearSpeciesSentence(highlight)),
 	'rare-species': (highlight) =>
 		renderSentence(buildRareSpeciesSentence(highlight)),
+	'mega-species': (highlight) =>
+		renderSentence(buildMegaSpeciesSentence(highlight)),
 	'long-absence-retrap': (highlight) =>
 		renderSentence(buildLongAbsenceRetrapSentence(highlight)),
 	'weight-record': (highlight) =>

--- a/app/models/__tests__/session-highlights.test.ts
+++ b/app/models/__tests__/session-highlights.test.ts
@@ -1667,14 +1667,14 @@ function makeRareSpeciesHighlight(
 describe('render — rare-species', () => {
 	it('renders the total session-day count', () => {
 		expect(renderedText(makeRareSpeciesHighlight())).toBe(
-			'Rarely recorded — Firecrest seen on only 2 days ever'
+			'MEGA — Firecrest seen on only 2 days ever'
 		);
 	});
 
 	it('renders a three-day count', () => {
 		expect(
 			renderedText(makeRareSpeciesHighlight({ totalSessionDays: 3 }))
-		).toBe('Rarely recorded — Firecrest seen on only 3 days ever');
+		).toBe('MEGA — Firecrest seen on only 3 days ever');
 	});
 });
 

--- a/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
+++ b/app/models/highlight-refinement-machine/__tests__/highlight-refinement-machine.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
 	combineFirstEverHighlights,
 	combineFirstOfYearHighlights,
+	combineFirstRareHighlights,
 	combineOnlyOfYearHighlights,
 	combineSessionTotalRecords,
 	combineSpeciesPlacementRecords,
@@ -21,6 +22,7 @@ import {
 	type FirstEverSpeciesHighlight,
 	type FirstOfYearSpeciesHighlight,
 	type LongAbsenceRetrapHighlight,
+	type MegaSpeciesHighlight,
 	type RareSpeciesHighlight,
 	type RecordScope,
 	type SessionHighlight,
@@ -500,6 +502,109 @@ describe('orderBySortValue (Ord-1)', () => {
 });
 
 // ---- Combining rules ----
+
+function rare(speciesName: string, totalSessionDays = 3): RareSpeciesHighlight {
+	return {
+		type: 'rare-species',
+		sortValue: familySortValue('rare-species'),
+		speciesName,
+		totalSessionDays
+	};
+}
+
+function mega(
+	base: MegaSpeciesHighlight['base'],
+	totalSessionDays: number
+): MegaSpeciesHighlight {
+	return {
+		type: 'mega-species',
+		sortValue: familySortValue('mega-species'),
+		base,
+		totalSessionDays
+	};
+}
+
+describe('combineFirstRareHighlights (Comb-0)', () => {
+	it('merges a first-of-year highlight with the same species rare highlight', () => {
+		const firstOfYearMeadowPipit = firstOfYear('Meadow Pipit', false);
+		const combined = combineFirstRareHighlights([
+			firstOfYearMeadowPipit,
+			rare('Meadow Pipit', 3)
+		]);
+		expect(combined).toEqual([mega(firstOfYearMeadowPipit, 3)]);
+	});
+
+	it('merges an only-of-year highlight with the same species rare highlight', () => {
+		const onlyOfYear = firstOfYear('Meadow Pipit', true);
+		const combined = combineFirstRareHighlights([
+			onlyOfYear,
+			rare('Meadow Pipit', 2)
+		]);
+		expect(combined).toEqual([mega(onlyOfYear, 2)]);
+	});
+
+	it('merges a first-ever highlight with the same species rare highlight', () => {
+		const firstEverMeadowPipit = firstEver('Meadow Pipit', false);
+		const combined = combineFirstRareHighlights([
+			firstEverMeadowPipit,
+			rare('Meadow Pipit', 3)
+		]);
+		expect(combined).toEqual([mega(firstEverMeadowPipit, 3)]);
+	});
+
+	it('merges an only-ever highlight with the same species rare highlight', () => {
+		const onlyEver = firstEver('Meadow Pipit', true);
+		const combined = combineFirstRareHighlights([
+			onlyEver,
+			rare('Meadow Pipit', 1)
+		]);
+		expect(combined).toEqual([mega(onlyEver, 1)]);
+	});
+
+	it('takes the list position of the first/only highlight and drops the rare', () => {
+		const firstOfYearMeadowPipit = firstOfYear('Meadow Pipit', false);
+		const combined = combineFirstRareHighlights([
+			weightRecord,
+			firstOfYearMeadowPipit,
+			rare('Meadow Pipit', 3)
+		]);
+		expect(combined).toEqual([weightRecord, mega(firstOfYearMeadowPipit, 3)]);
+	});
+
+	it('leaves a rare highlight untouched when no first/only for its species is present', () => {
+		const pool = [rare('Wryneck', 2), weightRecord];
+		expect(combineFirstRareHighlights(pool)).toEqual(pool);
+	});
+
+	it('leaves a first/only highlight untouched when its species has no rare highlight', () => {
+		const pool = [firstOfYear('Meadow Pipit', false), rare('Wryneck', 2)];
+		expect(combineFirstRareHighlights(pool)).toEqual(pool);
+	});
+
+	it('merges each species independently, leaving unmatched first/only highlights for later rules', () => {
+		const meadowPipit = firstOfYear('Meadow Pipit', true);
+		const chaffinch = firstOfYear('Chaffinch', true);
+		const combined = combineFirstRareHighlights([
+			meadowPipit,
+			chaffinch,
+			rare('Meadow Pipit', 3)
+		]);
+		// Meadow Pipit folds into a MEGA; Chaffinch (no rare) is left for Comb-2
+		expect(combined).toEqual([mega(meadowPipit, 3), chaffinch]);
+	});
+
+	it('is a noop on unrelated highlights', () => {
+		const pool = [weightRecord, quietestSince];
+		expect(combineFirstRareHighlights(pool)).toEqual(pool);
+	});
+
+	it('does not mutate the input list', () => {
+		const pool = [firstOfYear('Meadow Pipit', false), rare('Meadow Pipit', 3)];
+		const snapshot = [...pool];
+		combineFirstRareHighlights(pool);
+		expect(pool).toEqual(snapshot);
+	});
+});
 
 describe('combineSessionTotalRecords (Comb-1)', () => {
 	it('merges same-scope encounters and species records into one combined record', () => {
@@ -1320,6 +1425,32 @@ describe('runHighlightMachine', () => {
 		).toEqual([
 			['combined-species-placement-record', 2, 'Dunnock+Whitethroat'],
 			['combined-species-placement-record', 3, 'Wren+Robin'],
+			['weight-record']
+		]);
+	});
+
+	it('folds a first/only + rare into a MEGA at the top, leaving other onlys to combine', () => {
+		const pool: SessionHighlight[] = [
+			firstOfYear('Meadow Pipit', true),
+			firstOfYear('Chaffinch', true),
+			firstOfYear('Goldfinch', true),
+			rare('Meadow Pipit', 3),
+			weightRecord
+		];
+		const machined = runHighlightMachine(pool);
+		expect(
+			machined.map((highlight) =>
+				highlight.type === 'mega-species'
+					? [highlight.type, highlight.base.speciesName]
+					: 'speciesNames' in highlight
+						? [highlight.type, highlight.speciesNames.join('+')]
+						: [highlight.type]
+			)
+		).toEqual([
+			// the MEGA heads the list; the Meadow Pipit rare-species line is folded in
+			['mega-species', 'Meadow Pipit'],
+			// the two remaining only-of-year lines combine among themselves
+			['combined-only-of-year', 'Chaffinch+Goldfinch'],
 			['weight-record']
 		]);
 	});

--- a/app/models/highlight-refinement-machine/combine-first-rare-highlights.ts
+++ b/app/models/highlight-refinement-machine/combine-first-rare-highlights.ts
@@ -1,0 +1,73 @@
+import {
+	familySortValue,
+	type FirstEverSpeciesHighlight,
+	type FirstOfYearSpeciesHighlight,
+	type MegaSpeciesHighlight,
+	type RareSpeciesHighlight,
+	type SessionHighlight
+} from '@/app/models/session-highlights';
+
+function isRareSpecies(
+	highlight: SessionHighlight
+): highlight is RareSpeciesHighlight {
+	return highlight.type === 'rare-species';
+}
+
+function isFirstOrOnly(
+	highlight: SessionHighlight
+): highlight is FirstEverSpeciesHighlight | FirstOfYearSpeciesHighlight {
+	return (
+		highlight.type === 'first-ever-species' ||
+		highlight.type === 'first-of-year-species'
+	);
+}
+
+// Comb-0: a first/only record — of the year or ever — for a species the group
+// has only ever recorded on a handful of session days (a rare-species highlight)
+// merges both lines into one "MEGA" headline for that species. The first/only
+// line supplies the headline; the rare-species line is folded in as the rarity
+// note (totalSessionDays) and drops out. The combined line takes the position of
+// the first/only highlight it replaces.
+//
+// This runs BEFORE the other combine rules so the specific first/only line is
+// consumed here — otherwise combineOnlyOfYearHighlights / combineFirstOfYearHighlights
+// would have already folded it into a multi-species "First/Only A, B and C" line,
+// losing the pairing with its rare-species highlight.
+export function combineFirstRareHighlights(
+	highlights: SessionHighlight[]
+): SessionHighlight[] {
+	const megaByBase = new Map<SessionHighlight, MegaSpeciesHighlight>();
+	const consumedRareHighlights = new Set<SessionHighlight>();
+	for (const highlight of highlights) {
+		if (!isFirstOrOnly(highlight)) continue;
+		const rareHighlight = highlights.find(
+			(candidate) =>
+				isRareSpecies(candidate) &&
+				candidate.speciesName === highlight.speciesName &&
+				!consumedRareHighlights.has(candidate)
+		);
+		if (!rareHighlight || !isRareSpecies(rareHighlight)) continue;
+		consumedRareHighlights.add(rareHighlight);
+		megaByBase.set(highlight, {
+			type: 'mega-species',
+			sortValue: familySortValue('mega-species'),
+			base: highlight,
+			totalSessionDays: rareHighlight.totalSessionDays
+		});
+	}
+	if (megaByBase.size === 0) return highlights;
+
+	// Each MEGA takes the position of the first/only highlight it replaces; the
+	// absorbed rare-species highlight just drops out.
+	const result: SessionHighlight[] = [];
+	for (const highlight of highlights) {
+		const mega = megaByBase.get(highlight);
+		if (mega) {
+			result.push(mega);
+			continue;
+		}
+		if (consumedRareHighlights.has(highlight)) continue;
+		result.push(highlight);
+	}
+	return result;
+}

--- a/app/models/highlight-refinement-machine/index.ts
+++ b/app/models/highlight-refinement-machine/index.ts
@@ -2,6 +2,7 @@ import type { SessionHighlight } from '@/app/models/session-highlights';
 import { removeBusiestSinceWhenBusiestRecordHeld } from './remove-busiest-since-when-busiest-record-held';
 import { removeNarrowerScopeSpeciesRecords } from './remove-narrower-scope-species-records';
 import { removeCountAndWeightHighlightsForRareSpecies } from './remove-count-and-weight-highlights-for-rare-species';
+import { combineFirstRareHighlights } from './combine-first-rare-highlights';
 import { combineSessionTotalRecords } from './combine-session-total-records';
 import { combineOnlyOfYearHighlights } from './combine-only-of-year-highlights';
 import { combineFirstEverHighlights } from './combine-first-ever-highlights';
@@ -14,6 +15,7 @@ import { orderBySortValue } from './order-by-sort-value';
 export { removeBusiestSinceWhenBusiestRecordHeld } from './remove-busiest-since-when-busiest-record-held';
 export { removeNarrowerScopeSpeciesRecords } from './remove-narrower-scope-species-records';
 export { removeCountAndWeightHighlightsForRareSpecies } from './remove-count-and-weight-highlights-for-rare-species';
+export { combineFirstRareHighlights } from './combine-first-rare-highlights';
 export { combineSessionTotalRecords } from './combine-session-total-records';
 export { combineOnlyOfYearHighlights } from './combine-only-of-year-highlights';
 export { combineFirstEverHighlights } from './combine-first-ever-highlights';
@@ -36,6 +38,7 @@ const RULES: HighlightRule[] = [
 	removeBusiestSinceWhenBusiestRecordHeld, // Rem-1
 	removeNarrowerScopeSpeciesRecords, // Rem-2
 	removeCountAndWeightHighlightsForRareSpecies, // Rem-3
+	combineFirstRareHighlights, // Comb-0 — must precede the other combine rules
 	combineSessionTotalRecords, // Comb-1
 	combineOnlyOfYearHighlights, // Comb-2
 	combineYearSpeciesCounts, // Comb-3

--- a/app/models/session-highlights.ts
+++ b/app/models/session-highlights.ts
@@ -32,15 +32,18 @@ export const SCOPE_BREADTH_RANK = new Map(
 // listed after it, whatever `orderWithinFamily` values arise, so there are no
 // numeric bands to keep disjoint.
 
-// Families in editorial priority order, highest first. An "only ever" record
-// (the species' sole record in the data) heads the list, then plain first-ever,
-// rare-species and long-absence-retrap — all promoted above scoped records —
+// Families in editorial priority order, highest first. A "MEGA" record (a
+// first/only record for a species the group has barely ever recorded) heads the
+// list, then an "only ever" record (the species' sole record in the data), then
+// plain first-ever, rare-species and long-absence-retrap — all promoted above
+// scoped records —
 // then the scoped records themselves, then the juvenile-count records, then the
 // trailing context families. Juvenile records sit just below the general
 // scoped records: they're the same kind of "record" line but a more niche
 // measure, so they follow rather than interleave with the encounter/species
 // records.
 export const HIGHLIGHT_FAMILIES = [
+	'mega-species',
 	'only-ever-species',
 	'first-ever-species',
 	'rare-species',
@@ -420,6 +423,27 @@ export type CombinedWeightRecordHighlight = {
 	allTimeIsJoint: boolean;
 };
 
+// A "MEGA" highlight: a first/only record — of the year or ever — for a species
+// the group has only ever recorded on a handful of session days. Produced by the
+// machine's combine pass (combineFirstRareHighlights) when a first/only highlight
+// and a rare-species highlight for the *same* species coincide, folding both into
+// one headline line. The first/only line supplies the headline; the rarity rides
+// in a parenthetical, except for an "only ... ever" record, which already implies
+// maximal rarity and so carries none. Runs before the other combine rules so the
+// specific first/only line is consumed here rather than merged into a multi-species
+// "First/Only A, B and C" line.
+export type MegaSpeciesHighlight = {
+	type: 'mega-species';
+	sortValue: SortValue;
+	// The first/only highlight this MEGA is built on — its species also holds the
+	// rare-species highlight folded in as totalSessionDays. Its type discriminates
+	// the of-year vs ever headline phrasing.
+	base: FirstEverSpeciesHighlight | FirstOfYearSpeciesHighlight;
+	// Distinct session days the species has ever been recorded on, carried over
+	// from the rare-species highlight absorbed into this line (2–3 in practice)
+	totalSessionDays: number;
+};
+
 // The discriminated union the highlight machine's passes and the client
 // renderers both operate over. Highlights are plain serializable data so they
 // can cross the server-action -> client boundary; rendering happens client
@@ -435,6 +459,7 @@ export type SessionHighlight =
 	| RareSpeciesHighlight
 	| LongAbsenceRetrapHighlight
 	| WeightRecordHighlight
+	| MegaSpeciesHighlight
 	| CombinedSessionTotalRecordHighlight
 	| CombinedOnlyOfYearHighlight
 	| CombinedFirstEverHighlight


### PR DESCRIPTION
## What this does

Adds a MEGA highlight to the session-highlight refinement machine. A first/only record — of the year or ever — for a species the group has only ever recorded on a handful of session days now folds together with that species' "Rarely recorded" highlight into a single headline line, and standalone rare-species lines are reworded from **"Rarely recorded"** to **"MEGA"**.

Closes #391

### Examples (from the ticket)

| First/only line | Rare line | Combined MEGA |
|---|---|---|
| Only Meadow Pipit records of 2023 | seen on only 3 days ever | `MEGA — Only Meadow Pipit records of 2023 (only 3 records ever)` |
| First Meadow Pipit records of 2023 | seen on only 3 days ever | `MEGA — First Meadow Pipit records of 2023 (only 3 records ever)` |
| Only Meadow Pipit record ever | (subsumed) | `MEGA — Only Meadow Pipit record ever` |
| First Meadow Pipit record ever | seen on only 3 days ever | `MEGA — First Meadow Pipit ever (only recorded on 2 other occasions)` |

## How

- New highlight type `MegaSpeciesHighlight` (`type: 'mega-species'`) and a new top-priority `mega-species` family in `HIGHLIGHT_FAMILIES` so a MEGA leads the list.
- New machine rule **`combineFirstRareHighlights` (Comb-0)** — inserted as the **first** combine rule. It pairs a `first-ever-species`/`first-of-year-species` highlight with the same species' `rare-species` highlight, folds both into one MEGA (taking the first/only line's position, dropping the rare line). It runs before the other combine rules so the specific first/only line is consumed here rather than folded into a multi-species "First/Only A, B and C" line, which would lose the rare pairing.
- Renderer `buildMegaSpeciesSentence` builds the headline (reusing the existing of-year / first-ever sentence builders where they match) plus the rarity parenthetical; `buildRareSpeciesSentence` reworded to "MEGA".

## Tests

- New `combineFirstRareHighlights (Comb-0)` describe block (11 cases: each first/only variant × rare, position, no-match noops, multi-species independence, immutability).
- New full-machine test: a first/only + rare folds into a MEGA at the top while other only-of-year lines still combine among themselves.
- New renderer tests for all four ticket example sentences.
- Updated the existing end-to-end action test: its Robin fixture (rare + only-of-year 2024) now correctly produces `MEGA — Only Robin records of 2024 (only 2 records ever)` — real confirmation the feature works through the whole pipeline.

`npm run qa` (lint + type-check + 558 app tests) passes.

## Assumptions

- **Em dash, not hyphen:** used `MEGA — …` (em dash) rather than the ticket's `MEGA - …`, matching the house style already used for every other highlight sentence (`Rarely recorded — …`, `Busiest session ever — …`).
- **Preserved singular/plural from the source:** the ticket examples show `record` (singular) in a couple of MEGA outputs even where the source line was `records` (plural). I kept the source's `multipleIndividualsRecorded` phrasing (so `records` stays plural), treating the ticket's singular as a transcription slip — it carries more information and stays consistent with the standalone line.
- **First-ever + rare is currently unreachable by derivation** (a first-ever species has no prior day; `deriveRareSpecies` requires one), so examples 3 & 4 can't arise from real data today. I implemented them anyway per the spec, fully covered by unit tests, so the machine behaves correctly if such a pool ever occurs (e.g. future derivation changes). The realizable path (first/only **of year** + rare) is confirmed end-to-end by the updated action test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
