### PR TITLE
feat: add group_ticks RPC for first-ever species encounters

### DIFF
--- a/app/models/db.ts
+++ b/app/models/db.ts
@@ -30,3 +30,5 @@ export type LongAbsenceRetrapsResult =
 	Database['public']['Functions']['long_absence_retraps']['Returns'][number];
 export type StatsPerDayAndSpeciesResult =
 	Database['public']['Functions']['stats_per_day_and_species']['Returns'][number];
+export type GroupTicksResult =
+	Database['public']['Functions']['group_ticks']['Returns'][number];

--- a/supabase/__tests__/rpc-functions.test.ts
+++ b/supabase/__tests__/rpc-functions.test.ts
@@ -25,6 +25,23 @@ async function getGroupIdByName(name: string): Promise<number> {
 	return data.id;
 }
 
+// Locations are RLS-scoped to their owning group, so this must be queried with a
+// group-authenticated client rather than the anon `supabase` client used above.
+async function getLocationIdByName(
+	client: SupabaseClient,
+	name: string,
+	ringingGroupId: number
+): Promise<number> {
+	const { data, error } = await client
+		.from('Locations')
+		.select('id')
+		.eq('location_name', name)
+		.eq('ringing_group_id', ringingGroupId)
+		.single();
+	if (error || !data) throw new Error(`Location "${name}" not found — run npm run db:seed:e2e first`);
+	return data.id;
+}
+
 // Seed has 9 Alpha sessions: 2021-06-20, 2022-04-30, 2022-06-15, 2022-08-10,
 // 2022-10-20, 2023-05-12, 2023-07-08, 2023-09-14, 2024-05-10
 const ALPHA_SESSION_COUNT = 9;
@@ -978,6 +995,109 @@ describe('Postgres RPC integration tests', () => {
 					juv_count: 3,
 				});
 			});
+		});
+	});
+
+	describe('group_ticks', () => {
+		// Alpha species first-encounter dates (across all locations, all record types):
+		//   Reed Warbler 2022-06-15, Blue Tit 2022-04-30, Kingfisher 2022-04-30,
+		//   Robin 2021-06-20, Wren 2021-06-20
+		let alphaSiteBLocationId: number;
+
+		beforeAll(async () => {
+			alphaSiteBLocationId = await getLocationIdByName(alphaClient, 'Alpha Site B', alphaId);
+		});
+
+		it('a group with multiple species returns them ordered by most recent first_encounter_date first', async () => {
+			const { data, error } = await alphaClient.rpc('group_ticks', {
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toEqual([
+				{ species_name: 'Reed Warbler', first_encounter_date: '2022-06-15' },
+				{ species_name: 'Blue Tit', first_encounter_date: '2022-04-30' },
+				{ species_name: 'Kingfisher', first_encounter_date: '2022-04-30' },
+				{ species_name: 'Robin', first_encounter_date: '2021-06-20' },
+				{ species_name: 'Wren', first_encounter_date: '2021-06-20' },
+			]);
+		});
+
+		describe('ringing_group_filter parameter', () => {
+			it('scopes to that group only — a species encountered by a different group is excluded', async () => {
+				const { data, error } = await betaClient.rpc('group_ticks', {
+					ringing_group_filter: betaId,
+				});
+				expect(error).toBeNull();
+				expect(data).toEqual([
+					{ species_name: 'Chaffinch', first_encounter_date: '2023-06-01' },
+					{ species_name: 'Robin', first_encounter_date: '2023-06-01' },
+				]);
+				// Alpha-only species (e.g. Kingfisher) never appear when filtered to Beta
+				expect(data!.some((r) => r.species_name === 'Kingfisher')).toBe(false);
+			});
+		});
+
+		describe('location_filter parameter', () => {
+			it('scopes to that location only — a species first encountered at a different location is excluded', async () => {
+				const { data, error } = await alphaClient.rpc('group_ticks', {
+					ringing_group_filter: alphaId,
+					location_filter: alphaSiteBLocationId,
+				});
+				expect(error).toBeNull();
+				expect(data).toEqual([
+					{ species_name: 'Reed Warbler', first_encounter_date: '2023-09-14' },
+					{ species_name: 'Blue Tit', first_encounter_date: '2022-10-20' },
+					{ species_name: 'Robin', first_encounter_date: '2022-10-20' },
+				]);
+				// Kingfisher and Wren were only ever encountered at Alpha Site A (CES)
+				expect(data!.some((r) => r.species_name === 'Kingfisher')).toBe(false);
+				expect(data!.some((r) => r.species_name === 'Wren')).toBe(false);
+			});
+		});
+
+		describe('result_limit parameter', () => {
+			it('truncates the returned rows to N', async () => {
+				const { data, error } = await alphaClient.rpc('group_ticks', {
+					ringing_group_filter: alphaId,
+					result_limit: 2,
+				});
+				expect(error).toBeNull();
+				expect(data).toEqual([
+					{ species_name: 'Reed Warbler', first_encounter_date: '2022-06-15' },
+					{ species_name: 'Blue Tit', first_encounter_date: '2022-04-30' },
+				]);
+			});
+		});
+
+		it('a group with zero encounters returns an empty array', async () => {
+			const { data, error } = await gammaClient.rpc('group_ticks', {
+				ringing_group_filter: gammaId,
+			});
+			expect(error).toBeNull();
+			expect(data).toEqual([]);
+		});
+
+		it('two species sharing the same first_encounter_date are tie-broken by species_name ASC', async () => {
+			const { data, error } = await alphaClient.rpc('group_ticks', {
+				ringing_group_filter: alphaId,
+			});
+			expect(error).toBeNull();
+			const tiedAtJune2021 = data!.filter((r) => r.first_encounter_date === '2021-06-20');
+			expect(tiedAtJune2021.map((r) => r.species_name)).toEqual(['Robin', 'Wren']);
+			const tiedAtApril2022 = data!.filter((r) => r.first_encounter_date === '2022-04-30');
+			expect(tiedAtApril2022.map((r) => r.species_name)).toEqual(['Blue Tit', 'Kingfisher']);
+		});
+
+		it("a species' first-ever encounter logged with a non-'N' record_type still sets first_encounter_date", async () => {
+			// Beta's only Robin encounter is SHARED01, logged as record_type 'S' (a retrap-type
+			// record — the bird was originally ringed by Alpha). group_ticks must not filter to
+			// record_type = 'N' only, or Robin would be missing from Beta's results entirely.
+			const { data, error } = await betaClient.rpc('group_ticks', {
+				ringing_group_filter: betaId,
+			});
+			expect(error).toBeNull();
+			const robinRow = data!.find((r) => r.species_name === 'Robin');
+			expect(robinRow).toEqual({ species_name: 'Robin', first_encounter_date: '2023-06-01' });
 		});
 	});
 });

