### PR TITLE
Filter sessions on session_type instead of is_resighting_only

### DIFF
--- a/app/(routes)/sessions/__tests__/page.test.tsx
+++ b/app/(routes)/sessions/__tests__/page.test.tsx
@@ -40,13 +40,13 @@ describe('sessions page', () => {
 		expect(heading.textContent).toBe('Session history');
 	});
 
-	it('excludes resighting-only sessions from the query', async () => {
+	it('excludes non-FULL_GROWN sessions from the query', async () => {
 		const client = makeChainClient(alphaSessionsSnapshot);
 		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
 		render(await Page());
 		await screen.findByRole('heading', { level: 1 });
 		const chain = client.from.mock.results[0].value;
-		expect(chain.eq).toHaveBeenCalledWith('is_resighting_only', false);
+		expect(chain.eq).toHaveBeenCalledWith('session_type', 'FULL_GROWN');
 	});
 
 	describe('with multi-year data (alpha fixture)', () => {

--- a/app/(routes)/sessions/page.tsx
+++ b/app/(routes)/sessions/page.tsx
@@ -22,7 +22,7 @@ export async function fetchAllSessions(
 			'id, visit_date, location: Locations(id, location_name), encounters:Encounters(count)'
 		)
 		.eq('ringing_group_id', viewedGroupId)
-		.eq('is_resighting_only', false)
+		.eq('session_type', 'FULL_GROWN')
 		.order('visit_date', { ascending: false })
 		.then(catchSupabaseErrors) as Promise<SessionWithEncountersCount[]>;
 }

--- a/app/actions/__tests__/session-highlights.test.ts
+++ b/app/actions/__tests__/session-highlights.test.ts
@@ -64,7 +64,7 @@ const mockSessionsOrder = vi.fn();
 const mockSessionsRange = vi.fn();
 const mockSessionsEq = vi.fn();
 // eq is also on the builder itself so it self-chains — fetchSessionStats now
-// calls .eq() twice (ringing_group_id, then is_resighting_only) before .order()
+// calls .eq() twice (ringing_group_id, then session_type) before .order()
 const sessionsQueryBuilder = {
 	eq: mockSessionsEq,
 	order: mockSessionsOrder,
@@ -182,13 +182,13 @@ describe('fetchSessionHighlights', () => {
 		expect(mockEq).toHaveBeenCalledWith('ringing_group_id', GROUP_ID);
 	});
 
-	it('excludes resighting-only sessions from the session-dates query', async () => {
+	it('excludes non-FULL_GROWN sessions from the session-dates query', async () => {
 		const fetchSessionHighlights = await importFetchSessionHighlights();
 		await fetchSessionHighlights({
 			date: SESSION_DATE,
 			viewedGroupId: GROUP_ID
 		});
-		expect(mockSessionsEq).toHaveBeenCalledWith('is_resighting_only', false);
+		expect(mockSessionsEq).toHaveBeenCalledWith('session_type', 'FULL_GROWN');
 	});
 
 	it('requests deterministic ordering for paginated queries', async () => {
@@ -311,12 +311,13 @@ describe('fetchSessionHighlights', () => {
 		);
 	});
 
-	it('derives no highlights for a date whose only session is resighting-only, while other days stay unaffected', async () => {
-		// A resighting-only date is excluded from both stats_per_day_and_species
-		// (filtered at the RPC level by #429) and the sessionDates query (filtered
-		// by this ticket's Sessions .eq('is_resighting_only', false)) — it's
-		// simply absent from both stats blobs fed into every derive* function, so
-		// it's indistinguishable from "no session happened that day".
+	it('derives no highlights for a date whose only session is PULLI or FIELD_OBSERVATION, while other days stay unaffected', async () => {
+		// A PULLI or FIELD_OBSERVATION date is excluded from both
+		// stats_per_day_and_species (filtered at the RPC level) and the
+		// sessionDates query (filtered by this ticket's Sessions
+		// .eq('session_type', 'FULL_GROWN')) — it's simply absent from both stats
+		// blobs fed into every derive* function, so it's indistinguishable from
+		// "no session happened that day".
 		rpcPages = [
 			[statsRow('Wren', '2022-05-01', 5), statsRow('Wren', '2022-06-01', 3)]
 		];
@@ -354,7 +355,7 @@ describe('fetchSessionHighlights', () => {
 			(call) => (call as [string])[0] === 'stats_per_day_and_species'
 		);
 		expect(metricsCalls).toHaveLength(1);
-		// Two .eq() calls per fetch (ringing_group_id, is_resighting_only), and
+		// Two .eq() calls per fetch (ringing_group_id, session_type), and
 		// the session-dates query only runs once thanks to the stats cache
 		expect(mockSessionsEq).toHaveBeenCalledTimes(2);
 		// version query is run on each call

--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -73,7 +73,7 @@ async function fetchSessionStats(
 				.from('Sessions')
 				.select('visit_date')
 				.eq('ringing_group_id', viewedGroupId)
-				.eq('is_resighting_only', false)
+				.eq('session_type', 'FULL_GROWN')
 				.order('visit_date')
 				.range(fromRow, toRow)
 		)

--- a/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
@@ -144,42 +144,42 @@ describe('session detail page', () => {
 		expect(heading.textContent).toContain('15th March 2024');
 	});
 
-	it('excludes resighting-only sessions from the main Sessions query', async () => {
+	it('excludes non-FULL_GROWN sessions from the main Sessions query', async () => {
 		const client = makeSessionClient();
 		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
 		render(await renderPage());
 		await screen.findByTestId('session-stats');
 		const mainSessionsChain = client.from.mock.results[0].value;
 		expect(mainSessionsChain.eq).toHaveBeenCalledWith(
-			'is_resighting_only',
-			false
+			'session_type',
+			'FULL_GROWN'
 		);
 	});
 
 	describe('adjacent session date lookups', () => {
-		it('excludes resighting-only sessions from the previous-session lookup', async () => {
+		it('excludes non-FULL_GROWN sessions from the previous-session lookup', async () => {
 			const client = makeSessionClient();
 			mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
 			render(await renderPage());
 			await screen.findByTestId('session-stats');
 			const previousChain = client.from.mock.results[1].value;
 			expect(previousChain.eq).toHaveBeenCalledWith(
-				'is_resighting_only',
-				false
+				'session_type',
+				'FULL_GROWN'
 			);
 		});
 
-		it('excludes resighting-only sessions from the next-session lookup', async () => {
+		it('excludes non-FULL_GROWN sessions from the next-session lookup', async () => {
 			const client = makeSessionClient();
 			mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
 			render(await renderPage());
 			await screen.findByTestId('session-stats');
 			const nextChain = client.from.mock.results[2].value;
-			expect(nextChain.eq).toHaveBeenCalledWith('is_resighting_only', false);
+			expect(nextChain.eq).toHaveBeenCalledWith('session_type', 'FULL_GROWN');
 		});
 	});
 
-	describe('a date whose only Sessions row is resighting-only', () => {
+	describe('a date whose only Sessions row is PULLI or FIELD_OBSERVATION', () => {
 		it('renders the "No session found" empty state instead of 404ing', async () => {
 			const client = {
 				from: vi

--- a/app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx
@@ -108,15 +108,15 @@ describe('session site page', () => {
 		expect(heading.textContent).toContain('15th March 2024');
 	});
 
-	it('excludes resighting-only sessions from the Sessions query', async () => {
+	it('excludes non-FULL_GROWN sessions from the Sessions query', async () => {
 		const client = makeSessionClient();
 		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
 		render(await renderPage());
 		await screen.findByTestId('session-stats');
 		const mainSessionsChain = client.from.mock.results[0].value;
 		expect(mainSessionsChain.eq).toHaveBeenCalledWith(
-			'is_resighting_only',
-			false
+			'session_type',
+			'FULL_GROWN'
 		);
 	});
 

--- a/app/group/[groupId]/session/_shared.tsx
+++ b/app/group/[groupId]/session/_shared.tsx
@@ -46,7 +46,7 @@ async function fetchAdjacentSessionDates(
 			.from('Sessions')
 			.select('visit_date')
 			.eq('ringing_group_id', viewedGroupId)
-			.eq('is_resighting_only', false)
+			.eq('session_type', 'FULL_GROWN')
 			.lt('visit_date', date)
 			.order('visit_date', { ascending: false })
 			.limit(1)
@@ -55,7 +55,7 @@ async function fetchAdjacentSessionDates(
 			.from('Sessions')
 			.select('visit_date')
 			.eq('ringing_group_id', viewedGroupId)
-			.eq('is_resighting_only', false)
+			.eq('session_type', 'FULL_GROWN')
 			.gt('visit_date', date)
 			.order('visit_date', { ascending: true })
 			.limit(1)
@@ -80,7 +80,7 @@ export async function fetchSessionData({
 		)
 		.eq('visit_date', date)
 		.eq('ringing_group_id', viewedGroupId)
-		.eq('is_resighting_only', false)
+		.eq('session_type', 'FULL_GROWN')
 		.then(catchSupabaseErrors)) as (SessionRow & { location: LocationRow })[];
 
 	if (!sessions || sessions.length === 0) {


### PR DESCRIPTION
## What this covers

Closes #454. Replaces `.eq('is_resighting_only', false)` with `.eq('session_type', 'FULL_GROWN')` at the five call sites that surface "normal session" data — the direct generalization of #430's treatment of resighting-only sessions, now applied uniformly to both `PULLI` and `FIELD_OBSERVATION` sessions:

- `fetchAllSessions` (`app/(routes)/sessions/page.tsx`) — the `/sessions` calendar query.
- `fetchSessionData` (`app/group/[groupId]/session/_shared.tsx`) — the main `Sessions` select for the session detail page.
- `fetchAdjacentSessionDates`, same file — both the previous- and next-session lookups.
- `fetchSessionStats`'s `sessionRows` query (`app/actions/session-highlights.ts`) — feeds `stats.sessionDates`, used by every `derive*` highlight function.

**Behaviour change:** a `PULLI`-only session date now behaves exactly like a `FIELD_OBSERVATION`-only date already did — its session page renders the existing "No session found" empty state (not a 404), prev/next nav skips it, and it's absent from highlight-derivation `sessionDates` (so it can never be treated as a "session day" for highlight purposes). Per-species/per-bird stats are untouched — this ticket only touches the five call sites above, not encounter-level counting.

## Dependency note

This PR builds on #452 (merged into `main`), which added `Sessions.session_type`. It does **not** depend on #453's sibling PR (#459, RPC changes to `aggregate_stats`/`stats_per_day_and_species`) — this ticket's five call sites are plain `Sessions` queries, not the two RPCs #459 touches, so nothing here needs #459 to be merged or deployed first.

## Commits

1. Filter sessions calendar (`fetchAllSessions`).
2. Filter session page and prev/next nav (`fetchSessionData`, `fetchAdjacentSessionDates`).
3. Filter highlight-stat session dates (`fetchSessionStats`).

## Testing

- `npm run qa` (lint + type-check + 622 app tests) — all green.
- Full pre-push suite (lint, tsc, app tests, Playwright E2E `test:e2e:safe`) — all green (95/95 E2E specs).
- No DB schema change — `session_type` already exists per #452; no migration in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)