### PR TITLE
Hide resighting-only sessions from calendar, session pages, and highlight stats

### DIFF
--- a/app/(routes)/sessions/__tests__/page.test.tsx
+++ b/app/(routes)/sessions/__tests__/page.test.tsx
@@ -40,6 +40,15 @@ describe('sessions page', () => {
 		expect(heading.textContent).toBe('Session history');
 	});
 
+	it('excludes resighting-only sessions from the query', async () => {
+		const client = makeChainClient(alphaSessionsSnapshot);
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+		render(await Page());
+		await screen.findByRole('heading', { level: 1 });
+		const chain = client.from.mock.results[0].value;
+		expect(chain.eq).toHaveBeenCalledWith('is_resighting_only', false);
+	});
+
 	describe('with multi-year data (alpha fixture)', () => {
 		beforeEach(() => {
 			mockGetAuthenticatedSupabaseClient.mockResolvedValue(

--- a/app/(routes)/sessions/page.tsx
+++ b/app/(routes)/sessions/page.tsx
@@ -22,6 +22,7 @@ export async function fetchAllSessions(
 			'id, visit_date, location: Locations(id, location_name), encounters:Encounters(count)'
 		)
 		.eq('ringing_group_id', viewedGroupId)
+		.eq('is_resighting_only', false)
 		.order('visit_date', { ascending: false })
 		.then(catchSupabaseErrors) as Promise<SessionWithEncountersCount[]>;
 }

--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -62,11 +62,14 @@ const mockRpc = vi.fn();
 
 const mockSessionsOrder = vi.fn();
 const mockSessionsRange = vi.fn();
+const mockSessionsEq = vi.fn();
+// eq is also on the builder itself so it self-chains — fetchSessionStats now
+// calls .eq() twice (ringing_group_id, then is_resighting_only) before .order()
 const sessionsQueryBuilder = {
+	eq: mockSessionsEq,
 	order: mockSessionsOrder,
 	range: mockSessionsRange
 };
-const mockSessionsEq = vi.fn();
 const mockSessionsSelect = vi.fn(() => ({ eq: mockSessionsEq }));
 
 let statsVersion = 100;
@@ -177,6 +180,15 @@ describe('fetchSessionHighlights', () => {
 		expect(mockFrom).toHaveBeenCalledWith('Sessions');
 		expect(mockSelect).toHaveBeenCalledWith('visit_date');
 		expect(mockEq).toHaveBeenCalledWith('ringing_group_id', GROUP_ID);
+	});
+
+	it('excludes resighting-only sessions from the session-dates query', async () => {
+		const fetchSessionHighlights = await importFetchSessionHighlights();
+		await fetchSessionHighlights({
+			date: SESSION_DATE,
+			viewedGroupId: GROUP_ID
+		});
+		expect(mockSessionsEq).toHaveBeenCalledWith('is_resighting_only', false);
 	});
 
 	it('requests deterministic ordering for paginated queries', async () => {
@@ -299,6 +311,33 @@ describe('fetchSessionHighlights', () => {
 		);
 	});
 
+	it('derives no highlights for a date whose only session is resighting-only, while other days stay unaffected', async () => {
+		// A resighting-only date is excluded from both stats_per_day_and_species
+		// (filtered at the RPC level by #429) and the sessionDates query (filtered
+		// by this ticket's Sessions .eq('is_resighting_only', false)) — it's
+		// simply absent from both stats blobs fed into every derive* function, so
+		// it's indistinguishable from "no session happened that day".
+		rpcPages = [
+			[statsRow('Wren', '2022-05-01', 5), statsRow('Wren', '2022-06-01', 3)]
+		];
+		sessionPages = [
+			[{ visit_date: '2022-05-01' }, { visit_date: '2022-06-01' }]
+		];
+		const fetchSessionHighlights = await importFetchSessionHighlights();
+		const flaggedDateHighlights = await fetchSessionHighlights({
+			date: SESSION_DATE,
+			viewedGroupId: GROUP_ID
+		});
+		expect(flaggedDateHighlights).toEqual([]);
+		// A real session day untouched by the flagged date still derives its
+		// species-level highlights normally
+		const realDayHighlights = await fetchSessionHighlights({
+			date: '2022-05-01',
+			viewedGroupId: GROUP_ID
+		});
+		expect(sentencesOf(realDayHighlights).length).toBeGreaterThan(0);
+	});
+
 	it('serves cached stats when the data version is unchanged', async () => {
 		const fetchSessionHighlights = await importFetchSessionHighlights();
 		await fetchSessionHighlights({
@@ -315,7 +354,9 @@ describe('fetchSessionHighlights', () => {
 			(call) => (call as [string])[0] === 'stats_per_day_and_species'
 		);
 		expect(metricsCalls).toHaveLength(1);
-		expect(mockSessionsEq).toHaveBeenCalledTimes(1);
+		// Two .eq() calls per fetch (ringing_group_id, is_resighting_only), and
+		// the session-dates query only runs once thanks to the stats cache
+		expect(mockSessionsEq).toHaveBeenCalledTimes(2);
 		// version query is run on each call
 		expect(mockEncountersLimit).toHaveBeenCalledTimes(2);
 		// the cached blob still serves other session dates — the 2022 session

--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -73,6 +73,7 @@ async function fetchSessionStats(
 				.from('Sessions')
 				.select('visit_date')
 				.eq('ringing_group_id', viewedGroupId)
+				.eq('is_resighting_only', false)
 				.order('visit_date')
 				.range(fromRow, toRow)
 		)

--- a/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
@@ -98,8 +98,8 @@ const mockEncounters = [
 const mockPreviousSession = [{ visit_date: '2024-03-01' }];
 const mockNextSession = [{ visit_date: '2024-04-01' }];
 
-function makeSessionClient() {
-	const makeChain = (data: unknown) => ({
+function makeChain(data: unknown) {
+	return {
 		select: vi.fn().mockReturnThis(),
 		eq: vi.fn().mockReturnThis(),
 		in: vi.fn().mockReturnThis(),
@@ -109,7 +109,10 @@ function makeSessionClient() {
 		limit: vi.fn().mockReturnThis(),
 		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
 			Promise.resolve({ data, error: null }).then(resolve)
-	});
+	};
+}
+
+function makeSessionClient() {
 	return {
 		from: vi
 			.fn()
@@ -139,6 +142,56 @@ describe('session detail page', () => {
 		render(await renderPage());
 		const heading = await screen.findByRole('heading', { level: 1 });
 		expect(heading.textContent).toContain('15th March 2024');
+	});
+
+	it('excludes resighting-only sessions from the main Sessions query', async () => {
+		const client = makeSessionClient();
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+		render(await renderPage());
+		await screen.findByTestId('session-stats');
+		const mainSessionsChain = client.from.mock.results[0].value;
+		expect(mainSessionsChain.eq).toHaveBeenCalledWith(
+			'is_resighting_only',
+			false
+		);
+	});
+
+	describe('adjacent session date lookups', () => {
+		it('excludes resighting-only sessions from the previous-session lookup', async () => {
+			const client = makeSessionClient();
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+			render(await renderPage());
+			await screen.findByTestId('session-stats');
+			const previousChain = client.from.mock.results[1].value;
+			expect(previousChain.eq).toHaveBeenCalledWith(
+				'is_resighting_only',
+				false
+			);
+		});
+
+		it('excludes resighting-only sessions from the next-session lookup', async () => {
+			const client = makeSessionClient();
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+			render(await renderPage());
+			await screen.findByTestId('session-stats');
+			const nextChain = client.from.mock.results[2].value;
+			expect(nextChain.eq).toHaveBeenCalledWith('is_resighting_only', false);
+		});
+	});
+
+	describe('a date whose only Sessions row is resighting-only', () => {
+		it('renders the "No session found" empty state instead of 404ing', async () => {
+			const client = {
+				from: vi
+					.fn()
+					.mockReturnValueOnce(makeChain([]))
+					.mockReturnValueOnce(makeChain(mockPreviousSession))
+					.mockReturnValueOnce(makeChain(mockNextSession))
+			};
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+			render(await renderPage());
+			await screen.findByText(/No session found/i);
+		});
 	});
 
 	it('renders total bird and species counts', async () => {

--- a/app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx
@@ -108,6 +108,18 @@ describe('session site page', () => {
 		expect(heading.textContent).toContain('15th March 2024');
 	});
 
+	it('excludes resighting-only sessions from the Sessions query', async () => {
+		const client = makeSessionClient();
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+		render(await renderPage());
+		await screen.findByTestId('session-stats');
+		const mainSessionsChain = client.from.mock.results[0].value;
+		expect(mainSessionsChain.eq).toHaveBeenCalledWith(
+			'is_resighting_only',
+			false
+		);
+	});
+
 	it('does not render highlights on the location-filtered page', async () => {
 		render(await renderPage());
 		await screen.findByTestId('session-stats');

--- a/app/group/[groupId]/session/_shared.tsx
+++ b/app/group/[groupId]/session/_shared.tsx
@@ -46,6 +46,7 @@ async function fetchAdjacentSessionDates(
 			.from('Sessions')
 			.select('visit_date')
 			.eq('ringing_group_id', viewedGroupId)
+			.eq('is_resighting_only', false)
 			.lt('visit_date', date)
 			.order('visit_date', { ascending: false })
 			.limit(1)
@@ -54,6 +55,7 @@ async function fetchAdjacentSessionDates(
 			.from('Sessions')
 			.select('visit_date')
 			.eq('ringing_group_id', viewedGroupId)
+			.eq('is_resighting_only', false)
 			.gt('visit_date', date)
 			.order('visit_date', { ascending: true })
 			.limit(1)
@@ -78,6 +80,7 @@ export async function fetchSessionData({
 		)
 		.eq('visit_date', date)
 		.eq('ringing_group_id', viewedGroupId)
+		.eq('is_resighting_only', false)
 		.then(catchSupabaseErrors)) as (SessionRow & { location: LocationRow })[];
 
 	if (!sessions || sessions.length === 0) {


### PR DESCRIPTION
Closes #430

## What this covers

Consumes `Sessions.is_resighting_only` (added in #428) on the read/UI side: every query that lists or navigates between sessions, and the query that feeds session-highlight computations, now excludes `is_resighting_only = true` rows so a passive resighting never appears as if it were a ringing outing.

Adds `.eq('is_resighting_only', false)` to five Supabase queries:
- `fetchAllSessions` (`app/(routes)/sessions/page.tsx`) — the `/sessions` calendar query (also covers `/group/[groupId]/sessions`, which renders the same component).
- `fetchSessionData`'s main `Sessions` select (`app/group/[groupId]/session/_shared.tsx`).
- `fetchAdjacentSessionDates`'s previous- and next-lookup queries, same file.
- `fetchSessionStats`'s `sessionRows` query (`app/actions/session-highlights.ts`), which feeds `stats.sessionDates` used by every `derive*` function in `app/models/session-highlights.ts`.

No new `notFound()` logic was added — a flagged date's session page falls through to the existing "No session found" empty state automatically, since `fetchSessionData` never returns `null` and the Sessions query now simply matches zero rows for that date.

## Related work

#429 (already merged via #441) filters the same `is_resighting_only` flag out of the `stats_per_day_and_species`/`aggregate_stats` RPCs — that's the day/session-level stats layer. This PR is the sibling read/UI-query layer; no scope overlap.

## Tests

- `app/(routes)/sessions/__tests__/page.test.tsx` — asserts the calendar query excludes resighting-only sessions.
- `app/group/[groupId]/session/[date]/__tests__/page.test.tsx` — asserts the main Sessions query and both adjacent-date lookups exclude resighting-only sessions; asserts the "No session found" empty state renders for a date whose only Sessions row would be resighting-only.
- `app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx` — asserts the location-filtered page's Sessions query excludes resighting-only sessions.
- `app/actions/__tests__/session-highlights.test.ts` — asserts the session-dates query excludes resighting-only sessions; adds an edge-case test verifying a date absent from both `stats_per_day_and_species` and the sessionDates query derives zero highlights, while an unrelated real session day is unaffected. Also updates the `sessionsQueryBuilder` mock to self-chain `.eq()` (needed now the code calls it twice).

`npm run qa`: 577 app tests + lint + type-check green. Pre-push E2E (safe suite): 95 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)