### PR TITLE
test: isolate DB integration test writes from concurrent worktree runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,11 @@ Test RPC functions and RLS policies against the real local database. Require `np
 Tests can run concurrently in separate git worktrees (see `swarm`) against the same shared local
 Supabase instance. Any row a write test creates (ring numbers, group names, session/location
 names, etc.) must use a random or ticket/branch-specific identifier — never a fixed literal —
-so parallel runs never collide on the same row.
+so parallel runs never collide on the same row, and so date-based rows never collide in a
+group-wide aggregate RPC's results (e.g. `stats_per_day_and_species`) even without a unique
+constraint. Use the shared helpers in `supabase/__tests__/test-isolation.ts`
+(`randomTestSuffix`, `randomFutureDate`, `addDays`) rather than inventing a new isolation
+mechanism per file; extend an existing prefix convention (e.g. `TRIG-TEST-`) with the suffix.
 
 ## Environment variables
 

--- a/supabase/__tests__/readonly-role.test.ts
+++ b/supabase/__tests__/readonly-role.test.ts
@@ -15,6 +15,7 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import { getAuthenticatedSupabaseClientForGroup } from '../../lib/group-auth';
 import { supabase } from '../../lib/supabase';
+import { randomTestSuffix } from './test-isolation';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 async function getGroupIdByName(name: string): Promise<number> {
@@ -66,16 +67,20 @@ describe('app_readonly role', () => {
 	});
 
 	it('rejects INSERT with a read-only transaction error', async () => {
+		// The transaction is read-only, so this insert never actually commits — the
+		// random suffix is just for consistency with the isolation convention (see
+		// CLAUDE.md's "DB integration tests" section) in case that guarantee ever changes.
 		const { error } = await readonlyClient
 			.from('Species')
-			.insert({ species_name: 'Readonly Test Species' });
+			.insert({ species_name: `Readonly Test Species ${randomTestSuffix()}` });
 		expect(error?.code).toBe(READ_ONLY_TRANSACTION_ERROR_CODE);
 	});
 
 	it('rejects UPDATE with a read-only transaction error', async () => {
+		// As above: the transaction is read-only, so this update never actually commits.
 		const { error } = await readonlyClient
 			.from('RingingGroups')
-			.update({ group_name: 'Readonly Test Rename' })
+			.update({ group_name: `Readonly Test Rename ${randomTestSuffix()}` })
 			.eq('id', alphaId);
 		expect(error?.code).toBe(READ_ONLY_TRANSACTION_ERROR_CODE);
 	});

--- a/supabase/__tests__/rpc-functions.test.ts
+++ b/supabase/__tests__/rpc-functions.test.ts
@@ -12,6 +12,7 @@ import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import { execSync } from 'child_process';
 import { getAuthenticatedSupabaseClientForGroup } from '../../lib/group-auth';
 import { supabase } from '../../lib/supabase';
+import { addDays, randomFutureDate, randomTestSuffix } from './test-isolation';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 async function getGroupIdByName(name: string): Promise<number> {
@@ -744,10 +745,18 @@ describe('Postgres RPC integration tests', () => {
 			let locationId: number;
 			let sessionIds: number[];
 			let birdIds: number[];
+			let visitDates: string[];
 
 			beforeAll(async () => {
 				deltaId = await getGroupIdByName('Delta');
 				deltaClient = await getAuthenticatedSupabaseClientForGroup(deltaId);
+
+				const testSuffix = randomTestSuffix();
+				// Randomised so concurrent test runs (separate worktrees, same shared local
+				// Supabase instance) never combine their rows into the same
+				// stats_per_day_and_species aggregate row.
+				const firstVisitDate = randomFutureDate();
+				visitDates = [firstVisitDate, addDays(firstVisitDate, 1)];
 
 				const { data: species } = await supabase
 					.from('Species')
@@ -758,7 +767,7 @@ describe('Postgres RPC integration tests', () => {
 				const { data: location, error: locationError } = await deltaClient
 					.from('Locations')
 					.insert({
-						location_name: 'Stats Per Day Test Location',
+						location_name: `Stats Per Day Test Location ${testSuffix}`,
 						ringing_group_id: deltaId,
 					})
 					.select('id')
@@ -767,7 +776,7 @@ describe('Postgres RPC integration tests', () => {
 				locationId = location!.id;
 
 				const sessions = await Promise.all(
-					['2098-06-01', '2098-06-02'].map((visitDate) =>
+					visitDates.map((visitDate) =>
 						deltaClient
 							.from('Sessions')
 							.insert({ visit_date: visitDate, location_id: locationId })
@@ -781,7 +790,7 @@ describe('Postgres RPC integration tests', () => {
 				sessionIds = sessions.map(({ data }) => data!.id);
 
 				const birds = await Promise.all(
-					['STATSTEST1', 'STATSTEST2', 'STATSTEST3'].map((ringNo) =>
+					[`STATSTEST1-${testSuffix}`, `STATSTEST2-${testSuffix}`, `STATSTEST3-${testSuffix}`].map((ringNo) =>
 						deltaClient
 							.from('Birds')
 							.insert({ ring_no: ringNo, species_id: species!.id })
@@ -804,10 +813,10 @@ describe('Postgres RPC integration tests', () => {
 				const { error: encountersError } = await deltaClient
 					.from('Encounters')
 					.insert([
-						// 2098-06-01: one weighed + one unweighed encounter
+						// visitDates[0]: one weighed + one unweighed encounter
 						{ ...baseEncounter, bird_id: birdIds[0], session_id: sessionIds[0], weight: 15 },
 						{ ...baseEncounter, bird_id: birdIds[1], session_id: sessionIds[0] },
-						// 2098-06-02: only an unweighed encounter
+						// visitDates[1]: only an unweighed encounter
 						{ ...baseEncounter, bird_id: birdIds[2], session_id: sessionIds[1] },
 					]);
 				if (encountersError) throw encountersError;
@@ -829,10 +838,10 @@ describe('Postgres RPC integration tests', () => {
 				});
 				expect(error).toBeNull();
 				expect(
-					data!.find((row) => row.visit_date === '2098-06-01')
+					data!.find((row) => row.visit_date === visitDates[0])
 				).toEqual({
 					species_name: 'Robin',
-					visit_date: '2098-06-01',
+					visit_date: visitDates[0],
 					encounter_count: 2,
 					juv_count: 0,
 					weighed_birds_count: 1,
@@ -847,10 +856,10 @@ describe('Postgres RPC integration tests', () => {
 				});
 				expect(error).toBeNull();
 				expect(
-					data!.find((row) => row.visit_date === '2098-06-02')
+					data!.find((row) => row.visit_date === visitDates[1])
 				).toEqual({
 					species_name: 'Robin',
-					visit_date: '2098-06-02',
+					visit_date: visitDates[1],
 					encounter_count: 1,
 					juv_count: 0,
 					weighed_birds_count: 0,
@@ -868,10 +877,17 @@ describe('Postgres RPC integration tests', () => {
 			let locationId: number;
 			let sessionId: number;
 			let birdIds: number[];
+			let visitDate: string;
 
 			beforeAll(async () => {
 				deltaId = await getGroupIdByName('Delta');
 				deltaClient = await getAuthenticatedSupabaseClientForGroup(deltaId);
+
+				const testSuffix = randomTestSuffix();
+				// Randomised so concurrent test runs (separate worktrees, same shared local
+				// Supabase instance) never combine their rows into the same
+				// stats_per_day_and_species aggregate row.
+				visitDate = randomFutureDate();
 
 				const { data: species } = await supabase
 					.from('Species')
@@ -882,7 +898,7 @@ describe('Postgres RPC integration tests', () => {
 				const { data: location, error: locationError } = await deltaClient
 					.from('Locations')
 					.insert({
-						location_name: 'Juv Stats Test Location',
+						location_name: `Juv Stats Test Location ${testSuffix}`,
 						ringing_group_id: deltaId,
 					})
 					.select('id')
@@ -892,14 +908,20 @@ describe('Postgres RPC integration tests', () => {
 
 				const { data: session, error: sessionError } = await deltaClient
 					.from('Sessions')
-					.insert({ visit_date: '2099-06-01', location_id: locationId })
+					.insert({ visit_date: visitDate, location_id: locationId })
 					.select('id')
 					.single();
 				if (sessionError) throw sessionError;
 				sessionId = session!.id;
 
 				const birds = await Promise.all(
-					['JUVTEST1', 'JUVTEST2', 'JUVTEST3', 'JUVTEST4', 'JUVTEST5'].map(
+					[
+						`JUVTEST1-${testSuffix}`,
+						`JUVTEST2-${testSuffix}`,
+						`JUVTEST3-${testSuffix}`,
+						`JUVTEST4-${testSuffix}`,
+						`JUVTEST5-${testSuffix}`,
+					].map(
 						(ringNo) =>
 							deltaClient
 								.from('Birds')
@@ -948,10 +970,10 @@ describe('Postgres RPC integration tests', () => {
 					ringing_group_filter: deltaId,
 				});
 				expect(error).toBeNull();
-				const row = data!.find((row) => row.visit_date === '2099-06-01');
+				const row = data!.find((row) => row.visit_date === visitDate);
 				expect(row).toMatchObject({
 					species_name: 'Robin',
-					visit_date: '2099-06-01',
+					visit_date: visitDate,
 					encounter_count: 5,
 					juv_count: 3,
 				});

--- a/supabase/__tests__/test-isolation.ts
+++ b/supabase/__tests__/test-isolation.ts
@@ -1,0 +1,40 @@
+/**
+ * Isolation helpers for DB integration tests (`supabase/__tests__/*.test.ts`).
+ *
+ * Tests can run concurrently in separate git worktrees (see `swarm`) against the same
+ * shared local Supabase instance. Any row a write test creates (ring numbers, group
+ * names, session/location names, etc.) must use a random or ticket/branch-specific
+ * identifier — never a fixed literal — so parallel runs never collide on the same row
+ * or on the same aggregate query results. See CLAUDE.md's "DB integration tests"
+ * section.
+ *
+ * Convention: extend a descriptive fixed prefix (e.g. `TRIG-TEST-`) with the suffix
+ * from `randomTestSuffix()` rather than inventing a new isolation mechanism per file.
+ */
+
+/** A short random uppercase suffix to append to literal identifiers a test writes. */
+export function randomTestSuffix(): string {
+	return crypto.randomUUID().slice(0, 8).toUpperCase();
+}
+
+/**
+ * A random date far enough in the future to never collide with e2e seed data (which
+ * spans 2021–2024) or with the same date chosen by a concurrent test run. Use this
+ * instead of a fixed literal date for any row that feeds a query aggregating across a
+ * whole group (e.g. `stats_per_day_and_species`), where two concurrent runs picking the
+ * same date would combine their rows into a single aggregate and break both runs'
+ * expectations.
+ */
+export function randomFutureDate(): string {
+	const year = 2080 + Math.floor(Math.random() * 20); // 2080–2099
+	const month = String(1 + Math.floor(Math.random() * 12)).padStart(2, '0');
+	const day = String(1 + Math.floor(Math.random() * 28)).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+}
+
+/** Adds `days` (may be negative) to an ISO `YYYY-MM-DD` date string. */
+export function addDays(isoDate: string, days: number): string {
+	const date = new Date(`${isoDate}T00:00:00Z`);
+	date.setUTCDate(date.getUTCDate() + days);
+	return date.toISOString().slice(0, 10);
+}

