### PR TITLE
Add take-over skill to reclaim a swarm-worked branch

### DIFF
--- a/.claude/skills/swarm/SKILL.md
+++ b/.claude/skills/swarm/SKILL.md
@@ -11,7 +11,9 @@ description: >-
   of up to 4 worker subagents (the orchestrator doesn't count): each completion triggers a
   re-select + respawn until no eligible work remains; while idle, a "check again" command forces
   a fresh GitHub re-scan for newly-available work. A stop command prompts the user to confirm
-  halt-all vs drain. Orchestration only — PR maintenance, selection, worktree isolation, model
+  halt-all vs drain. Tracks every live worker in a gitignored local state file
+  (`.claude/swarm-state.json`) so the `take-over` skill can find and halt the right agent even
+  from a fresh session. Orchestration only — PR maintenance, selection, worktree isolation, model
   routing, parallelism, refill, termination, teardown. Triggers: "swarm", "/swarm", "pick up
   ready tickets", "work the ready queue".
 ---
@@ -27,6 +29,37 @@ merge conflicts and address outstanding feedback so they can merge — then (b) 
 
 Confirm GitHub Issues are enabled: run `gh issue list` once. If it errors with issues disabled,
 stop and tell the user to enable them (`gh repo edit --enable-issues`) before continuing.
+
+## State file (`.claude/swarm-state.json`)
+
+Every live worker gets one entry here — this is how the `take-over` skill finds and halts the
+right agent from a session that never saw it spawn (there's no tool to list running background
+agents; this file is the only durable record). Gitignored, machine-local, never committed.
+
+Entry shape:
+```json
+{
+  "kind": "ticket",
+  "issue": 412,
+  "pr": null,
+  "branch": "feature/412-add-species-chart",
+  "title": "Add species breakdown chart to session page",
+  "worktreePath": "/abs/path/.claude/worktrees/...",
+  "agentId": "<id returned when spawning>",
+  "model": "sonnet",
+  "startedAt": "<ISO timestamp>"
+}
+```
+(`kind` is `"ticket"` for §3 workers or `"maintenance"` for §1 workers; use `pr` instead of/alongside
+`issue` for maintenance workers, and `title` is the ticket title or PR title, whichever is known.)
+
+- **On every spawn** (§1 and §3): after the Agent tool call returns an id, find the worktree path
+  — if not already given back by the spawn result, diff `git worktree list` from just before the
+  spawn to just after; the new entry is the freshly-created worktree. Then append the entry:
+  create the file with `[]` first if it doesn't exist, then
+  `jq --argjson e '<entry-json>' '. + [$e]' .claude/swarm-state.json > /tmp/swarm-state.tmp && mv /tmp/swarm-state.tmp .claude/swarm-state.json`.
+- **On every completion** (§4) **and on halt/drain** (Termination): remove that worker's entry —
+  `jq --arg id '<agentId>' 'map(select(.agentId != $id))' .claude/swarm-state.json > /tmp/swarm-state.tmp && mv /tmp/swarm-state.tmp .claude/swarm-state.json`.
 
 **Concurrency is capped at 4 worker subagents.** The top-level swarm orchestrator (the parent
 agent running this skill) does not count toward the cap — it only selects, spawns, reports and
@@ -78,6 +111,8 @@ both concerns for that PR:
      and push. If on inspection neither a real conflict nor genuine feedback remains, no-op and
      report that.
 
+Append a `kind: "maintenance"` entry (see State file) for this worker right after spawning it.
+
 If no open PR needs maintenance, skip to ticket selection with the full budget.
 
 ## 2. Select tickets (fill the remaining budget)
@@ -114,6 +149,8 @@ For each selected issue, launch an Agent (default background, so they run in par
   `origin/main` picks up already-merged sibling tickets), then run the `implement-ticket` skill
   for issue `<n>` and return its result (PR number + URL + test status).
 
+Append a `kind: "ticket"` entry (see State file) for this worker right after spawning it.
+
 The subagent owns branch/commits/tests/PR/mermaid-diff via `implement-ticket`, including the
 test-isolation rule for any DB integration tests it writes. swarm does not duplicate that
 logic — it only pins the branch base to `origin/main` and enforces the `db-migration` cap so
@@ -124,7 +161,8 @@ instance.
 
 Every time a worker subagent finishes (completions arrive as notifications, usually one at a
 time):
-1. **Record** its worktree path for teardown and note whether it succeeded or needs the user.
+1. **Record** its worktree path for teardown, remove its entry from the state file (see State
+   file), and note whether it succeeded or needs the user.
 2. **Report** that unit:
    - **Maintained PRs**: PR → conflicts resolved? → feedback addressed (+ reviewer reply URL) →
      commit pushed → now mergeable? (or "no-op, nothing outstanding").
@@ -171,10 +209,12 @@ with these two options:
   normally. No new refills after this.
 
 Then do exactly what they pick:
-- *Halt all now* → `TaskStop` every tracked live worker, confirm each is stopped, report what was
-  abandoned (branch/worktree state may be partial), and exit the loop.
+- *Halt all now* → `TaskStop` every tracked live worker, remove each from the state file, confirm
+  each is stopped, report what was abandoned (branch/worktree state may be partial), and exit the
+  loop.
 - *Drain* → keep the refill suppressed, await the running workers' completions, report each as it
-  lands (§4 steps 1–2 only, no refill), and exit the loop once the pool empties.
+  lands (§4 steps 1–2 only, no refill — completions already remove their own state-file entry),
+  and exit the loop once the pool empties.
 
 Either way, leave worktrees in place for teardown unless the user also asks to clean up.
 
@@ -214,3 +254,6 @@ Confirm each removal; report anything skipped (e.g. a worktree with unpushed cha
 - Every ticket branch is based on freshly-fetched `origin/main`, never on the local checkout.
 - Per-ticket work goes through `implement-ticket` — don't reinvent it here, including its
   DB-test-isolation rule.
+- Keep `.claude/swarm-state.json` in sync with the live worker set on every spawn, completion,
+  and halt — it's the only durable record of which agent id is working which branch, and
+  `take-over` depends on it being current.

--- a/.claude/skills/take-over/SKILL.md
+++ b/.claude/skills/take-over/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: take-over
+description: >-
+  Reclaim a branch that a swarm worker (or other worktree-isolated agent) is mid-way through, so
+  the user can keep working on it by hand (e.g. in VS Code). Git refuses to check out a branch
+  that's already checked out in another worktree — this resolves an identifier (branch name,
+  issue/PR number, a raw agent id, or a paraphrase of the ticket title) to the worker doing that
+  work via swarm's state file, halts that agent, stashes and removes its worktree, then checks
+  the branch out (reapplying the stash) in the current working directory. Works from any session,
+  including a fresh one that never saw the worker spawn. Triggers: "take over ticket <n>", "take
+  over this branch", "let me work on this myself", "/take-over <identifier>", or git complaining
+  a branch is already checked out elsewhere.
+---
+
+# take-over
+
+Free a branch that's locked inside another worktree — usually a `swarm` worker's — and check it
+out here instead, halting whatever was working on it and keeping any uncommitted progress. The
+identifier is the skill argument (e.g. `/take-over 412`, `/take-over feature/412-species-chart`,
+`/take-over "the species chart ticket"`).
+
+## 1. Resolve the identifier
+
+Read `.claude/swarm-state.json` (if missing, treat as `[]` — everything below still works via
+git directly, just without an agent id to halt). Try, in order, until one produces exactly one
+match:
+
+1. **Exact branch match** — identifier equals an entry's `branch`, or an exact ref found in
+   `git branch -a` / `git worktree list`.
+2. **Issue/PR number match** — identifier is numeric or `#<n>`; match against `issue` or `pr`.
+3. **Agent id match** — identifier matches an entry's `agentId` exactly (the user may have this
+   from something swarm printed, or from elsewhere in the harness).
+4. **Title substring match** — case-insensitive substring/keyword match against `title`.
+
+If none of these hit and the identifier reads like a paraphrase (free text, not a number or
+branch-shaped string), resolve it to an issue first: `gh issue list --search "<identifier>"
+--state open --json number,title`, then retry steps 2–4 against that issue's number.
+
+**If the state file still has no match** (never tracked, or its entry was already cleared) but
+the identifier clearly names a real ticket: derive the expected branch pattern from
+`implement-ticket`'s convention (`feature/<n>-<slug>`) and look for it directly in `git branch
+-a` / `git worktree list`. This covers hand-run `implement-ticket` work and stale state entries.
+There will be no agent id to halt in this case — see step 3.
+
+**Multiple matches** (an ambiguous paraphrase, or a number that coincidentally matches more than
+one entry) → `AskUserQuestion` listing each candidate's title, branch, and kind, and stop until
+the user picks one.
+
+**No match anywhere** → report that plainly and stop; don't guess.
+
+## 2. Guard: already there?
+
+If the resolved worktree path is the current directory, there's nothing to relocate — just do
+step 3 (halt) and stop; report that the user is already sitting in that worktree.
+
+## 3. Halt the agent
+
+If an `agentId` was found: `TaskStop <agentId>`, then remove that entry from
+`.claude/swarm-state.json` (same `jq` pattern swarm uses). Report success even if `TaskStop`
+reports "not found" — that just means it had already finished.
+
+If no `agentId` was found for a worktree/branch that clearly exists (untracked or stale entry):
+tell the user plainly that nothing could be positively stopped — it was either never run through
+swarm, or its tracking entry is gone — and that if something is still actively writing to that
+worktree, this won't stop it. This is the one point worth a beat of hesitation; continue once
+acknowledged, but don't silently plough through it.
+
+## 4. Preserve the worktree's uncommitted work
+
+`git -C <worktreePath> status --porcelain`. If dirty:
+`git -C <worktreePath> stash push -u -m "take-over: <branch> $(date -u +%Y-%m-%dT%H:%M:%SZ)"`.
+Note the stash ref (`git -C <worktreePath> stash list` — it'll be the top entry) so step 8 can
+reapply exactly this one, not whatever else happens to be on top of the stash stack by then.
+
+## 5. Free the branch
+
+`git worktree remove <worktreePath>`. If git still refuses (leftover files it won't clean up on
+its own), surface the exact error to the user rather than force-removing — don't guess whether
+those leftovers are safe to lose.
+
+## 6. Protect the current directory's own state
+
+`git status --porcelain` in the current directory. If dirty, stash it too (`-u`, clearly named,
+e.g. `"take-over: pre-checkout autosave $(date -u +%Y-%m-%dT%H:%M:%SZ)"`) before switching
+branches — never discard uncommitted work silently. This stash has nothing to do with the branch
+being taken over: report it and leave it stashed for the user to recover later by hand
+(`git stash list` / `git stash pop`); do not touch it again in this run.
+
+## 7. Checkout
+
+`git fetch origin`, then `git checkout <branch>`.
+
+## 8. Reapply the worktree's stash
+
+If step 4 created a stash, reapply it now: `git stash pop <that stash ref>`. Report cleanly if it
+applies with no conflicts; if it doesn't, say so and leave the stash in place rather than forcing
+it — the user can resolve and pop it manually.
+
+## 9. Report
+
+Summarise: whether the agent was halted (or why not), that the worktree was removed, that the
+branch is now checked out here, any stashes created/reapplied (and any left behind, e.g. the
+current-directory autosave from step 6), and — if the branch has an open PR — its URL, so the
+user knows pushing new commits will update it rather than needing a fresh PR.
+
+## Rules
+
+- Never remove a worktree or discard changes without stashing first — uncommitted work always
+  survives a take-over.
+- Ambiguous identifier resolution always gets `AskUserQuestion`; never guess between candidates.
+- The current directory's pre-existing uncommitted changes (step 6) are never auto-reapplied —
+  only the taken-over branch's own stash (step 4) is.
+- If no agent id can be found for an existing worktree/branch, say so before proceeding — don't
+  present a silent, unqualified success.

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ e2e/.auth/
 playwright-report/
 test-results/
 e2e/group-ids.json
+
+# swarm's local worker-tracking state (machine-local, never committed)
+/.claude/swarm-state.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,10 @@ A leaderboard/statistics dashboard for bird ringing data. Bird ringing groups (o
 Tickets are created with the `flesh-out-ticket` skill (single task) or `tasks-to-tickets` skill
 (a whole task list, one issue per task, reusing `flesh-out-ticket` per ticket) and implemented
 with the `implement-ticket` skill. `swarm` picks up open `ready` tickets and open PRs needing
-maintenance and runs them in parallel, one git worktree + subagent per unit of work.
+maintenance and runs them in parallel, one git worktree + subagent per unit of work. If you want
+to grab a branch `swarm` is mid-way through and keep working on it by hand (e.g. in VS Code), use
+the `take-over` skill — it halts the worker and frees the branch's worktree so a normal
+`git checkout` works.
 
 When creating a ticket, add exactly one model label reflecting implementation complexity — the
 subagent implementing it runs on that model:


### PR DESCRIPTION
## Summary
- New `take-over` skill: resolves an identifier (branch name, issue/PR number, agent id, or a paraphrase of the ticket title) to a swarm worker, halts it, stashes and removes its worktree, then checks the branch out in the current working directory — solving "git says this branch is already checked out in another worktree" when the user wants to grab work `swarm` is mid-way through.
- `swarm` now persists a gitignored `.claude/swarm-state.json` (branch/issue/pr → agent id → worktree path) as it spawns/completes workers, since there's no tool to enumerate running background agents — this lets `take-over` resolve the right agent id even from a fresh session that never saw the worker spawn.
- Base branch is `skills/ht1-consolidation` (stacked — that's where `swarm` was introduced, in #420, not yet on `main`).

## Test plan
- [x] Pre-push hook: app tests + DB integration tests + HTTP/e2e suite (98 passed)
- [x] Confirmed `.claude/swarm-state.json` naming is consistent across `swarm`, `take-over`, and `.gitignore`
- [ ] Manual exercise against a real swarm-spawned worktree (needs a live swarm run to validate end-to-end — noted in the skill's own verification notes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)