### PR TITLE
Generalize swarm's db-migration cap to an exclusive-resource label set

### DIFF
--- a/.claude/skills/flesh-out-ticket/SKILL.md
+++ b/.claude/skills/flesh-out-ticket/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Turn ONE sketched task into a precise, commit-sized, test-enumerated ticket and file it as a
   labelled GitHub issue. Fleshes out scope/acceptance criteria, breaks the work into small
   commits, enumerates describe blocks and test titles (USE algorithm), identifies which stack
-  layers it touches (tagging `db-migration` if it touches `supabase/schema/`), picks the
+  layers it touches (tagging `db-migration` if it touches `supabase/schema/`, or `e2e-exclusive`
+  if it touches a path listed in `e2e/mutating-spec-triggers.json`), picks the
   cheapest Claude model that can do it accurately (fable/sonnet/opus label), ALWAYS asks for
   confirmation, then runs `gh issue create` with the model label plus `ready`. Can optionally
   file the ticket as a GitHub sub-issue of a named tracking issue. Operates on a single task
@@ -83,13 +84,18 @@ Then call **AskUserQuestion** offering: **Confirm & create** / **Edit** / **Chan
 ### 7. Create the GitHub issue
 Only after confirmation:
 1. Ensure labels exist. Run `gh label list`. `ready`/`opus`/`sonnet`/`fable` already exist in
-   this repo. If the ticket touches `supabase/schema/` (step 2) and the `db-migration` label is
-   missing, create it:
-   `gh label create db-migration --color b60205 --description "Touches supabase/schema/ — swarm runs at most one of these at a time"`
+   this repo. These two are the **exclusive-resource label set** — `swarm` caps at most 1
+   ticket carrying *either* in flight at a time, since both mean the ticket will mutate the
+   single shared local Supabase instance. Create whichever is missing and needed:
+   - If the ticket touches `supabase/schema/` (step 2) and `db-migration` is missing:
+     `gh label create db-migration --color b60205 --description "Touches supabase/schema/ — swarm runs at most one exclusive-resource ticket at a time"`
+   - If the ticket touches a path listed in `e2e/mutating-spec-triggers.json` (step 2) and
+     `e2e-exclusive` is missing:
+     `gh label create e2e-exclusive --color b60205 --description "Touches a @mutates E2E spec's trigger path — swarm runs at most one exclusive-resource ticket at a time"`
 2. Write the fleshed markdown (sections 1–4) to a temp file in the scratchpad and create the
    issue from it (avoids shell-escaping problems):
    `gh issue create --title "<title>" --body-file <tmpfile> --label <model> --label ready`