--- a/supabase/schema/schemas/public/functions/group_ticks.sql
+++ b/supabase/schema/schemas/public/functions/group_ticks.sql
@@ -1,0 +1,32 @@
+CREATE FUNCTION public.group_ticks (
+	ringing_group_filter bigint DEFAULT NULL::bigint,
+	location_filter bigint DEFAULT NULL::bigint,
+	result_limit integer DEFAULT NULL::integer
+) RETURNS TABLE (species_name text, first_encounter_date date) LANGUAGE plpgsql STABLE
+SET
+	search_path TO 'public',
+	'pg_catalog' AS $function$
+BEGIN
+  RETURN QUERY
+	SELECT
+		sp.species_name as species_name,
+		MIN(sess.visit_date) as first_encounter_date
+	FROM public."Encounters" en
+		LEFT JOIN public."Birds" b on b.id=en.bird_id
+		LEFT JOIN public."Species" sp on sp.id=b.species_id
+		LEFT JOIN public."Sessions" sess on sess.id=en.session_id
+	WHERE
+		(ringing_group_filter IS NULL OR sess.ringing_group_id = ringing_group_filter) AND
+		(location_filter IS NULL OR sess.location_id = location_filter)
+	GROUP BY
+		sp.species_name
+	ORDER BY first_encounter_date DESC, sp.species_name ASC
+	LIMIT result_limit;
+END;
+$function$;
+
+GRANT ALL ON FUNCTION public.group_ticks (bigint, bigint, integer) TO anon;
+
+GRANT ALL ON FUNCTION public.group_ticks (bigint, bigint, integer) TO authenticated;
+
+GRANT ALL ON FUNCTION public.group_ticks (bigint, bigint, integer) TO service_role;

--- a/types/supabase.types.ts
+++ b/types/supabase.types.ts
@@ -328,6 +328,17 @@ export type Database = {
           species_name: string
         }[]
       }
+      group_ticks: {
+        Args: {
+          location_filter?: number
+          result_limit?: number
+          ringing_group_filter?: number
+        }
+        Returns: {
+          first_encounter_date: string
+          species_name: string
+        }[]
+      }
       long_absence_retraps: {
         Args: {
           min_gap_days?: number


### PR DESCRIPTION
## Summary

- Adds `public.group_ticks(ringing_group_filter, location_filter, result_limit)`, a Postgres RPC that returns each species' earliest `visit_date` (`first_encounter_date`) across a group's encounters, ordered most-recent-first (tie-broken by species name). Modeled on `notable_retraps.sql`'s filter/grant pattern per the ticket.
- All record types count toward "first encounter" — results are **not** filtered to `record_type = 'N'`, so a species whose earliest logged row happens to be a retrap-type record still gets the correct date.
- `location_filter` is threaded through but unused by any caller yet, keeping a future "site tick" feature a one-parameter call away.
- Adds the `GroupTicksResult` type export in `app/models/db.ts` and regenerates `types/supabase.types.ts`.
- Adds a `describe('group_ticks', ...)` block to `supabase/__tests__/rpc-functions.test.ts` covering the ticket's USE test list, reusing existing Alpha/Beta/Gamma e2e seed data (no new rows written, so no test-isolation concerns).

This is backend-only, per the ticket's scope — no server action or UI consumes this RPC yet (tracked separately, blocked by this ticket).

Closes #423

## Test plan

- [x] `npm run test:integration -- rpc-functions` — 57/57 passing (7 new `group_ticks` tests)
- [x] `npm run test:integration` (full suite) — 86/86 passing
- [x] `npm run qa` (lint + type-check + app tests) — 561/561 app tests passing
- [x] Pre-push hook (lint, tsc, test:nowatch, e2e) — 98/98 Playwright tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)