### PR TITLE
feat: add group ticks page

### DIFF
--- a/app/(routes)/__tests__/page.test.tsx
+++ b/app/(routes)/__tests__/page.test.tsx
@@ -165,6 +165,12 @@ describe('home page', () => {
 			).toBeDefined();
 		});
 
+		it('renders a "View all" link to /ticks when data is present', async () => {
+			render(await Page());
+			const link = await screen.findByRole('link', { name: 'View all' });
+			expect(link.getAttribute('href')).toBe('/ticks');
+		});
+
 		describe('with no ticks yet', () => {
 			it('omits the paragraph entirely', async () => {
 				mockGetAuthenticatedSupabaseClient.mockResolvedValue(
@@ -176,6 +182,15 @@ describe('home page', () => {
 				});
 				expect(heading).toBeDefined();
 				expect(screen.queryByText(/Last group tick:/)).toBeNull();
+			});
+
+			it('omits the "View all" link', async () => {
+				mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+					makeChainClient({ lastGroupTick: [] })
+				);
+				render(await Page());
+				await screen.findByRole('heading', { name: 'Recent Sessions' });
+				expect(screen.queryByRole('link', { name: 'View all' })).toBeNull();
 			});
 		});
 	});

--- a/app/(routes)/page.tsx
+++ b/app/(routes)/page.tsx
@@ -255,10 +255,15 @@ function RecentSessions({
 function LastGroupTick({ data }: { data: GroupTicksResult | null }) {
 	if (!data) return null;
 	return (
-		<p className="text-lg">
-			Last group tick: {data.species_name} on{' '}
-			{formatDate(new Date(data.first_encounter_date), 'do MMMM yyyy')}
-		</p>
+		<div>
+			<p className="text-lg">
+				Last group tick: {data.species_name} on{' '}
+				{formatDate(new Date(data.first_encounter_date), 'do MMMM yyyy')}
+			</p>
+			<NoPrefetchLink href="/ticks" className="link link-secondary text-sm">
+				View all
+			</NoPrefetchLink>
+		</div>
 	);
 }
 function TopSpecies({ data }: { data: SpeciesWithBirdsCount[] }) {

--- a/app/(routes)/ticks/__tests__/page.test.tsx
+++ b/app/(routes)/ticks/__tests__/page.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import Page from '../page';
+import type { GroupTicksResult } from '@/app/models/db';
+
+const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
+	mockGetAuthenticatedSupabaseClient: vi.fn()
+}));
+
+vi.mock('@/lib/group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+const ticksSnapshot: GroupTicksResult[] = [
+	{ species_name: 'Carrion Crow', first_encounter_date: '2026-05-02' },
+	{ species_name: 'Robin', first_encounter_date: '2025-11-20' },
+	{ species_name: 'Blue Tit', first_encounter_date: '2024-03-01' }
+];
+
+function makeRpcClient(data: unknown) {
+	const thenable = {
+		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+			Promise.resolve({ data, error: null }).then(resolve)
+	};
+	return { rpc: vi.fn().mockReturnValue(thenable) };
+}
+
+describe('ticks page', () => {
+	beforeEach(() => {
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+			makeRpcClient(ticksSnapshot)
+		);
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders heading', async () => {
+		render(await Page());
+		const heading = await screen.findByRole('heading', { level: 1 });
+		expect(heading.textContent).toBe('Ticks');
+	});
+
+	it('renders one entry per tick, formatted as "{species} on {date}"', async () => {
+		render(await Page());
+		const list = await screen.findByRole('list');
+		const items = list.querySelectorAll('li');
+		expect(items.length).toBe(ticksSnapshot.length);
+		expect(items[0].textContent).toBe('Carrion Crow on 2nd May 2026');
+		expect(items[1].textContent).toBe('Robin on 20th November 2025');
+		expect(items[2].textContent).toBe('Blue Tit on 1st March 2024');
+	});
+
+	it('renders ticks in the order returned by the server (most recent first)', async () => {
+		render(await Page());
+		const list = await screen.findByRole('list');
+		const items = [...list.querySelectorAll('li')].map(
+			(item) => item.textContent
+		);
+		expect(items).toEqual([
+			'Carrion Crow on 2nd May 2026',
+			'Robin on 20th November 2025',
+			'Blue Tit on 1st March 2024'
+		]);
+	});
+
+	describe('with no ticks yet', () => {
+		it('renders a friendly empty state instead of a list', async () => {
+			mockGetAuthenticatedSupabaseClient.mockResolvedValue(makeRpcClient([]));
+			render(await Page());
+			await screen.findByRole('heading', { level: 1 });
+			expect(screen.queryByRole('list')).toBeNull();
+			expect(screen.getByText('No ticks yet.')).toBeDefined();
+		});
+	});
+});