-   — add `--label db-migration` too if step 2 flagged a schema change.
+   — add `--label db-migration` and/or `--label e2e-exclusive` too if step 2 flagged either.
 3. If the task came from a named tracking issue (see Input), link the new issue as its
    sub-issue: `gh api repos/{owner}/{repo}/issues/<parent>/sub_issues -f sub_issue_id=<new-issue-node-id>`
    (resolve the new issue's node id via `gh issue view <new-number> --json id` first).
@@ -98,6 +104,7 @@ Only after confirmation:
 ## Rules
 - Single task per run. Never batch — that's `tasks-to-tickets`.
 - Every issue gets exactly two labels (model + `ready`), plus `db-migration` when it touches
-  `supabase/schema/`.
+  `supabase/schema/` and/or `e2e-exclusive` when it touches a path in
+  `e2e/mutating-spec-triggers.json`.
 - Confirmation gate in step 6 is mandatory — no issue without an explicit yes.
 - Sub-issue linking only happens when the task's source was a named tracking issue.

--- a/.claude/skills/swarm/SKILL.md
+++ b/.claude/skills/swarm/SKILL.md
@@ -5,8 +5,9 @@ description: >-
   then pick unblocked `ready` GitHub issues and implement them in parallel. Each unit of work
   runs in its own git worktree via a subagent on the model named by the ticket's label
   (fable/sonnet/opus). Biases toward tickets that unblock the most others, and never runs more
-  than one `db-migration`-labelled ticket at a time (this repo shares one local Supabase
-  instance across worktrees). Each ticket subagent runs the implement-ticket skill (branch,
+  than one exclusive-resource-labelled ticket (`db-migration` or `e2e-exclusive`, combined) at a
+  time (this repo shares one local Supabase instance across worktrees). Each ticket subagent runs
+  the implement-ticket skill (branch,
   commits, tests, PR with "Closes #<n>", mermaid-diff). Runs as a continuously-refilling pool
   of up to 4 worker subagents (the orchestrator doesn't count): each completion triggers a
   re-select + respawn until no eligible work remains; while idle, a "check again" command forces
@@ -64,10 +65,12 @@ Entry shape:
 **Concurrency is capped at 4 worker subagents.** The top-level swarm orchestrator (the parent
 agent running this skill) does not count toward the cap — it only selects, spawns, reports and
 refills; it holds no worktree and does no ticket work. So: 1 orchestrator + up to 4 workers.
-Within that cap, **at most 1 `db-migration`-labelled ticket may be in flight at a time** — this
-repo has a single shared local Supabase instance, so concurrent schema migrations or concurrent
-DB integration tests from different worktrees can collide. Non-`db-migration` tickets are not
-affected by this extra cap.
+Within that cap, **at most 1 ticket carrying an exclusive-resource label may be in flight at a
+time** — the exclusive-resource label set is `db-migration` and `e2e-exclusive`. Both mean the
+ticket will mutate the single shared local Supabase instance (schema migrations, or the
+`@mutates`-tagged E2E specs a ticket's diff will trigger per `e2e/mutating-spec-triggers.json`),
+so they share **one combined counter**, not two independent caps. Tickets carrying neither label
+are not affected by this extra cap.
 
 PR maintenance goes first — merging open PRs unblocks downstream tickets — so allocate free
 slots to PRs needing maintenance first, then fill the remainder with tickets.
@@ -124,10 +127,11 @@ Filter and rank:
   unblocked).
 - **Skip in-flight** — drop issues that already have an open linked PR or an existing branch
   (`gh issue view <n> --json closedByPullRequestsReferences` / `git branch -a`).
-- **Cap `db-migration` at 1 in-flight** — if a ticket carries the `db-migration` label, only
-  select it if no other `db-migration` ticket is currently running **and** none has already been
-  picked earlier in this same selection pass. Extra `db-migration` tickets are skipped this
-  round; they remain eligible on the next refill once the in-flight one completes.
+- **Cap the exclusive-resource label set at 1 in-flight** — if a ticket carries `db-migration` or
+  `e2e-exclusive`, only select it if no other ticket carrying either label is currently running
+  **and** none has already been picked earlier in this same selection pass. Extra
+  exclusive-resource tickets are skipped this round; they remain eligible on the next refill once
+  the in-flight one completes.
 - **Bias to unblockers** — among what's left, rank by the count of *open* issues in `blocking`
   (how many others this ticket unblocks), highest first; tie-break on lowest issue number.
 - Take as many as the **free slots** allow (4 minus workers currently running — both tracks).
@@ -153,7 +157,7 @@ Append a `kind: "ticket"` entry (see State file) for this worker right after spa
 
 The subagent owns branch/commits/tests/PR/mermaid-diff via `implement-ticket`, including the
 test-isolation rule for any DB integration tests it writes. swarm does not duplicate that
-logic — it only pins the branch base to `origin/main` and enforces the `db-migration` cap so
+logic — it only pins the branch base to `origin/main` and enforces the exclusive-resource cap so
 parallel worktrees don't build on a stale checkout or collide on the shared local Supabase
 instance.
 
@@ -171,13 +175,13 @@ time):
      couldn't push so the user can intervene.
 3. **Refill** — unless termination has been requested (see below), immediately re-run selection
    (§1 then §2) for the now-free slot(s) and spawn replacements up to the cap (respecting the
-   `db-migration` cap). A finished ticket often makes its PR eligible for maintenance and unblocks
-   downstream tickets, so a completion usually creates fresh work. If nothing is eligible and no
-   workers remain, report the pool is drained and go idle.
+   exclusive-resource cap). A finished ticket often makes its PR eligible for maintenance and
+   unblocks downstream tickets, so a completion usually creates fresh work. If nothing is
+   eligible and no workers remain, report the pool is drained and go idle.
 
 Track the live worker set (subagent id → what it's doing, including whether it's the in-flight
-`db-migration` ticket) across the whole run so the cap, refill, and termination logic all have an
-accurate count.
+exclusive-resource ticket) across the whole run so the cap, refill, and termination logic all
+have an accurate count.
 
 ## 4.5 Manual re-check (user asks to re-scan)
 
