### PR TITLE
Split E2E suite so most branches skip shared-state-mutating specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,6 @@ playwright-report/
 test-results/
 e2e/group-ids.json
 
-# swarm's local worker-tracking state (machine-local, never committed)
+# swarm's local worker-tracking state and per-ticket worktrees (machine-local, never committed)
 /.claude/swarm-state.json
+/.claude/worktrees/

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 npm run lint
 npx tsc --noEmit
 npm run test:nowatch
-npm run test:e2e
+./scripts/e2e-select-suite.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,7 +225,11 @@ source it exercises:
 - `scripts/e2e-select-suite.sh` diffs the branch against `origin/main`; if any changed file matches
   a trigger path it runs the full `npm run test:e2e`, otherwise `npm run test:e2e:safe`
   (`--grep-invert @mutates`) — so most branches never execute the mutating spec at all, and don't
-  need any cross-worktree coordination for it.
+  need any cross-worktree coordination for it. It also treats a change to any direct (one-level,
+  not transitive) local import dependency of a trigger file as touching that trigger — resolved by
+  `scripts/resolve-mutating-import-deps.mjs` via a regex-based import scan, excluding type-only
+  imports — so editing e.g. `lib/group-auth.ts` (imported by `app/api/import/route.ts`) still
+  selects the full suite even though it isn't listed in `mutating-spec-triggers.json` itself.
 - Adding a new spec that writes to shared fixture rows: tag its `test.describe`/`test` with
   `@mutates` and add its trigger paths to `e2e/mutating-spec-triggers.json` — the hook and the
   ticket-labelling skills both read that one file, so nothing else needs updating.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,18 +161,23 @@ Three separate Vitest configs:
 | Suite | Config | Command | Runs in |
 |---|---|---|---|
 | App tests | `vitest.config.ts` | `npm run test:nowatch` | pre-push hook + CI |
-| DB integration tests | `vitest.integration.config.ts` | `npm run test:integration` | pre-push hook (requires local Supabase) |
+| DB integration tests | `vitest.integration.config.ts` | `npm run test:integration` | manually (requires local Supabase) |
 | HTTP tests | `vitest.http.config.ts` | `npm run test:http` | manually (auto-starts Next.js dev server if not running) |
+| E2E tests | `playwright.config.ts` | `npm run test:e2e` (full) / `test:e2e:safe` / `test:e2e:mutates` | pre-push hook (diff-aware, see below) + CI (full) |
 
 ```sh
 npm test              # watch mode (app tests only)
 npm run test:nowatch  # single run (app tests)
 npm run test:integration  # DB integration tests against local Supabase
 npm run test:http     # HTTP tests — starts dev server automatically if needed
+npm run test:e2e      # full Playwright E2E suite
 npm run qa            # lint + type-check + app tests
 ```
 
-The pre-push hook runs app tests and DB integration tests. Local Supabase must be running (`npm run db:start:local`) and seeded (`npm run db:seed:e2e`) for integration tests to pass.
+The pre-push hook runs app tests, then `scripts/e2e-select-suite.sh` (see "E2E tests" below) —
+never DB integration tests, which are run manually. Local Supabase must be running
+(`npm run db:start:local`) and seeded (`npm run db:seed:e2e`) for the E2E and DB integration
+suites to pass.
 
 HTTP tests (`http-tests/`) use `http-tests/global-setup.ts` to start/stop the Next.js dev server automatically. If a server is already running at `http://localhost:3000` (or `TEST_BASE_URL`), it reuses it and does not kill it after the suite.
 
@@ -199,6 +204,31 @@ group-wide aggregate RPC's results (e.g. `stats_per_day_and_species`) even witho
 constraint. Use the shared helpers in `supabase/__tests__/test-isolation.ts`
 (`randomTestSuffix`, `randomFutureDate`, `addDays`) rather than inventing a new isolation
 mechanism per file; extend an existing prefix convention (e.g. `TRIG-TEST-`) with the suffix.
