### PR TITLE
feat: show new-bird count in home summary stats

### DIFF
--- a/app/(routes)/__tests__/page.test.tsx
+++ b/app/(routes)/__tests__/page.test.tsx
@@ -279,7 +279,7 @@ describe('home page', () => {
 				p.textContent?.includes('sessions, with')
 			);
 			expect(paragraph?.textContent?.replace(/\s+/g, ' ').trim()).toBe(
-				`${allTime.session_count} sessions, with ${allTime.bird_count} birds of ${allTime.species_count} species encountered ${allTime.encounter_count} times`
+				`${allTime.session_count} sessions, with ${allTime.bird_count} birds (${allTime.new_bird_count} new) of ${allTime.species_count} species encountered ${allTime.encounter_count} times`
 			);
 			const boldValues = Array.from(
 				paragraph?.querySelectorAll('.font-bold') ?? []
@@ -300,8 +300,23 @@ describe('home page', () => {
 				p.textContent?.startsWith('This year:')
 			);
 			expect(paragraph?.textContent?.replace(/\s+/g, ' ').trim()).toBe(
-				`This year: ${thisYear.session_count} sessions, with ${thisYear.bird_count} birds of ${thisYear.species_count} species encountered ${thisYear.encounter_count} times`
+				`This year: ${thisYear.session_count} sessions, with ${thisYear.bird_count} birds (${thisYear.new_bird_count} new) of ${thisYear.species_count} species encountered ${thisYear.encounter_count} times`
 			);
+		});
+
+		it('renders the new-bird count as a de-emphasised (italic) parenthetical, not one of the bold counts', async () => {
+			const { container } = render(await Page());
+			await screen.findByRole('heading', { name: 'Recent Sessions' });
+			const { allTime } = summaryStatsSnapshot;
+			const paragraph = Array.from(container.querySelectorAll('p')).find((p) =>
+				p.textContent?.includes('sessions, with')
+			);
+			const italic = paragraph?.querySelector('.italic');
+			expect(italic?.textContent).toBe(`(${allTime.new_bird_count} new)`);
+			const boldValues = Array.from(
+				paragraph?.querySelectorAll('.font-bold') ?? []
+			).map((el) => el.textContent);
+			expect(boldValues).not.toContain(String(allTime.new_bird_count));
 		});
 
 		it('calls aggregate_stats with from_date set to 1 Jan of the current year for the this-year paragraph, and no date filter for the all-time paragraph', async () => {

--- a/app/(routes)/page.tsx
+++ b/app/(routes)/page.tsx
@@ -296,7 +296,8 @@ function SummaryParagraph({
 		<p className="text-lg">
 			{prefix}
 			<span className="font-bold">{stats.session_count}</span> sessions, with{' '}
-			<span className="font-bold">{stats.bird_count}</span> birds of{' '}
+			<span className="font-bold">{stats.bird_count}</span> birds{' '}
+			<span className="italic">({stats.new_bird_count} new)</span> of{' '}
 			<span className="font-bold">{stats.species_count}</span> species
 			encountered <span className="font-bold">{stats.encounter_count}</span>{' '}
 			times


### PR DESCRIPTION
## What this covers

Surfaces the number of individual birds newly ringed in scope (birds with at least one `record_type = 'N'` encounter) as a de-emphasised parenthetical in the home page summary paragraph:

> 147 sessions, with 5065 birds *(2000 new)* of 52 species encountered 7304 times

## Key finding / assumption

The ticket asked to "update `aggregate_stats` to add a new column `new_birds`". On investigation, `aggregate_stats` **already returns a `new_bird_count` column** computing exactly the ticket's definition (`COUNT(DISTINCT bird_id) WHERE record_type = 'N'`, scoped to the query's date/group filters) — it's in the deployed schema, the generated types, and the test fixtures, but was previously unused by the app. Per YAGNI/DRY, this PR reuses that existing column rather than adding a duplicate `new_birds`, so **no schema change is needed** (consistent with the ticket carrying no `db-migration` label). The value is rendered as an italic, non-bold parenthetical to match the ticket's `_(2000 new)_` formatting and keep it visually secondary to the primary bold counts.

## Layers touched

- `app/(routes)/page.tsx` — `SummaryParagraph` now renders `({new_bird_count} new)`.
- `app/(routes)/__tests__/page.test.tsx` — updated the two full-text summary expectations and added a test asserting the new-bird figure renders as an italic parenthetical and is not one of the bold counts.

## Tests

`npm run qa` passes: lint (0 errors), type-check clean, 613 app tests pass.

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)