--- a/supabase/__tests__/triggers.test.ts
+++ b/supabase/__tests__/triggers.test.ts
@@ -12,6 +12,7 @@ import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import { execSync } from 'child_process';
 import { getAuthenticatedSupabaseClientForGroup } from '../../lib/group-auth';
 import { supabase } from '../../lib/supabase';
+import { randomTestSuffix } from './test-isolation';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 const LOCAL_DB_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
@@ -54,9 +55,11 @@ describe('Encounters — same-session retrap suppression trigger', () => {
 		if (speciesError || !species) throw new Error('Robin species not found — run npm run db:seed:e2e first');
 		const speciesId = species.id;
 
+		const testSuffix = randomTestSuffix();
+
 		const { data: loc, error: locError } = await groupClient
 			.from('Locations')
-			.insert({ location_name: 'Trigger Test Location', ringing_group_id: deltaId })
+			.insert({ location_name: `Trigger Test Location ${testSuffix}`, ringing_group_id: deltaId })
 			.select('id')
 			.single();
 		if (locError) throw locError;
@@ -71,7 +74,7 @@ describe('Encounters — same-session retrap suppression trigger', () => {
 		sessionId = sess!.id;
 
 		const birds = await Promise.all(
-			['TRIG-TEST-N', 'TRIG-TEST-S', 'TRIG-TEST-FRESH'].map((ringNo) =>
+			[`TRIG-TEST-N-${testSuffix}`, `TRIG-TEST-S-${testSuffix}`, `TRIG-TEST-FRESH-${testSuffix}`].map((ringNo) =>
 				groupClient
 					.from('Birds')
 					.insert({ ring_no: ringNo, species_id: speciesId })


### PR DESCRIPTION
## Summary

Audits every `.insert()` / `.update()` / `.upsert()` / `.delete()` call in `supabase/__tests__/*.ts` for hardcoded literal identifiers that could collide when `swarm` runs multiple worktrees concurrently against the same shared local Supabase instance.

- Adds a small shared helper module, `supabase/__tests__/test-isolation.ts`, with `randomTestSuffix()`, `randomFutureDate()`, and `addDays()` — documented at the top of the file per CLAUDE.md's DB integration tests section.
- `triggers.test.ts`: extends the existing `TRIG-TEST-*` prefix with a random suffix, and randomises the test location name.
- `rpc-functions.test.ts` (`unweighed encounters` and `juvenile encounters` blocks under `stats_per_day_and_species`): randomises location names, ring numbers, and — importantly — session dates. These blocks feed a group-wide aggregate RPC, so two concurrent runs picking the same fixed date (e.g. `2098-06-01`) would combine their rows into a single aggregate result and break both runs' assertions, even without a unique-constraint violation.
- `readonly-role.test.ts`: randomises the two literal names used in its rejected INSERT/UPDATE, for consistency with the convention (these writes always fail with the read-only transaction error `25006` before committing, so there's no real collision risk today, but the values shouldn't rely on that invariant holding).
- `rls.test.ts` and `ring-sequences.test.ts` contain no writes — out of scope.
- Updates CLAUDE.md's "DB integration tests" section to point at the new shared helper and explain the aggregate-RPC collision case.

## Test plan

- `npm run test:integration` — 5 files, 79 tests, all passing.
- `npm run qa` (lint + type-check + app tests) — 46 files, 561 tests, all passing.
- Pre-push hook (app tests, DB integration tests, and the full Playwright E2E suite) — all green (98 E2E tests passed).

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)