### PR TITLE
Add Sessions.session_type identity column and 3-way import bucketing (#452)

### DIFF
--- a/lib/__tests__/demon-import.test.ts
+++ b/lib/__tests__/demon-import.test.ts
@@ -284,60 +284,126 @@ describe('processEncounterRow', () => {
 			{
 				visit_date: '2023-03-15',
 				location_id: locationId,
+				session_type: 'FULL_GROWN',
 				is_resighting_only: false
 			},
-			'visit_date,location_id,is_resighting_only'
+			'visit_date,location_id,session_type'
 		);
 	});
 
-	describe('is_resighting_only bucketing', () => {
-		function sessionUpsertArgs() {
-			return upsert.mock.calls.find(([table]) => table === 'Sessions');
+	describe('session_type bucketing', () => {
+		function sessionData() {
+			return upsert.mock.calls.find(([table]) => table === 'Sessions')?.[1];
 		}
 
+		it('buckets an N record_type with a non-pulli age as FULL_GROWN', async () => {
+			await processEncounterRow(
+				makeDemonRow({ record_type: 'N', age: '3' }),
+				upsert,
+				RINGING_GROUP_ID
+			);
+			expect(sessionData()).toMatchObject({ session_type: 'FULL_GROWN' });
+		});
+
+		it('buckets an N record_type with age 1J (recently-fledged juvenile) as FULL_GROWN, not PULLI', async () => {
+			await processEncounterRow(
+				makeDemonRow({ record_type: 'N', age: '1J' }),
+				upsert,
+				RINGING_GROUP_ID
+			);
+			expect(sessionData()).toMatchObject({ session_type: 'FULL_GROWN' });
+		});
+
+		it('buckets an N record_type with raw age 1 (nestling) as PULLI', async () => {
+			await processEncounterRow(
+				makeDemonRow({ record_type: 'N', age: '1' }),
+				upsert,
+				RINGING_GROUP_ID
+			);
+			expect(sessionData()).toMatchObject({ session_type: 'PULLI' });
+		});
+
 		it.each(['U', 'F', 'D'])(
-			'buckets a %s record_type as is_resighting_only: true',
+			'buckets a %s record_type as FIELD_OBSERVATION regardless of age (record-type precedence over age 1)',
 			async (recordType) => {
 				await processEncounterRow(
-					makeDemonRow({ record_type: recordType }),
+					makeDemonRow({ record_type: recordType, age: '1' }),
 					upsert,
 					RINGING_GROUP_ID
 				);
-				expect(sessionUpsertArgs()).toEqual([
-					'Sessions',
-					expect.objectContaining({ is_resighting_only: true }),
-					'visit_date,location_id,is_resighting_only'
-				]);
+				expect(sessionData()).toMatchObject({
+					session_type: 'FIELD_OBSERVATION'
+				});
 			}
 		);
 
 		it.each(['N', 'S', 'C', 'T'])(
-			'buckets a %s record_type as is_resighting_only: false',
+			'buckets a %s record_type with a non-pulli age as FULL_GROWN',
+			async (recordType) => {
+				await processEncounterRow(
+					makeDemonRow({ record_type: recordType, age: '3' }),
+					upsert,
+					RINGING_GROUP_ID
+				);
+				expect(sessionData()).toMatchObject({ session_type: 'FULL_GROWN' });
+			}
+		);
+
+		it('buckets an unrecognised record_type with a non-pulli age as FULL_GROWN', async () => {
+			await processEncounterRow(
+				makeDemonRow({ record_type: 'Z', age: '3' }),
+				upsert,
+				RINGING_GROUP_ID
+			);
+			expect(sessionData()).toMatchObject({ session_type: 'FULL_GROWN' });
+		});
+
+		it('buckets an unrecognised record_type with raw age 1 as PULLI', async () => {
+			await processEncounterRow(
+				makeDemonRow({ record_type: 'Z', age: '1' }),
+				upsert,
+				RINGING_GROUP_ID
+			);
+			expect(sessionData()).toMatchObject({ session_type: 'PULLI' });
+		});
+
+		it('buckets an empty/unparseable age as FULL_GROWN (NaN must not equal 1)', async () => {
+			await processEncounterRow(
+				makeDemonRow({ record_type: 'N', age: '' }),
+				upsert,
+				RINGING_GROUP_ID
+			);
+			expect(sessionData()).toMatchObject({ session_type: 'FULL_GROWN' });
+		});
+	});
+
+	describe('is_resighting_only stays in sync with session_type', () => {
+		function sessionData() {
+			return upsert.mock.calls.find(([table]) => table === 'Sessions')?.[1];
+		}
+
+		it.each(['U', 'F', 'D'])(
+			'still upserts is_resighting_only: true for a %s record_type',
 			async (recordType) => {
 				await processEncounterRow(
 					makeDemonRow({ record_type: recordType }),
 					upsert,
 					RINGING_GROUP_ID
 				);
-				expect(sessionUpsertArgs()).toEqual([
-					'Sessions',
-					expect.objectContaining({ is_resighting_only: false }),
-					'visit_date,location_id,is_resighting_only'
-				]);
+				expect(sessionData()).toMatchObject({ is_resighting_only: true });
 			}
 		);
 
-		it('treats all other record_type as is_resighting_only: false', async () => {
+		it('upserts is_resighting_only: false for a PULLI-bucketed row', async () => {
 			await processEncounterRow(
-				makeDemonRow({ record_type: 'Z' }),
+				makeDemonRow({ record_type: 'N', age: '1' }),
 				upsert,
 				RINGING_GROUP_ID
 			);
-			expect(sessionUpsertArgs()).toEqual([
-				'Sessions',
-				expect.objectContaining({ is_resighting_only: false }),
-				'visit_date,location_id,is_resighting_only'
-			]);
+			expect(sessionData()).toMatchObject({
+				session_type: 'PULLI',
+				is_resighting_only: false
+			});
 		});
 	});
 

--- a/lib/demon-import.ts
+++ b/lib/demon-import.ts
@@ -215,21 +215,36 @@ export async function processEncounterRow(
 
 	const visitDate = convertDateFormat(row.visit_date as string);
 
-	const isResightingOnly = (
-		RESIGHTING_RECORD_TYPES as readonly string[]
-	).includes(row.record_type as string);
+	// Parse the age code once, up front — it feeds both the session-type decision
+	// and the Encounters insert below.
+	const age_code = Number(String(row.age).replace('J', ''));
+	const is_juv = String(row.age).endsWith('J');
+
+	// A row's own record_type/age deterministically picks its session bucket
+	// (no cross-row aggregation, no import-order sensitivity). record_type wins
+	// over age: a resighting/recovery of a pulli-age bird is still a
+	// FIELD_OBSERVATION, not a PULLI capture. A raw age of 1 (but not 1J) is a
+	// pulli; is_juv guards against a recently-fledged juvenile being mistaken
+	// for a nestling.
+	const sessionType = (RESIGHTING_RECORD_TYPES as readonly string[]).includes(
+		row.record_type as string
+	)
+		? 'FIELD_OBSERVATION'
+		: age_code === 1 && !is_juv
+			? 'PULLI'
+			: 'FULL_GROWN';
 
 	const sessionId = await upsert<SessionsInsert>(
 		'Sessions',
 		{
 			visit_date: visitDate,
 			location_id: locationId,
-			is_resighting_only: isResightingOnly
+			session_type: sessionType,
+			// Kept in sync with session_type until #393's tickets 3/5 migrate off it.
+			is_resighting_only: sessionType === 'FIELD_OBSERVATION'
 		},
-		'visit_date,location_id,is_resighting_only' as keyof SessionsInsert
+		'visit_date,location_id,session_type' as keyof SessionsInsert
 	);
-
-	const age_code = Number(String(row.age).replace('J', ''));
 
 	await upsert<EncountersInsert>(
 		'Encounters',
@@ -240,7 +255,7 @@ export async function processEncounterRow(
 			extra_text: row.extra_text as string | null,
 			finding_condition: row.finding_condition as string | null,
 			finding_circumstances: row.finding_circumstances as string | null,
-			is_juv: String(row.age).endsWith('J'),
+			is_juv,
 			moult_code: row.moult_code as string | null,
 			old_greater_coverts: row.old_greater_coverts
 				? Number(row.old_greater_coverts)

--- a/supabase/__tests__/session-type.test.ts
+++ b/supabase/__tests__/session-type.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Integration tests for the Sessions.session_type identity column (#452).
+ *
+ * Covers the widened (visit_date, location_id, session_type) unique constraint,
+ * ringing_group_id derivation on a hand-inserted PULLI row, and the one-off backfill
+ * data-migration logic that flips resighting rows to FIELD_OBSERVATION, splits mixed
+ * pulli/full-grown rows, and flips pure-pulli rows to PULLI.
+ *
+ * Requires local Supabase running and e2e seed data loaded:
+ *   npm run db:start:local
+ *   npm run db:seed:e2e
+ *
+ * Run with: npm run test:integration
+ *
+ * All rows created here use a run-unique suffix and a random future base date so
+ * concurrent worktree runs against the shared local Supabase instance never collide.
+ */
+
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import { execSync } from 'child_process';
+import { getAuthenticatedSupabaseClientForGroup } from '../../lib/group-auth';
+import { supabase } from '../../lib/supabase';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { randomTestSuffix, randomFutureDate, addDays } from './test-isolation';
+
+const LOCAL_DB_URL = 'postgresql://postgres:postgres@127.0.0.1:54322/postgres';
+
+function psql(sql: string) {
+	execSync(`psql "${LOCAL_DB_URL}" -c "${sql.replace(/"/g, '\\"')}"`);
+}
+
+function psqlScalar(sql: string): string {
+	return execSync(
+		`psql "${LOCAL_DB_URL}" -t -A -c "${sql.replace(/"/g, '\\"')}"`
+	)
+		.toString()
+		.split('\n')
+		.map((line) => line.trim())
+		.filter(Boolean)[0];
+}
+
+async function getRobinSpeciesId(): Promise<number> {
+	const { data, error } = await supabase
+		.from('Species')
+		.select('id')
+		.eq('species_name', 'Robin')
+		.single();
+	if (error || !data)
+		throw new Error('Robin species not found — run npm run db:seed:e2e first');
+	return data.id;
+}
+
+function createIsolatedGroupAndLocation(suffix: string): {
+	groupId: number;
+	locationId: number;
+} {
+	const groupId = Number(
+		psqlScalar(
+			`INSERT INTO "RingingGroups" (group_name) VALUES ('session-type-${suffix}') RETURNING id;`
+		)
+	);
+	const locationId = Number(
+		psqlScalar(
+			`INSERT INTO "Locations" (location_name, ringing_group_id) VALUES ('session-type-loc-${suffix}', ${groupId}) RETURNING id;`
+		)
+	);
+	return { groupId, locationId };
+}
+
+function cleanupGroup(groupId: number, locationId: number) {
+	psql(
+		`DELETE FROM "Encounters" WHERE session_id IN (SELECT id FROM "Sessions" WHERE location_id = ${locationId});` +
+			`DELETE FROM "Sessions" WHERE location_id = ${locationId};` +
+			`DELETE FROM "Birds" WHERE ${groupId} = ANY(ringing_group_ids);` +
+			`DELETE FROM "Locations" WHERE id = ${locationId};` +
+			`DELETE FROM "RingingGroups" WHERE id = ${groupId};`
+	);
+}
+
+describe('Sessions — session_type identity', () => {
+	const suffix = `identity-${randomTestSuffix()}`;
+	const visitDate = randomFutureDate();
+	let groupId: number;
+	let locationId: number;
+	let groupClient: SupabaseClient;
+
+	beforeAll(async () => {
+		({ groupId, locationId } = createIsolatedGroupAndLocation(suffix));
+		groupClient = await getAuthenticatedSupabaseClientForGroup(groupId);
+	});
+
+	afterAll(() => cleanupGroup(groupId, locationId));
+
+	it('allows all three session_type rows for the same visit_date/location, and rejects a duplicate triple', async () => {
+		for (const session_type of [
+			'FULL_GROWN',
+			'FIELD_OBSERVATION',
+			'PULLI'
+		] as const) {
+			const { error } = await groupClient
+				.from('Sessions')
+				.insert({
+					visit_date: visitDate,
+					location_id: locationId,
+					session_type
+				});
+			expect(error).toBeNull();
+		}
+
+		const duplicate = await groupClient.from('Sessions').insert({
+			visit_date: visitDate,
+			location_id: locationId,
+			session_type: 'PULLI'
+		});
+		expect(duplicate.error?.code).toBe('23505');
+	});
+
+	it('rejects a session_type outside the allowed set', async () => {
+		const { error } = await groupClient.from('Sessions').insert({
+			visit_date: addDays(visitDate, 1),
+			location_id: locationId,
+			session_type: 'NEST_RECORD'
+		});
+		expect(error?.code).toBe('23514'); // check_violation
+	});
+
+	it('derives ringing_group_id for a hand-inserted PULLI Sessions row', async () => {
+		const { data, error } = await groupClient
+			.from('Sessions')
+			.insert({
+				visit_date: addDays(visitDate, 2),
+				location_id: locationId,
+				session_type: 'PULLI'
+			})
+			.select('ringing_group_id')
+			.single();
+		expect(error).toBeNull();
+		expect(data?.ringing_group_id).toBe(groupId);
+	});
+});
+
+describe('session_type backfill migration', () => {
+	// Mirrors the data steps hand-appended to the #452 migration, scoped by location_id
+	// so it only touches this test's isolated fixtures. Post-migration the column is
+	// NOT NULL DEFAULT 'FULL_GROWN', so freshly-inserted fixtures arrive as FULL_GROWN;
+	// this scoped backfill treats (session_type = 'FULL_GROWN' AND is_resighting_only =
+	// FALSE) as the "unclassified" set the real migration keyed off session_type IS NULL.
+	// PULLI encounter = age_code = 1 AND NOT is_juv.
+	function runBackfillScopedToLocation(loc: number) {
+		psql(
+			`UPDATE "Sessions" SET session_type = 'FIELD_OBSERVATION' WHERE location_id = ${loc} AND is_resighting_only = TRUE;`
+		);
+		psql(
+			`WITH mixed_sessions AS (
+				SELECT s.id AS old_session_id, s.visit_date, s.location_id
+				FROM "Sessions" s
+				WHERE s.location_id = ${loc}
+					AND s.session_type = 'FULL_GROWN' AND s.is_resighting_only = FALSE
+					AND EXISTS (SELECT 1 FROM "Encounters" e WHERE e.session_id = s.id AND e.age_code = 1 AND NOT e.is_juv)
+					AND EXISTS (SELECT 1 FROM "Encounters" e WHERE e.session_id = s.id AND NOT (e.age_code = 1 AND NOT e.is_juv))
+			), inserted_twins AS (
+				INSERT INTO "Sessions" (visit_date, location_id, session_type, is_resighting_only)
+				SELECT visit_date, location_id, 'PULLI', FALSE FROM mixed_sessions
+				RETURNING id AS new_session_id, visit_date, location_id
+			)
+			UPDATE "Encounters" e
+			SET session_id = t.new_session_id
+			FROM mixed_sessions m
+			JOIN inserted_twins t ON t.visit_date = m.visit_date AND t.location_id = m.location_id
+			WHERE e.session_id = m.old_session_id AND e.age_code = 1 AND NOT e.is_juv;`
+		);
+		psql(
+			`UPDATE "Sessions" s SET session_type = 'PULLI'
+			WHERE s.location_id = ${loc}
+				AND s.session_type = 'FULL_GROWN' AND s.is_resighting_only = FALSE
+				AND EXISTS (SELECT 1 FROM "Encounters" e WHERE e.session_id = s.id)
+				AND NOT EXISTS (SELECT 1 FROM "Encounters" e WHERE e.session_id = s.id AND NOT (e.age_code = 1 AND NOT e.is_juv));`
+		);
+	}
+
+	const suffix = `backfill-${randomTestSuffix()}`;
+	const baseDate = randomFutureDate();
+	let groupId: number;
+	let locationId: number;
+	let groupClient: SupabaseClient;
+	let speciesId: number;
+
+	// Fixtures, inserted at the post-migration default (session_type = 'FULL_GROWN').
+	const fieldObsDate = baseDate; // is_resighting_only = TRUE
+	const mixedDate = addDays(baseDate, 1); // one pulli + one full-grown encounter
+	const pureFullGrownDate = addDays(baseDate, 2); // one non-pulli encounter
+	const purePulliDate = addDays(baseDate, 3); // one pulli encounter
+	const juv1JDate = addDays(baseDate, 4); // one age-1J encounter (must stay FULL_GROWN)
+	const emptyDate = addDays(baseDate, 5); // no encounters
+
+	let fieldObsSessionId: number;
+	let mixedSessionId: number;
+	let pureFullGrownSessionId: number;
+	let purePulliSessionId: number;
+	let juv1JSessionId: number;
+	let emptySessionId: number;
+
+	async function insertBird(ringNo: string): Promise<number> {
+		const { data, error } = await groupClient
+			.from('Birds')
+			.insert({ ring_no: ringNo, species_id: speciesId })
+			.select('id')
+			.single();
+		if (error) throw error;
+		return data!.id;
+	}
+
+	async function insertSession(
+		visitDate: string,
+		isResightingOnly = false
+	): Promise<number> {
+		const { data, error } = await groupClient
+			.from('Sessions')
+			.insert({
+				visit_date: visitDate,
+				location_id: locationId,
+				is_resighting_only: isResightingOnly
+			})
+			.select('id')
+			.single();
+		if (error) throw error;
+		return data!.id;
+	}
+
+	async function insertEncounter(
+		birdId: number,
+		sessionId: number,
+		ageCode: number,
+		isJuv: boolean
+	) {
+		const { error } = await groupClient.from('Encounters').insert({
+			capture_time: '10:00:00',
+			scheme: 'BTO',
+			sex: 'M',
+			record_type: 'N',
+			age_code: ageCode,
+			is_juv: isJuv,
+			bird_id: birdId,
+			session_id: sessionId
+		});
+		if (error) throw error;
+	}
+
+	beforeAll(async () => {
+		({ groupId, locationId } = createIsolatedGroupAndLocation(suffix));
+		groupClient = await getAuthenticatedSupabaseClientForGroup(groupId);
+		speciesId = await getRobinSpeciesId();
+
+		fieldObsSessionId = await insertSession(fieldObsDate, true);
+		mixedSessionId = await insertSession(mixedDate);
+		pureFullGrownSessionId = await insertSession(pureFullGrownDate);
+		purePulliSessionId = await insertSession(purePulliDate);
+		juv1JSessionId = await insertSession(juv1JDate);
+		emptySessionId = await insertSession(emptyDate);
+
+		const [birdA, birdB, birdC, birdD, birdE, birdF] = await Promise.all([
+			insertBird(`STA-${suffix}`),
+			insertBird(`STB-${suffix}`),
+			insertBird(`STC-${suffix}`),
+			insertBird(`STD-${suffix}`),
+			insertBird(`STE-${suffix}`),
+			insertBird(`STF-${suffix}`)
+		]);
+
+		// field observation: one encounter (its age is irrelevant — the row is flagged
+		// is_resighting_only)
+		await insertEncounter(birdA, fieldObsSessionId, 3, false);
+		// mixed: one full-grown (age 3) + one pulli (age 1, not juv)
+		await insertEncounter(birdB, mixedSessionId, 3, false);
+		await insertEncounter(birdC, mixedSessionId, 1, false);
+		// pure full-grown: one age-3 encounter
+		await insertEncounter(birdD, pureFullGrownSessionId, 3, false);
+		// pure pulli: one age-1 (not juv) encounter
+		await insertEncounter(birdE, purePulliSessionId, 1, false);
+		// 1J: age_code 1 but is_juv TRUE — must NOT be treated as pulli
+		await insertEncounter(birdF, juv1JSessionId, 1, true);
+		// emptySession deliberately has no encounters
+
+		runBackfillScopedToLocation(locationId);
+	});
+
+	afterAll(() => cleanupGroup(groupId, locationId));
+
+	async function sessionTypeOf(sessionId: number): Promise<string | undefined> {
+		const { data } = await groupClient
+			.from('Sessions')
+			.select('session_type')
+			.eq('id', sessionId)
+			.single();
+		return data?.session_type;
+	}
+
+	it('sets a resighting-only row to FIELD_OBSERVATION in place (no split)', async () => {
+		expect(await sessionTypeOf(fieldObsSessionId)).toBe('FIELD_OBSERVATION');
+		const { data: rows } = await groupClient
+			.from('Sessions')
+			.select('id')
+			.eq('location_id', locationId)
+			.eq('visit_date', fieldObsDate);
+		expect(rows).toHaveLength(1);
+	});
+
+	it('splits a mixed pulli/full-grown row, repointing the pulli encounter onto a new PULLI row', async () => {
+		// original kept in place as FULL_GROWN
+		expect(await sessionTypeOf(mixedSessionId)).toBe('FULL_GROWN');
+
+		const { data: rows } = await groupClient
+			.from('Sessions')
+			.select('id, session_type')
+			.eq('location_id', locationId)
+			.eq('visit_date', mixedDate);
+		expect(rows).toHaveLength(2);
+		const twin = rows!.find((r) => r.session_type === 'PULLI');
+		expect(twin).toBeDefined();
+
+		const { data: originalEncounters } = await groupClient
+			.from('Encounters')
+			.select('age_code, is_juv')
+			.eq('session_id', mixedSessionId);
+		expect(originalEncounters).toEqual([{ age_code: 3, is_juv: false }]);
+
+		const { data: twinEncounters } = await groupClient
+			.from('Encounters')
+			.select('age_code, is_juv')
+			.eq('session_id', twin!.id);
+		expect(twinEncounters).toEqual([{ age_code: 1, is_juv: false }]);
+	});
+
+	it('leaves a pure full-grown row at FULL_GROWN in place', async () => {
+		expect(await sessionTypeOf(pureFullGrownSessionId)).toBe('FULL_GROWN');
+	});
+
+	it('flips a pure-pulli row to PULLI in place (no split)', async () => {
+		expect(await sessionTypeOf(purePulliSessionId)).toBe('PULLI');
+		const { data: rows } = await groupClient
+			.from('Sessions')
+			.select('id')
+			.eq('location_id', locationId)
+			.eq('visit_date', purePulliDate);
+		expect(rows).toHaveLength(1);
+	});
+
+	it('leaves an age-1J row at FULL_GROWN (is_juv guards against nestling misclassification)', async () => {
+		expect(await sessionTypeOf(juv1JSessionId)).toBe('FULL_GROWN');
+	});
+
+	it('leaves a zero-encounter row at FULL_GROWN (conservative default)', async () => {
+		expect(await sessionTypeOf(emptySessionId)).toBe('FULL_GROWN');
+	});
+});

--- a/supabase/schema/schemas/public/tables/"Sessions".sql
+++ b/supabase/schema/schemas/public/tables/"Sessions".sql
@@ -3,7 +3,10 @@ CREATE TABLE public."Sessions" (
 	visit_date date NOT NULL,
 	location_id bigint NOT NULL,
 	ringing_group_id bigint NOT NULL,
-	is_resighting_only boolean NOT NULL DEFAULT FALSE
+	is_resighting_only boolean NOT NULL DEFAULT FALSE,
+	session_type text NOT NULL DEFAULT 'FULL_GROWN' CHECK (
+		session_type IN ('FULL_GROWN', 'FIELD_OBSERVATION', 'PULLI')
+	)
 );
 
 CREATE INDEX idx_sessions_location_id ON public."Sessions" (location_id);
@@ -80,7 +83,7 @@ ALTER TABLE public."Sessions"
 ADD CONSTRAINT "Sessions_pkey" PRIMARY KEY (id);
 
 ALTER TABLE public."Sessions"
-ADD CONSTRAINT "Sessions_visit_date_location_id_key" UNIQUE (visit_date, location_id, is_resighting_only);
+ADD CONSTRAINT "Sessions_visit_date_location_id_key" UNIQUE (visit_date, location_id, session_type);
 
 ALTER TABLE public."Sessions"
 ADD CONSTRAINT sessions_location_id_fkey FOREIGN KEY (location_id) REFERENCES public."Locations" (id);

--- a/types/supabase.types.ts
+++ b/types/supabase.types.ts
@@ -227,6 +227,7 @@ export type Database = {
           is_resighting_only: boolean
           location_id: number
           ringing_group_id: number
+          session_type: string
           visit_date: string
         }
         Insert: {
@@ -234,6 +235,7 @@ export type Database = {
           is_resighting_only?: boolean
           location_id: number
           ringing_group_id: number
+          session_type?: string
           visit_date: string
         }
         Update: {
@@ -241,6 +243,7 @@ export type Database = {
           is_resighting_only?: boolean
           location_id?: number
           ringing_group_id?: number
+          session_type?: string
           visit_date?: string
         }
         Relationships: [


### PR DESCRIPTION
> ⚠️ **Database migration — do not merge before pushing.** This PR's schema change must be
> deployed to prod (`npm run db:migration:push`, run via the `take-over` skill) before this
> PR is merged. Merging first triggers a Vercel prod deploy of code that expects a schema
> prod doesn't have yet.
>
> **Extra care — the data migration cannot be regenerated by `db:schema:apply`.** This repo
> gitignores `supabase/migrations/`, and `db:schema:apply` only regenerates the *DDL* diff
> (the column, CHECK, and unique-constraint changes) — **not** the hand-authored data
> backfill/split below. Deploying the DDL alone would leave every existing resighting/pulli
> session at the `FULL_GROWN` default, i.e. wrongly showing as a normal session until #393's
> tickets 2–3 land. **Before pushing to prod, paste the "Data migration" block below onto the
> end of the regenerated migration** (it is also mirrored in
> `supabase/__tests__/session-type.test.ts`, per the #428 precedent). The full prod-ready
> migration is reproduced under "Prod-ready migration SQL" at the bottom.

Closes #452. Part of #393 (this is the foundation ticket; tickets 2–5 build on it).

## What this covers

Replaces the 2-way `is_resighting_only` split (added in #428) with a 3-way `session_type`
identity column on `Sessions` — `FULL_GROWN` / `FIELD_OBSERVATION` / `PULLI` — so each
`Encounters` row's own `record_type`/`age` deterministically picks its session bucket at import
time (no trigger, no cross-row aggregation, no import-order sensitivity).

- **Schema** (`supabase/schema/.../"Sessions".sql`): add `session_type text NOT NULL DEFAULT
  'FULL_GROWN'` with a `CHECK (session_type IN ('FULL_GROWN','FIELD_OBSERVATION','PULLI'))`
  (plain `text` + `CHECK`, not a native enum); widen the `Sessions_visit_date_location_id_key`
  unique constraint from `(visit_date, location_id, is_resighting_only)` to `(visit_date,
  location_id, session_type)`. `is_resighting_only` stays a plain column.
- **Import** (`lib/demon-import.ts`): parse `age_code`/`is_juv` once, above the Sessions upsert;
  compute `sessionType` with **record-type-then-age precedence** — `RESIGHTING_RECORD_TYPES`
  (`U`/`F`/`D`) → `FIELD_OBSERVATION`; else `age_code === 1 && !is_juv` → `PULLI`; else
  `FULL_GROWN`. The Sessions upsert now writes `session_type` (+ `is_resighting_only =
  sessionType === 'FIELD_OBSERVATION'`, kept in sync until #393's tickets 3/5) and targets the
  widened conflict key.
- **Types**: regenerated `types/supabase.types.ts`.
- **Tests**: unit coverage for every bucketing branch + the `is_resighting_only` sync; DB
  integration coverage for the widened constraint, `ringing_group_id` derivation on a PULLI row,
  and the backfill/split migration.

## Investigation (per #393)

`SELECT is_juv, count(*) FROM "Encounters" WHERE age_code = 1 GROUP BY is_juv;` returned **0 rows**
against the local seed DB. Consistent with the confirmed finding in the ticket body: `is_juv` is
reliably set only for raw age `1J`, never for raw age `1`. So `PULLI = (age_code = 1 AND NOT
is_juv)`, and any `age_code = 1` row whose `is_juv` were unreliable falls through to `FULL_GROWN`
(never guessed as `PULLI` — wrongly hiding a real session is worse than wrongly showing one).

## Assumptions made (subagent mode)

- **Migration not committed to git.** `supabase/migrations/` is gitignored and 0 migration files
  are tracked, so the migration is not part of the PR diff; its canonical data-migration DML is
  preserved in the committed integration test and reproduced below (matching how #428's backfill
  is handled). The migration file was applied to the shared local DB and used to run the
  integration tests.
- **Migration ordering.** Written prod-safely: drop old constraint → add `session_type` nullable
  → backfill/split → `DEFAULT` + `NOT NULL` + `CHECK` → re-add widened unique constraint. The
  backfill must precede the new unique constraint because a pre-existing `(date, location)` pair
  that splits into `FULL_GROWN` + `PULLI` twins would otherwise transiently collide.
- **CHECK constraint named `Sessions_session_type_check`** to match the auto-generated name of the
  inline column check in the declarative schema, so future declarative diffs don't churn.

## Test status

- App tests: **622 passed** (`vitest run`).
- DB integration (`supabase/__tests__/session-type.test.ts`): **9 passed**.
- Full Playwright E2E (pre-push, full suite incl. the `@mutates` import spec — this branch touches
  the `lib/demon-import.ts` trigger): **98 passed**.
- Type-check + eslint clean (0 errors).

## Prod-ready migration SQL

<details><summary>Full migration (paste onto the regenerated DDL migration before pushing to prod)</summary>

```sql
-- 1. Drop the old (visit_date, location_id, is_resighting_only) unique constraint.
ALTER TABLE public."Sessions" DROP CONSTRAINT "Sessions_visit_date_location_id_key";

-- 2. Add session_type as nullable (no default yet) so the backfill sets meaningful
--    values before NOT NULL is enforced.
ALTER TABLE public."Sessions" ADD COLUMN session_type text;

-- 3a. Every existing resighting-only row is a FIELD_OBSERVATION (already isolated
--     by #428 — no split needed).
UPDATE public."Sessions" SET session_type = 'FIELD_OBSERVATION' WHERE is_resighting_only = TRUE;

-- 3b. Split each remaining (non-resighting, still-NULL) row that mixes pulli and
--     non-pulli encounters: create a PULLI twin for the same visit_date/location_id
--     and repoint the pulli encounters onto it. PULLI encounter = age_code = 1 AND NOT is_juv.
WITH mixed_sessions AS (
	SELECT s.id AS old_session_id, s.visit_date, s.location_id
	FROM public."Sessions" s
	WHERE s.session_type IS NULL
		AND EXISTS (SELECT 1 FROM public."Encounters" e WHERE e.session_id = s.id AND e.age_code = 1 AND NOT e.is_juv)
		AND EXISTS (SELECT 1 FROM public."Encounters" e WHERE e.session_id = s.id AND NOT (e.age_code = 1 AND NOT e.is_juv))
), inserted_twins AS (
	INSERT INTO public."Sessions" (visit_date, location_id, session_type, is_resighting_only)
	SELECT visit_date, location_id, 'PULLI', FALSE FROM mixed_sessions
	RETURNING id AS new_session_id, visit_date, location_id
)
UPDATE public."Encounters" e
SET session_id = t.new_session_id
FROM mixed_sessions m
JOIN inserted_twins t ON t.visit_date = m.visit_date AND t.location_id = m.location_id
WHERE e.session_id = m.old_session_id AND e.age_code = 1 AND NOT e.is_juv;

-- 3c. Flip a remaining pure-pulli row (has encounters, all pulli) in place.
UPDATE public."Sessions" s SET session_type = 'PULLI'
WHERE s.session_type IS NULL
	AND EXISTS (SELECT 1 FROM public."Encounters" e WHERE e.session_id = s.id)
	AND NOT EXISTS (SELECT 1 FROM public."Encounters" e WHERE e.session_id = s.id AND NOT (e.age_code = 1 AND NOT e.is_juv));

-- 3d. Everything still NULL is FULL_GROWN: pure full-grown rows, zero-encounter
--     rows (conservative default), and the kept halves of the split rows above.
UPDATE public."Sessions" SET session_type = 'FULL_GROWN' WHERE session_type IS NULL;

-- 4. Now that every row has a value, enforce DEFAULT + NOT NULL + CHECK.
ALTER TABLE public."Sessions" ALTER COLUMN session_type SET DEFAULT 'FULL_GROWN';
ALTER TABLE public."Sessions" ALTER COLUMN session_type SET NOT NULL;
ALTER TABLE public."Sessions" ADD CONSTRAINT "Sessions_session_type_check" CHECK (session_type IN ('FULL_GROWN', 'FIELD_OBSERVATION', 'PULLI'));

-- 5. Re-add the unique constraint, widened to session_type.
ALTER TABLE public."Sessions" ADD CONSTRAINT "Sessions_visit_date_location_id_key" UNIQUE (visit_date, location_id, session_type);
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