@@ -190,7 +194,7 @@ If the user issues any re-check-like command — e.g. "check again", "re-check",
 again", "any new work?", "refresh", "poll github" — immediately re-run selection from scratch
 against live GitHub state (§1 maintenance first, then §2 tickets) **without** waiting for a
 completion, and spawn workers for every newly-eligible unit up to the free slots (cap still 4;
-`db-migration` cap still 1; count workers already running). Report what the re-scan found:
+exclusive-resource cap still 1; count workers already running). Report what the re-scan found:
 - If new work is eligible, spawn it and report each unit started (as in §4 step 2).
 - If nothing new is eligible, say so plainly (e.g. "re-checked — still N blocked, M in-flight,
   nothing newly available") and stay idle.
@@ -234,9 +238,10 @@ Confirm each removal; report anything skipped (e.g. a worktree with unpushed cha
   shared branch.
 - Never pick a blocked ticket; never exceed **4 concurrent worker subagents** across both tracks.
   The orchestrator itself is not a worker and does not count toward the 4.
-- Never run more than **1 `db-migration`-labelled ticket** at a time — extra ones wait for the
-  next refill. This protects the single shared local Supabase instance from concurrent schema
-  migrations.
+- Never run more than **1 exclusive-resource-labelled ticket** (`db-migration` or
+  `e2e-exclusive`, combined) at a time — extra ones wait for the next refill. This protects the
+  single shared local Supabase instance from concurrent schema migrations and concurrent
+  `@mutates`-tagged E2E runs.
 - Keep the pool full: on every worker completion, refill freed slots (maintenance first, then
   tickets) until no eligible work remains — then go idle, don't exit.
 - On any re-check-like command from the user ("check again", "rescan", "any new work?"), re-run

--- a/.claude/skills/tasks-to-tickets/SKILL.md
+++ b/.claude/skills/tasks-to-tickets/SKILL.md
@@ -7,7 +7,9 @@ description: >-
   clarifications/improvements and writing accepted ones back to the source (the tracking issue's
   body, if that's where it came from), before drafting. Enumerates commits and tests, picks a
   model label (fable/sonnet/opus) + `ready`, tags `db-migration` where a task touches
-  `supabase/schema/`, and expresses inter-task dependencies as GitHub native "blocked by" links.
+  `supabase/schema/` and `e2e-exclusive` where it touches a path in
+  `e2e/mutating-spec-triggers.json`, and expresses inter-task dependencies as GitHub native
+  "blocked by" links.
   When run under a named tracking issue, each created ticket is filed as its GitHub sub-issue.
   Drafting is parallelised across subagents, but the flesh-out-ticket confirmation gate still
   fires for every ticket in the main thread. Triggers: "tasks to tickets", "create tickets for
@@ -72,6 +74,8 @@ When there are more than ~3 tasks, fan out to `general-purpose` subagents to dra
   - `body` — the fleshed markdown (context/scope/acceptance/out-of-scope/reuse + stack layers
     touched + commit breakdown + test enumeration).
   - `touchesDbSchema` — whether it touches `supabase/schema/` (drives the `db-migration` label).
+  - `touchesE2eMutatingTrigger` — whether it touches a path listed in
+    `e2e/mutating-spec-triggers.json` (drives the `e2e-exclusive` label).
   - `modelLabel` + one-line justification (`fable`|`sonnet`|`opus`).
   - `dependsOn` — the other tasks (identified by summary) this task is blocked by.
 
@@ -86,9 +90,9 @@ user confirms and can give feedback on each WIP ticket individually.
 
 ### 5. Create issues
 On each confirmation, run `flesh-out-ticket` step 7: ensure the model label, `ready`, and (if
-`touchesDbSchema`) `db-migration` labels exist (create if missing), write the body to a
-scratchpad temp file, then:
-`gh issue create --title "..." --body-file <tmpfile> --label <model> --label ready [--label db-migration]`.
+`touchesDbSchema`) `db-migration` and/or (if `touchesE2eMutatingTrigger`) `e2e-exclusive` labels
+exist (create if missing), write the body to a scratchpad temp file, then:
+`gh issue create --title "..." --body-file <tmpfile> --label <model> --label ready [--label db-migration] [--label e2e-exclusive]`.
 If this run is scoped under a tracking issue, link each created issue as its sub-issue (same
 mechanism as `flesh-out-ticket` step 7.3). Record the mapping `task → issue number`.
 
@@ -110,7 +114,8 @@ links.
 - One issue per task. Reuse `flesh-out-ticket` for the per-ticket work — do not reinvent its
   fleshing, confirmation gate, labelling, or creation logic.
 - Every issue: one model label (`fable`|`sonnet`|`opus`) + `ready`, plus `db-migration` when it
-  touches `supabase/schema/`, plus any blocked-by links and (when scoped under a tracking issue)
-  sub-issue membership.
+  touches `supabase/schema/` and/or `e2e-exclusive` when it touches a path in
+  `e2e/mutating-spec-triggers.json`, plus any blocked-by links and (when scoped under a tracking
+  issue) sub-issue membership.
 - The per-ticket confirmation gate is non-negotiable and runs in the main thread, even when
   drafting was parallelised.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,10 +45,13 @@ subagent implementing it runs on that model:
 - `opus` — fiddly or multi-constraint work (complex SQL, seed-data churn, interacting rules)
 - `fable` — complex or foundational work that sets patterns others build on
 
-If a ticket touches `supabase/schema/`, it also gets the `db-migration` label. This repo has a
-single shared local Supabase instance, so `swarm` never runs more than one `db-migration`-labelled
-ticket at a time — concurrent worktrees running schema migrations or DB integration tests against
-the same instance would otherwise collide.
+This repo has a single shared local Supabase instance, so any ticket that will mutate it gets an
+**exclusive-resource label**, and `swarm` never runs more than one exclusive-resource-labelled
+ticket at a time (combined across the whole set) — concurrent worktrees doing either kind of
+mutation would otherwise collide:
+- `db-migration` — touches `supabase/schema/` (schema migrations or DB integration tests).
+- `e2e-exclusive` — touches a path listed in `e2e/mutating-spec-triggers.json` (an E2E spec
+  tagged `@mutates`; see "E2E tests (Playwright)" below).
 
 ## Authentication model
 
@@ -226,6 +229,9 @@ source it exercises:
   a trigger path it runs the full `npm run test:e2e`, otherwise `npm run test:e2e:safe`
   (`--grep-invert @mutates`) — so most branches never execute the mutating spec at all, and don't
   need any cross-worktree coordination for it.
+- The rare ticket whose scope *does* intersect a trigger path gets the `e2e-exclusive` label
+  (alongside `db-migration`, in the same exclusive-resource set `swarm` caps at 1 in-flight — see
+  "Larger work" above) so two worktrees never run a `@mutates` spec concurrently.
 - Adding a new spec that writes to shared fixture rows: tag its `test.describe`/`test` with
   `@mutates` and add its trigger paths to `e2e/mutating-spec-triggers.json` — the hook and the
   ticket-labelling skills both read that one file, so nothing else needs updating.


### PR DESCRIPTION
## Summary
Stacked on #437 (increment 1 of 2) — merge that first.

- Generalizes `swarm`'s existing "cap `db-migration` at 1 in-flight" mechanism into a small
  **exclusive-resource label set** (`db-migration` + new `e2e-exclusive`), capped at 1 combined
  in-flight — both labels mean the ticket will mutate the single shared local Supabase instance
  (schema migration vs. triggering the `@mutates` E2E spec from #437), so they share one counter
  instead of needing an independent cap invented per new collision type.
- `flesh-out-ticket` and `tasks-to-tickets` now also tag `e2e-exclusive` when a ticket's planned
  scope touches a path in `e2e/mutating-spec-triggers.json` (added in #437), mirroring the
  existing `db-migration` detection for `supabase/schema/`.
- `CLAUDE.md` "Larger work" section and the new "E2E tests (Playwright)" section (from #437) now
  describe the combined label set.

No app code changes — skill/doc prose only.

## Test plan
- No app tests apply (prose-only change).
- Re-read every edited section for internal consistency — no leftover reference to a single
  hardcoded `db-migration` check without its `e2e-exclusive` counterpart (verified via grep).
- Full pre-push hook run (lint, type-check, `test:nowatch`, E2E) passing — 98 E2E tests (full
  suite ran since this branch, based on #437, still diffs against `origin/main` which doesn't yet
  have #437's `import.spec.ts` tag change merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)