### PR TITLE
feat: show last group tick on the home page

### DIFF
--- a/app/(routes)/__tests__/page.test.tsx
+++ b/app/(routes)/__tests__/page.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, cleanup } from '@testing-library/react';
 import Page from '../page';
 import recentSessionsSnapshot from '@/test-fixtures/snapshots/fetchRecentSessions.alpha.json';
 import topSpeciesSnapshot from '@/test-fixtures/snapshots/fetchTopSpecies.alpha.json';
+import type { GroupTicksResult } from '@/app/models/db';
 
 const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
 	mockGetAuthenticatedSupabaseClient: vi.fn()
@@ -16,14 +17,23 @@ vi.mock('@/app/actions/top-performers', () => ({
 	getTopStats: vi.fn().mockResolvedValue([])
 }));
 
+const defaultLastGroupTick: GroupTicksResult[] = [
+	{ species_name: 'Carrion Crow', first_encounter_date: '2026-02-12' }
+];
+
 function makeChainClient(
-	overrides: { Sessions?: unknown; Species?: unknown } = {}
+	overrides: {
+		Sessions?: unknown;
+		Species?: unknown;
+		lastGroupTick?: unknown;
+	} = {}
 ) {
 	const dataByTable: Record<string, unknown> = {
 		Sessions: recentSessionsSnapshot,
 		Species: topSpeciesSnapshot,
 		...overrides
 	};
+	const lastGroupTick = overrides.lastGroupTick ?? defaultLastGroupTick;
 	function chainFor(data: unknown) {
 		const thenable = {
 			then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
@@ -38,7 +48,11 @@ function makeChainClient(
 		};
 	}
 	return {
-		from: vi.fn((table: string) => chainFor(dataByTable[table] ?? []))
+		from: vi.fn((table: string) => chainFor(dataByTable[table] ?? [])),
+		rpc: vi.fn().mockReturnValue({
+			then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+				Promise.resolve({ data: lastGroupTick, error: null }).then(resolve)
+		})
 	};
 }
 
@@ -138,6 +152,31 @@ describe('home page', () => {
 			// 2 sessions on same date: 1 day-total link (StatOutput) + 2 site links
 			// + 1 link each for the 2 single-session dates = 5 total
 			expect(sessionLinks.length).toBe(5);
+		});
+	});
+
+	describe('last group tick', () => {
+		it('renders "Last group tick: {species} on {date}" paragraph when data is present', async () => {
+			render(await Page());
+			expect(
+				await screen.findByText(
+					'Last group tick: Carrion Crow on 12th February 2026'
+				)
+			).toBeDefined();
+		});
+
+		describe('with no ticks yet', () => {
+			it('omits the paragraph entirely', async () => {
+				mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+					makeChainClient({ lastGroupTick: [] })
+				);
+				render(await Page());
+				const heading = await screen.findByRole('heading', {
+					name: 'Recent Sessions'
+				});
+				expect(heading).toBeDefined();
+				expect(screen.queryByText(/Last group tick:/)).toBeNull();
+			});
 		});
 	});
 

--- a/app/(routes)/page.tsx
+++ b/app/(routes)/page.tsx
@@ -17,9 +17,10 @@ import { getTopStats, type UserTopStatsArgs } from '../actions/top-performers';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
 import type { SessionWithEncountersCount } from '../models/session';
-import type { SpeciesRow } from '../models/db';
+import type { SpeciesRow, GroupTicksResult } from '../models/db';
 import { SessionsByDay } from '../components/SessionHistoryCalendar';
 import { NoPrefetchLink } from '../components/shared/NoPrefetchLink';
+import { format as formatDate } from 'date-fns';
 
 type SpeciesWithBirdsCount = Pick<SpeciesRow, 'id' | 'species_name'> & {
 	birds: { count: number }[];
@@ -29,6 +30,7 @@ type PageModel = {
 	stats: StatsAccordionModel[];
 	recentSessions: SessionWithEncountersCount[];
 	topSpecies: SpeciesWithBirdsCount[];
+	lastGroupTick: GroupTicksResult | null;
 };
 function getStatConfigs(
 	date: Date
@@ -168,6 +170,19 @@ export async function fetchRecentSessions(
 	return sessions.filter((s) => recentDates.includes(s.visit_date));
 }
 
+export async function fetchLastGroupTick(
+	viewedGroupId: number
+): Promise<GroupTicksResult | null> {
+	const supabase = await getAuthenticatedSupabaseClient();
+	const ticks = (await supabase
+		.rpc('group_ticks', {
+			ringing_group_filter: viewedGroupId,
+			result_limit: 1
+		})
+		.then(catchSupabaseErrors)) as GroupTicksResult[] | null;
+	return ticks?.[0] ?? null;
+}
+
 export async function fetchTopSpecies(): Promise<SpeciesWithBirdsCount[]> {
 	const supabase = await getAuthenticatedSupabaseClient();
 	const species = (await supabase
@@ -212,7 +227,8 @@ export async function fetchHomePageData(
 			})
 		),
 		recentSessions: await fetchRecentSessions(viewedGroupId),
-		topSpecies: await fetchTopSpecies()
+		topSpecies: await fetchTopSpecies(),
+		lastGroupTick: await fetchLastGroupTick(viewedGroupId)
 	};
 }
 
@@ -234,6 +250,15 @@ function RecentSessions({
 				/>
 			</BoxyList>
 		</div>
+	);
+}
+function LastGroupTick({ data }: { data: GroupTicksResult | null }) {
+	if (!data) return null;
+	return (
+		<p className="text-lg">
+			Last group tick: {data.species_name} on{' '}
+			{formatDate(new Date(data.first_encounter_date), 'do MMMM yyyy')}
+		</p>
 	);
 }
 function TopSpecies({ data }: { data: SpeciesWithBirdsCount[] }) {
@@ -264,6 +289,7 @@ function HomePageContent({
 }) {
 	return (
 		<PageWrapper>
+			<LastGroupTick data={data.lastGroupTick} />
 			<RecentSessions
 				data={data.recentSessions}
 				viewedGroupId={viewedGroupId}


### PR DESCRIPTION
## Summary
- Adds `fetchLastGroupTick(viewedGroupId)` in `app/(routes)/page.tsx`, calling the `group_ticks` RPC (`result_limit: 1`) via `getAuthenticatedSupabaseClient()` / `catchSupabaseErrors()`, following the existing `fetchRecentSessions` pattern in that file.
- Wires the result into `fetchHomePageData` / `PageModel`, and renders a `text-lg` paragraph — "Last group tick: {species_name} on {ordinal date}" (e.g. "Last group tick: Carrion Crow on 12th February 2026"), formatted with `date-fns` (`do MMMM yyyy`), consistent with the ordinal-date convention already used in `StatOutput`/`SessionsByDay`.
- Paragraph is placed above `RecentSessions`/`StatsAccordion`; omitted entirely (no error, no "undefined"/"null") when the group has zero ticks.

## Test plan
- [x] `npm run qa` (lint + type-check + app tests) — 571 tests passing, 0 errors
- [x] New tests in `app/(routes)/__tests__/page.test.tsx`:
  - renders "Last group tick: {species} on {date}" paragraph when data is present
  - omits the paragraph entirely when the group has no ticks yet
- [x] Pre-push hook: app tests + E2E safe suite (95 passed) — this change doesn't touch any `@mutates` trigger path

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)