+
+### E2E tests (Playwright)
+
+Playwright specs live in `e2e/`, run against fixed seed-data groups (`Alpha`/`Beta`/`Gamma`/`Delta`,
+seeded by `npm run db:seed:e2e`) and the same single shared local Supabase instance as everything
+else. Unlike DB integration tests, most E2E specs are read-only assertions against that stable
+seed data — safe under any amount of worktree concurrency, since nothing mutates the rows they
+read.
+
+The exception is any spec tagged `@mutates` (currently only `e2e/authenticated/import.spec.ts`,
+which does raw writes/deletes against the `Delta` group's rows) — concurrent worktrees both
+running a `@mutates` spec at the same time can collide. Rather than isolating each one (there's
+only one, and its writes are inherently global-fixture writes, not isolable per-worktree rows),
+the pre-push hook avoids running it unless the branch's diff actually touches the spec or the
+source it exercises:
+
+- `e2e/mutating-spec-triggers.json` maps the `@mutates` tag to the paths that make it relevant
+  (e.g. `lib/demon-import.ts`, `app/api/import/`).
+- `scripts/e2e-select-suite.sh` diffs the branch against `origin/main`; if any changed file matches
+  a trigger path it runs the full `npm run test:e2e`, otherwise `npm run test:e2e:safe`
+  (`--grep-invert @mutates`) — so most branches never execute the mutating spec at all, and don't
+  need any cross-worktree coordination for it.
+- Adding a new spec that writes to shared fixture rows: tag its `test.describe`/`test` with
+  `@mutates` and add its trigger paths to `e2e/mutating-spec-triggers.json` — the hook and the
+  ticket-labelling skills both read that one file, so nothing else needs updating.
 
 ## Environment variables
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,8 +227,9 @@ source it exercises:
   (`--grep-invert @mutates`) — so most branches never execute the mutating spec at all, and don't
   need any cross-worktree coordination for it. It also treats a change to any direct (one-level,
   not transitive) local import dependency of a trigger file as touching that trigger — resolved by
-  `scripts/resolve-mutating-import-deps.mjs` via a regex-based import scan, excluding type-only
-  imports — so editing e.g. `lib/group-auth.ts` (imported by `app/api/import/route.ts`) still
+  `scripts/resolve-mutating-import-deps.mjs`, which parses each trigger file with the TypeScript
+  compiler API and walks its import declarations, excluding type-only imports — so editing e.g.
+  `lib/group-auth.ts` (imported by `app/api/import/route.ts`) still
   selects the full suite even though it isn't listed in `mutating-spec-triggers.json` itself.
 - Adding a new spec that writes to shared fixture rows: tag its `test.describe`/`test` with
   `@mutates` and add its trigger paths to `e2e/mutating-spec-triggers.json` — the hook and the

--- a/e2e/authenticated/import.spec.ts
+++ b/e2e/authenticated/import.spec.ts
@@ -10,7 +10,7 @@ function psql(sql: string) {
 	if (result.status !== 0) throw new Error(`psql failed: ${result.stderr}`)
 }
 
-test.describe.serial('import flow', { tag: '@delta' }, () => {
+test.describe.serial('import flow', { tag: ['@delta', '@mutates'] }, () => {
 	test.beforeAll(async () => {
 		// Disable trigger to avoid NOT NULL proven_age violation when all encounters for a bird are deleted
 		psql(`ALTER TABLE "Encounters" DISABLE TRIGGER trigger_encounters_refresh_bird_proven_age`)

--- a/e2e/mutating-spec-triggers.json
+++ b/e2e/mutating-spec-triggers.json
@@ -1,0 +1,8 @@
+{
+	"@mutates": [
+		"lib/demon-import.ts",
+		"app/api/import/",
+		"scripts/import-csv.ts",
+		"e2e/authenticated/import.spec.ts"
+	]
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ const eslintConfig = [
       "build/**",
       "next-env.d.ts",
       "app/_v1/**",
+      ".claude/worktrees/**",
     ],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
 		"test:integration": "dotenvx run -f .env.dev -- vitest run --config vitest.integration.config.ts",
 		"test:http": "vitest run --config vitest.http.config.ts",
 		"test:e2e": "playwright test",
+		"test:e2e:safe": "playwright test --grep-invert @mutates",
+		"test:e2e:mutates": "playwright test --grep @mutates",
 		"qa": "npm run lint && npm run type:check && npm run test:ci",
 		"prepare": "husky"
 	},

--- a/scripts/e2e-select-suite.sh
+++ b/scripts/e2e-select-suite.sh
@@ -5,6 +5,12 @@ CHANGED=$(git diff --name-only origin/main...HEAD)
 
 TRIGGER_PATHS=$(node --input-type=commonjs -e "console.log(require('./e2e/mutating-spec-triggers.json')['@mutates'].join('\n'))")
 
+# Also treat direct (one-level) local import dependencies of the trigger
+# files as trigger paths — see scripts/resolve-mutating-import-deps.mjs.
+DEPENDENCY_PATHS=$(node scripts/resolve-mutating-import-deps.mjs)
+TRIGGER_PATHS="$TRIGGER_PATHS
+$DEPENDENCY_PATHS"
+
 MATCHED=false
 while IFS= read -r path; do
 	[ -z "$path" ] && continue

--- a/scripts/e2e-select-suite.sh
+++ b/scripts/e2e-select-suite.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+CHANGED=$(git diff --name-only origin/main...HEAD)
+
+TRIGGER_PATHS=$(node --input-type=commonjs -e "console.log(require('./e2e/mutating-spec-triggers.json')['@mutates'].join('\n'))")
+
+MATCHED=false
+while IFS= read -r path; do
+	[ -z "$path" ] && continue
+	if echo "$CHANGED" | grep -qF "$path"; then
+		MATCHED=true
+		break
+	fi
+done <<EOF
+$TRIGGER_PATHS
+EOF
+
+if [ "$MATCHED" = true ]; then
+	echo "e2e-select-suite: diff touches an @mutates trigger path — running full test:e2e"
+	exec npm run test:e2e
+else
+	echo "e2e-select-suite: diff doesn't touch any @mutates trigger path — running test:e2e:safe"
+	exec npm run test:e2e:safe
+fi

--- a/scripts/resolve-mutating-import-deps.mjs
+++ b/scripts/resolve-mutating-import-deps.mjs
@@ -11,13 +11,17 @@
  * Type-only imports are excluded, since they can't affect runtime behaviour:
  *   - whole-statement `import type { X } from '...'`
  *   - named specifiers marked inline, `import { type X } from '...'`
- *   - named specifiers that resolve to a `export type`/`export interface`
- *     declaration in the target file, even when imported without the `type`
- *     keyword (common in this codebase, e.g. `types/supabase.types.ts`)
+ *   - named specifiers that resolve to a `export type`/`export interface`/
+ *     `export type { X }`/`export { type X }` declaration in the target
+ *     file, even when imported without the `type` keyword (common in this
+ *     codebase, e.g. `types/supabase.types.ts`)
  *
- * This is a regex-based scan, not a full TS parse — it's deliberately kept
- * lightweight (one level deep only) rather than pulling in the TypeScript
- * compiler API for a check this narrow in scope.
+ * Each trigger file (and each target file it imports from) is parsed into a
+ * real TypeScript AST via the `typescript` compiler API, rather than
+ * pattern-matching import statements with regexes — so the parsing handles
+ * the full grammar (multi-line clauses, aliases, JSX, etc.) correctly rather
+ * than approximately. Resolution is still deliberately kept to one level
+ * deep only, not a full transitive dependency graph.
  *
  * Usage: node scripts/resolve-mutating-import-deps.mjs
  * Prints one repo-relative path per line.
@@ -25,16 +29,13 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import ts from 'typescript';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 
 const triggersPath = path.join(repoRoot, 'e2e', 'mutating-spec-triggers.json');
 const triggers = JSON.parse(readFileSync(triggersPath, 'utf8'))['@mutates'];
-
-const IMPORT_STATEMENT_RE =
-	/^\s*import\s+(type\s+)?([\s\S]*?)\s+from\s+['"]([^'"]+)['"];?/gm;
-const TYPE_EXPORT_RE = /^\s*export\s+(?:type|interface)\s+([A-Za-z0-9_$]+)/gm;
 
 /** Expand a trigger path (file or directory) into its .ts/.tsx source files. */
 function sourceFilesFor(triggerPath) {
@@ -84,75 +85,105 @@ function resolveLocalImport(specifier, fromFile) {
 	);
 }
 
-/** Names exported as `export type X` / `export interface X` from a file. */
-function typeOnlyExportNames(file) {
+const sourceFileCache = new Map();
+
+/** Parse a file into a TypeScript AST, caching since files can be visited more than once. */
+function parseSourceFile(file) {
+	let sourceFile = sourceFileCache.get(file);
+	if (sourceFile) return sourceFile;
 	const contents = readFileSync(file, 'utf8');
-	const names = new Set();
-	let match;
-	TYPE_EXPORT_RE.lastIndex = 0;
-	while ((match = TYPE_EXPORT_RE.exec(contents))) names.add(match[1]);
+	const scriptKind = file.endsWith('.tsx')
+		? ts.ScriptKind.TSX
+		: ts.ScriptKind.TS;
+	sourceFile = ts.createSourceFile(
+		file,
+		contents,
+		ts.ScriptTarget.Latest,
+		/* setParentNodes */ true,
+		scriptKind
+	);
+	sourceFileCache.set(file, sourceFile);
+	return sourceFile;
+}
+
+function hasExportModifier(node) {
+	return (
+		ts.canHaveModifiers(node) &&
+		(ts.getModifiers(node) ?? []).some(
+			(modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+		)
+	);
+}
+
+const typeOnlyExportsCache = new Map();
+
+/**
+ * Names exported from a file's top-level statements as type-only:
+ * `export type X`, `export interface X`, `export type { X }`, or
+ * `export { type X }`.
+ */
+function typeOnlyExportNames(file) {
+	let names = typeOnlyExportsCache.get(file);
+	if (names) return names;
+	names = new Set();
+
+	for (const statement of parseSourceFile(file).statements) {
+		if (
+			(ts.isInterfaceDeclaration(statement) ||
+				ts.isTypeAliasDeclaration(statement)) &&
+			hasExportModifier(statement)
+		) {
+			names.add(statement.name.text);
+		} else if (
+			ts.isExportDeclaration(statement) &&
+			statement.exportClause &&
+			ts.isNamedExports(statement.exportClause)
+		) {
+			for (const element of statement.exportClause.elements) {
+				if (statement.isTypeOnly || element.isTypeOnly) {
+					names.add(element.name.text);
+				}
+			}
+		}
+	}
+
+	typeOnlyExportsCache.set(file, names);
 	return names;
 }
 
-/** Parse the clause between `import` and `from` into its specifiers. */
-function parseImportClause(clause) {
-	const braceIndex = clause.indexOf('{');
-	const hasNamed = braceIndex !== -1;
-	const defaultOrNamespacePart = (
-		hasNamed ? clause.slice(0, braceIndex) : clause
-	)
-		.replace(/,\s*$/, '')
-		.trim();
-	const namedPart = hasNamed
-		? clause.slice(braceIndex + 1, clause.lastIndexOf('}'))
-		: '';
-	const namedSpecifiers = namedPart
-		.split(',')
-		.map((s) => s.trim())
-		.filter(Boolean)
-		.map((s) => {
-			const isType = /^type\s+/.test(s);
-			const name = s
-				.replace(/^type\s+/, '')
-				.split(/\s+as\s+/)[0]
-				.trim();
-			return { name, isType };
-		});
-	return {
-		hasDefaultOrNamespace: defaultOrNamespacePart.length > 0,
-		namedSpecifiers
-	};
-}
+/** Does this import declaration's clause pull in at least one runtime value from targetFile? */
+function importsAValue(importClause, targetFile) {
+	if (!importClause) return false; // side-effect-only import, e.g. `import './x'`
+	if (importClause.isTypeOnly) return false; // whole-statement `import type { X } from '...'`
+	if (importClause.name) return true; // default import assumed to be a value
 
-/** Does this import statement pull in at least one runtime value? */
-function importsAValue(clause, targetFile) {
-	const { hasDefaultOrNamespace, namedSpecifiers } = parseImportClause(clause);
-	if (hasDefaultOrNamespace) return true; // default/namespace imports assumed to be values
-	if (namedSpecifiers.length === 0) return false; // side-effect-only import, e.g. `import './x'`
+	const namedBindings = importClause.namedBindings;
+	if (!namedBindings) return false;
+	if (ts.isNamespaceImport(namedBindings)) return true; // `import * as X` assumed to be a value
 
-	const unmarkedNames = namedSpecifiers
-		.filter((s) => !s.isType)
-		.map((s) => s.name);
-	if (unmarkedNames.length === 0) return false; // every specifier explicitly `type`
-
+	// NamedImports: `import { A, type B } from '...'`
 	const typeExports = typeOnlyExportNames(targetFile);
-	return unmarkedNames.some((name) => !typeExports.has(name));
+	return namedBindings.elements.some((element) => {
+		if (element.isTypeOnly) return false; // `import { type X }`
+		const importedName = (element.propertyName ?? element.name).text;
+		return !typeExports.has(importedName);
+	});
 }
 
 const deps = new Set();
 
 for (const triggerPath of triggers) {
 	for (const file of sourceFilesFor(triggerPath)) {
-		const contents = readFileSync(file, 'utf8');
-		IMPORT_STATEMENT_RE.lastIndex = 0;
-		let match;
-		while ((match = IMPORT_STATEMENT_RE.exec(contents))) {
-			const [, isTypeOnlyStatement, clause, specifier] = match;
-			if (isTypeOnlyStatement) continue;
+		for (const statement of parseSourceFile(file).statements) {
+			if (!ts.isImportDeclaration(statement)) continue;
+			if (!ts.isStringLiteral(statement.moduleSpecifier)) continue;
 
-			const targetFile = resolveLocalImport(specifier, file);
+			const targetFile = resolveLocalImport(
+				statement.moduleSpecifier.text,
+				file
+			);
 			if (!targetFile) continue;
-			if (!importsAValue(clause, targetFile)) continue;
+			if (!importsAValue(statement.importClause, targetFile)) continue;
 
 			deps.add(path.relative(repoRoot, targetFile));
 		}

--- a/scripts/resolve-mutating-import-deps.mjs
+++ b/scripts/resolve-mutating-import-deps.mjs
@@ -1,0 +1,162 @@
+/**
+ * Resolves the direct (one-level, not transitive) local import dependencies
+ * of the `@mutates` trigger paths in e2e/mutating-spec-triggers.json.
+ *
+ * Why: a change to a file that e.g. lib/demon-import.ts imports from — but
+ * which isn't itself listed as a trigger path — could change import
+ * behaviour just as much as editing the trigger file directly. This script
+ * finds those one-hop dependencies so scripts/e2e-select-suite.sh can treat
+ * changes to them as also touching the trigger.
+ *
+ * Type-only imports are excluded, since they can't affect runtime behaviour:
+ *   - whole-statement `import type { X } from '...'`
+ *   - named specifiers marked inline, `import { type X } from '...'`
+ *   - named specifiers that resolve to a `export type`/`export interface`
+ *     declaration in the target file, even when imported without the `type`
+ *     keyword (common in this codebase, e.g. `types/supabase.types.ts`)
+ *
+ * This is a regex-based scan, not a full TS parse — it's deliberately kept
+ * lightweight (one level deep only) rather than pulling in the TypeScript
+ * compiler API for a check this narrow in scope.
+ *
+ * Usage: node scripts/resolve-mutating-import-deps.mjs
+ * Prints one repo-relative path per line.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+const triggersPath = path.join(repoRoot, 'e2e', 'mutating-spec-triggers.json');
+const triggers = JSON.parse(readFileSync(triggersPath, 'utf8'))['@mutates'];
+
+const IMPORT_STATEMENT_RE =
+	/^\s*import\s+(type\s+)?([\s\S]*?)\s+from\s+['"]([^'"]+)['"];?/gm;
+const TYPE_EXPORT_RE = /^\s*export\s+(?:type|interface)\s+([A-Za-z0-9_$]+)/gm;
+
+/** Expand a trigger path (file or directory) into its .ts/.tsx source files. */
+function sourceFilesFor(triggerPath) {
+	const abs = path.join(repoRoot, triggerPath);
+	if (!existsSync(abs)) return [];
+	if (statSync(abs).isDirectory()) return listSourceFiles(abs);
+	return /\.(ts|tsx)$/.test(abs) ? [abs] : [];
+}
+
+function listSourceFiles(dir) {
+	const results = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		if (entry.name === '__tests__') continue;
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			results.push(...listSourceFiles(full));
+		} else if (
+			/\.(ts|tsx)$/.test(entry.name) &&
+			!/\.(test|spec)\.tsx?$/.test(entry.name)
+		) {
+			results.push(full);
+		}
+	}
+	return results;
+}
+
+/** Resolve an import specifier to an on-disk .ts/.tsx file, if it's local. */
+function resolveLocalImport(specifier, fromFile) {
+	let base;
+	if (specifier.startsWith('.')) {
+		base = path.resolve(path.dirname(fromFile), specifier);
+	} else if (specifier.startsWith('@/')) {
+		base = path.join(repoRoot, specifier.slice(2));
+	} else {
+		return null; // bare specifier — npm package or Node builtin, not local src
+	}
+	const candidates = [
+		`${base}.ts`,
+		`${base}.tsx`,
+		path.join(base, 'index.ts'),
+		path.join(base, 'index.tsx')
+	];
+	return (
+		candidates.find(
+			(candidate) => existsSync(candidate) && statSync(candidate).isFile()
+		) ?? null
+	);
+}
+
+/** Names exported as `export type X` / `export interface X` from a file. */
+function typeOnlyExportNames(file) {
+	const contents = readFileSync(file, 'utf8');
+	const names = new Set();
+	let match;
+	TYPE_EXPORT_RE.lastIndex = 0;
+	while ((match = TYPE_EXPORT_RE.exec(contents))) names.add(match[1]);
+	return names;
+}
+
+/** Parse the clause between `import` and `from` into its specifiers. */
+function parseImportClause(clause) {
+	const braceIndex = clause.indexOf('{');
+	const hasNamed = braceIndex !== -1;
+	const defaultOrNamespacePart = (
+		hasNamed ? clause.slice(0, braceIndex) : clause
+	)
+		.replace(/,\s*$/, '')
+		.trim();
+	const namedPart = hasNamed
+		? clause.slice(braceIndex + 1, clause.lastIndexOf('}'))
+		: '';
+	const namedSpecifiers = namedPart
+		.split(',')
+		.map((s) => s.trim())
+		.filter(Boolean)
+		.map((s) => {
+			const isType = /^type\s+/.test(s);
+			const name = s
+				.replace(/^type\s+/, '')
+				.split(/\s+as\s+/)[0]
+				.trim();
+			return { name, isType };
+		});
+	return {
+		hasDefaultOrNamespace: defaultOrNamespacePart.length > 0,
+		namedSpecifiers
+	};
+}
+
+/** Does this import statement pull in at least one runtime value? */
+function importsAValue(clause, targetFile) {
+	const { hasDefaultOrNamespace, namedSpecifiers } = parseImportClause(clause);
+	if (hasDefaultOrNamespace) return true; // default/namespace imports assumed to be values
+	if (namedSpecifiers.length === 0) return false; // side-effect-only import, e.g. `import './x'`
+
+	const unmarkedNames = namedSpecifiers
+		.filter((s) => !s.isType)
+		.map((s) => s.name);
+	if (unmarkedNames.length === 0) return false; // every specifier explicitly `type`
+
+	const typeExports = typeOnlyExportNames(targetFile);
+	return unmarkedNames.some((name) => !typeExports.has(name));
+}
+
+const deps = new Set();
+
+for (const triggerPath of triggers) {
+	for (const file of sourceFilesFor(triggerPath)) {
+		const contents = readFileSync(file, 'utf8');
+		IMPORT_STATEMENT_RE.lastIndex = 0;
+		let match;
+		while ((match = IMPORT_STATEMENT_RE.exec(contents))) {
+			const [, isTypeOnlyStatement, clause, specifier] = match;
+			if (isTypeOnlyStatement) continue;
+
+			const targetFile = resolveLocalImport(specifier, file);
+			if (!targetFile) continue;
+			if (!importsAValue(clause, targetFile)) continue;
+
+			deps.add(path.relative(repoRoot, targetFile));
+		}
+	}
+}
+
+for (const dep of deps) console.log(dep);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,12 @@ export default defineConfig({
     name: 'app',
     setupFiles: ['./vitest.setup.tsx'],
     environment: 'happy-dom',
-    exclude: ['**/node_modules/**', 'supabase/__tests__/**', 'http-tests/**', 'e2e/**'],
+    exclude: [
+      '**/node_modules/**',
+      'supabase/__tests__/**',
+      'http-tests/**',
+      'e2e/**',
+      '.claude/worktrees/**',
+    ],
   },
 })


### PR DESCRIPTION
## Summary
- Concurrent `swarm` worktrees push at the same time and both run the full Playwright E2E suite against the single shared local Supabase instance. `e2e/authenticated/import.spec.ts` does raw, unscoped writes/deletes against fixed seed-data rows, so unrelated specs in a sibling worktree can fail mid-push.
- Tag any spec that mutates shared fixture rows with `@mutates` (currently only `import.spec.ts`) and add `e2e/mutating-spec-triggers.json` mapping that tag to the source paths that make it relevant.
- `.husky/pre-push` now runs `scripts/e2e-select-suite.sh`: diffs the branch against `origin/main`, runs the full `test:e2e` only if the diff touches a trigger path, otherwise `test:e2e:safe` (`--grep-invert @mutates`). Most branches never execute the destructive spec at all — no reseeding, no coordination needed.
- `test:e2e` (full) is unchanged and still what CI uses.
- Fixed a doc/hook mismatch found along the way: CLAUDE.md claimed the pre-push hook ran DB integration tests — it never did; it actually runs E2E tests (previously undocumented as a suite at all). Corrected the suite table and added an "E2E tests (Playwright)" section.
- Also fixed two related contention bugs surfaced while verifying this: `.claude/worktrees/` (where `swarm` puts per-ticket worktrees) was neither gitignored nor excluded from eslint/vitest, so a worktree with build/test artifacts on disk broke lint and app-test runs from the main checkout.

This is increment 1 of 2 — increment 2 will generalize `swarm`'s `db-migration` in-flight cap into a small exclusive-resource label set (`db-migration` + a new `e2e-exclusive`) so the rare ticket that *does* need the mutating spec is still serialized across worktrees, without a filesystem lock.

## Test plan
- [x] `npm run test:e2e:safe` — 95 tests, `import flow` specs excluded
- [x] `npm run test:e2e:mutates` — only the 3 `import flow` tests run, all pass
- [x] `scripts/e2e-select-suite.sh` picks `test:e2e:safe` on a diff untouched by trigger paths, and full `test:e2e` when the diff touches `import.spec.ts`/`lib/demon-import.ts`
- [x] Full pre-push hook run (lint, type-check, `test:nowatch`, `e2e-select-suite.sh`) — 561 app tests + 98 E2E tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)