--- a/app/(routes)/ticks/page.tsx
+++ b/app/(routes)/ticks/page.tsx
@@ -1,0 +1,58 @@
+import { GroupTicksResult } from '@/app/models/db';
+import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
+import { catchSupabaseErrors } from '@/lib/supabase';
+import {
+	BootstrapPageData,
+	DefaultPageParams
+} from '@/app/components/layout/BootstrapPageData';
+import {
+	BoxyList,
+	PageWrapper,
+	PrimaryHeading
+} from '@/app/components/shared/DesignSystem';
+import { format as formatDate } from 'date-fns';
+
+export async function fetchGroupTicks(
+	_: DefaultPageParams,
+	viewedGroupId: number
+): Promise<GroupTicksResult[]> {
+	const supabase = await getAuthenticatedSupabaseClient();
+	return supabase
+		.rpc('group_ticks', { ringing_group_filter: viewedGroupId })
+		.then(catchSupabaseErrors) as Promise<GroupTicksResult[]>;
+}
+
+function ListTicks({ data }: { data: GroupTicksResult[] }) {
+	return (
+		<PageWrapper>
+			<PrimaryHeading>Ticks</PrimaryHeading>
+			{data.length === 0 ? (
+				<p>No ticks yet.</p>
+			) : (
+				<BoxyList>
+					{data.map((tick) => (
+						<li key={`${tick.species_name}-${tick.first_encounter_date}`}>
+							{tick.species_name} on{' '}
+							{formatDate(new Date(tick.first_encounter_date), 'do MMMM yyyy')}
+						</li>
+					))}
+				</BoxyList>
+			)}
+		</PageWrapper>
+	);
+}
+
+export default async function TicksPage({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
+	return (
+		<BootstrapPageData<GroupTicksResult[]>
+			viewedGroupId={viewedGroupId}
+			getCacheKeys={() => ['ticks']}
+			dataFetcher={fetchGroupTicks}
+			PageComponent={ListTicks}
+		/>
+	);
+}

--- a/app/components/layout/GlobalNav.tsx
+++ b/app/components/layout/GlobalNav.tsx
@@ -10,6 +10,7 @@ const moreLinks = [
 	{ href: '/mistakes', label: 'Mistakes' },
 	{ href: '/retraps', label: 'Retraps' },
 	{ href: '/resightings', label: 'Resightings' },
+	{ href: '/ticks', label: 'Ticks' },
 	{ href: '/effort', label: 'Effort' },
 	{ href: '/ring-sequences', label: 'Ring Sequences' },
 	{ href: '/controls', label: 'Controls' }

--- a/app/components/layout/__tests__/GlobalNav.test.tsx
+++ b/app/components/layout/__tests__/GlobalNav.test.tsx
@@ -35,6 +35,7 @@ describe('DesktopNavItems', () => {
 		expect(screen.getByRole('link', { name: 'Mistakes' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Retraps' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Resightings' })).toBeDefined();
+		expect(screen.getByRole('link', { name: 'Ticks' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Effort' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Ring Sequences' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Controls' })).toBeDefined();
@@ -72,15 +73,20 @@ describe('DesktopNavItems', () => {
 describe('MobileNavItems', () => {
 	afterEach(cleanup);
 
-	it('renders all 8 links in a flat list', () => {
+	it('renders all 9 links in a flat list', () => {
 		render(<MobileNavItems classes="" />);
 		const links = screen.getAllByRole('link');
-		expect(links).toHaveLength(8);
+		expect(links).toHaveLength(9);
 	});
 
 	it('includes Resightings link', () => {
 		render(<MobileNavItems classes="" />);
 		expect(screen.getByRole('link', { name: 'Resightings' })).toBeDefined();
+	});
+
+	it('includes Ticks link', () => {
+		render(<MobileNavItems classes="" />);
+		expect(screen.getByRole('link', { name: 'Ticks' })).toBeDefined();
 	});
 
 	it('includes Sessions link', () => {

--- a/app/group/[groupId]/ticks/page.tsx
+++ b/app/group/[groupId]/ticks/page.tsx
@@ -1,0 +1,10 @@
+import TicksPage from '@/app/(routes)/ticks/page';
+
+export default async function CrossGroupTicksPage({
+	params
+}: {
+	params: Promise<{ groupId: string }>;
+}) {
+	const { groupId } = await params;
+	return <TicksPage viewedGroupId={Number(groupId)} />;
+}


### PR DESCRIPTION
## Summary
- New `/ticks` page lists every species tick for the group, most recent first, reusing the `group_ticks` RPC (added in #445) called without `result_limit` so it returns the full history in DESC date order.
- Rendering follows the same "{species} on {date}" format as the home page's last-tick summary (`do MMMM yyyy`, e.g. "2nd May 2026").
- Adds a cross-group wrapper page at `/group/[groupId]/ticks`, matching the existing pattern used by `/mistakes`, `/retraps`, and `/resightings`.
- The home page's "Last group tick" summary now has a "View all" link to `/ticks`.
- Adds a "Ticks" entry to the global nav's "More" menu (desktop + mobile).

## Test plan
- [x] `npm run qa` — lint, typecheck, and all 604 app tests pass
- [x] New tests in `app/(routes)/ticks/__tests__/page.test.tsx`: heading, per-tick formatting, ordering, empty state
- [x] Updated `app/(routes)/__tests__/page.test.tsx`: "View all" link present when a last tick exists, absent otherwise
- [x] Updated `app/components/layout/__tests__/GlobalNav.test.tsx`: Ticks link present in desktop dropdown and mobile nav
- [x] Pre-push hook: full app test suite + Playwright `test:e2e:safe` (95 specs) both green

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)