### PR TITLE
Add /pulli page listing pulli-session encounters

### DIFF
--- a/app/(routes)/pulli/__tests__/page.test.tsx
+++ b/app/(routes)/pulli/__tests__/page.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import Page, { fetchPulliEncounters } from '../page';
+import pulliEncountersSnapshot from '@/test-fixtures/snapshots/fetchPulliEncounters.alpha.json';
+import type { PulliEncounter } from '@/app/models/session';
+
+const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
+	mockGetAuthenticatedSupabaseClient: vi.fn()
+}));
+
+vi.mock('@/lib/group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+function makeEncountersClient(data: unknown) {
+	const chain = {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+			Promise.resolve({ data, error: null }).then(resolve)
+	};
+	const client = { from: vi.fn().mockReturnValue(chain) };
+	return { client, chain };
+}
+
+describe('pulli page', () => {
+	beforeEach(() => {
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+			makeEncountersClient(pulliEncountersSnapshot).client
+		);
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders heading', async () => {
+		render(await Page());
+		const heading = await screen.findByRole('heading', { level: 1 });
+		expect(heading.textContent).toBe('Pulli');
+	});
+
+	it('shows every fixture row in the table', async () => {
+		render(await Page());
+		const table = await screen.findByRole('table');
+		const rows = table.querySelectorAll('tbody tr');
+		expect(rows.length).toBe(
+			(pulliEncountersSnapshot as PulliEncounter[]).length
+		);
+	});
+
+	it("renders each row's formatted visit date", async () => {
+		render(await Page());
+		const table = await screen.findByRole('table');
+		expect(table.textContent).toContain('01 Mar 2024');
+	});
+
+	it('renders ring_no as a link to /bird/[ringNo]', async () => {
+		render(await Page());
+		const table = await screen.findByRole('table');
+		const firstRow = table.querySelectorAll('tbody tr')[0];
+		const link = firstRow.querySelector('a');
+		expect(link).toBeTruthy();
+		expect(link?.getAttribute('href')).toBe('/bird/APULLI02');
+	});
+
+	it('renders species, location, and notes columns', async () => {
+		render(await Page());
+		const table = await screen.findByRole('table');
+		const headers = [...table.querySelectorAll('thead th')].map(
+			(th) => th.textContent
+		);
+		expect(headers).toContain('Species');
+		expect(headers).toContain('Location');
+		expect(headers).toContain('Notes');
+		expect(table.textContent).toContain('Blue Tit');
+		expect(table.textContent).toContain('Garden Feeder Station');
+		expect(table.textContent).toContain('Nest box 3');
+	});
+
+	it('re-sorts rows when a column header is clicked', async () => {
+		render(await Page());
+		const table = await screen.findByRole('table');
+		const firstRowBefore = table.querySelectorAll('tbody tr')[0].textContent;
+		const ringHeader = [...table.querySelectorAll('thead th')].find((th) =>
+			th.textContent?.includes('Ring')
+		)!;
+		fireEvent.click(ringHeader);
+		const firstRowAfter = table.querySelectorAll('tbody tr')[0].textContent;
+		expect(firstRowAfter).not.toBe(firstRowBefore);
+	});
+
+	it('renders a null notes cell gracefully when extra_text is null', async () => {
+		render(await Page());
+		const table = await screen.findByRole('table');
+		const rows = [...table.querySelectorAll('tbody tr')];
+		const rowWithNoNotes = rows.find((row) =>
+			row.textContent?.includes('APULLI02')
+		)!;
+		const notesCell = rowWithNoNotes.querySelectorAll('td')[4];
+		expect(notesCell.textContent).toBe('–');
+	});
+
+	it('renders empty state gracefully when there are no pulli encounters', async () => {
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+			makeEncountersClient([]).client
+		);
+		render(await Page());
+		const table = await screen.findByRole('table');
+		const rows = table.querySelectorAll('tbody tr');
+		expect(rows.length).toBe(0);
+	});
+});
+
+describe('fetchPulliEncounters query building', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('filters encounters to the viewed group', async () => {
+		const { client, chain } = makeEncountersClient(pulliEncountersSnapshot);
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+		await fetchPulliEncounters({}, 42);
+		expect(chain.eq).toHaveBeenCalledWith('ringing_group_id', 42);
+	});
+
+	it('filters to session.session_type = PULLI via the embedded-join filter', async () => {
+		const { client, chain } = makeEncountersClient(pulliEncountersSnapshot);
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+		await fetchPulliEncounters({}, 42);
+		expect(chain.eq).toHaveBeenCalledWith('session.session_type', 'PULLI');
+	});
+});

--- a/app/(routes)/pulli/page.tsx
+++ b/app/(routes)/pulli/page.tsx
@@ -1,0 +1,67 @@
+import { PulliEncounter } from '@/app/models/session';
+import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
+import { catchSupabaseErrors } from '@/lib/supabase';
+import {
+	BootstrapPageData,
+	DefaultPageParams
+} from '@/app/components/layout/BootstrapPageData';
+import {
+	PageWrapper,
+	PrimaryHeading
+} from '@/app/components/shared/DesignSystem';
+import { PulliEncountersTable } from '@/app/components/PulliEncountersTable';
+
+export async function fetchPulliEncounters(
+	_: DefaultPageParams,
+	viewedGroupId: number
+): Promise<PulliEncounter[]> {
+	const supabase = await getAuthenticatedSupabaseClient();
+	return supabase
+		.from('Encounters')
+		.select(
+			`
+			id,
+			extra_text,
+			bird:Birds (
+				ring_no,
+				species:Species (
+					species_name
+				)
+			),
+			session:Sessions!inner (
+				visit_date,
+				session_type,
+				location:Locations (
+					location_name
+				)
+			)
+		`
+		)
+		.eq('ringing_group_id', viewedGroupId)
+		.eq('session.session_type', 'PULLI')
+		.then(catchSupabaseErrors) as Promise<PulliEncounter[]>;
+}
+
+function ListPulliEncounters({ data }: { data: PulliEncounter[] }) {
+	return (
+		<PageWrapper>
+			<PrimaryHeading>Pulli</PrimaryHeading>
+			<PulliEncountersTable data={data} />
+		</PageWrapper>
+	);
+}
+
+export default async function PulliPage({
+	viewedGroupId
+}: {
+	viewedGroupId?: number;
+} = {}) {
+	return (
+		<BootstrapPageData<PulliEncounter[]>
+			viewedGroupId={viewedGroupId}
+			getCacheKeys={() => ['pulli']}
+			dataFetcher={fetchPulliEncounters}
+			PageComponent={ListPulliEncounters}
+		/>
+	);
+}

--- a/app/components/PulliEncountersTable.tsx
+++ b/app/components/PulliEncountersTable.tsx
@@ -1,0 +1,108 @@
+'use client';
+import { format as formatDate } from 'date-fns';
+import { NoPrefetchLink } from '@/app/components/shared/NoPrefetchLink';
+import type { PulliEncounter } from '@/app/models/session';
+import {
+	SortableTable,
+	type ColumnConfig,
+	type RowModelWithRawData,
+	getFormattedValue
+} from '@/app/components/shared/SortableTable';
+
+type PulliRowModel = {
+	ringNo: string;
+	speciesName: string;
+	visitDate: Date;
+	locationName: string;
+	notes: string | null;
+};
+
+function dateFormatter(value: unknown): string {
+	return formatDate(value as Date, 'dd MMM yyyy');
+}
+
+function notesFormatter(value: unknown): string {
+	return (value as string | null) ?? '–';
+}
+
+const columnConfigs = {
+	ringNo: {
+		label: 'Ring',
+		invertSort: true
+	},
+	speciesName: {
+		label: 'Species',
+		invertSort: true
+	},
+	visitDate: {
+		label: 'Visit date',
+		formatter: dateFormatter
+	},
+	locationName: {
+		label: 'Location',
+		invertSort: true
+	},
+	notes: {
+		label: 'Notes',
+		invertSort: true,
+		formatter: notesFormatter
+	}
+} as Record<keyof PulliRowModel, ColumnConfig>;
+
+const cellFormatter = getFormattedValue<PulliRowModel>(columnConfigs);
+
+function rowDataTransform(encounter: PulliEncounter): PulliRowModel {
+	return {
+		ringNo: encounter.bird.ring_no,
+		speciesName: encounter.bird.species.species_name,
+		visitDate: new Date(encounter.session.visit_date),
+		locationName: encounter.session.location.location_name,
+		notes: encounter.extra_text
+	};
+}
+
+function RingCell({
+	model
+}: {
+	model: RowModelWithRawData<PulliEncounter, PulliRowModel>;
+}) {
+	return (
+		<NoPrefetchLink className="link" href={`/bird/${model.ringNo}`}>
+			{model.ringNo}
+		</NoPrefetchLink>
+	);
+}
+
+function PulliEncountersTableBody({
+	data
+}: {
+	data: RowModelWithRawData<PulliEncounter, PulliRowModel>[];
+}) {
+	return (
+		<tbody>
+			{data.map((row) => (
+				<tr key={row._rawRowData.id}>
+					<td>
+						<RingCell model={row} />
+					</td>
+					<td>{row.speciesName}</td>
+					<td>{cellFormatter(row.visitDate, 'visitDate')}</td>
+					<td>{row.locationName}</td>
+					<td>{cellFormatter(row.notes, 'notes')}</td>
+				</tr>
+			))}
+		</tbody>
+	);
+}
+
+export function PulliEncountersTable({ data }: { data: PulliEncounter[] }) {
+	return (
+		<SortableTable<PulliEncounter, PulliRowModel>
+			columnConfigs={columnConfigs}
+			data={data}
+			initialSortColumn="visitDate"
+			rowDataTransform={rowDataTransform}
+			TableBodyComponent={PulliEncountersTableBody}
+		/>
+	);
+}

--- a/app/components/layout/GlobalNav.tsx
+++ b/app/components/layout/GlobalNav.tsx
@@ -10,6 +10,7 @@ const moreLinks = [
 	{ href: '/mistakes', label: 'Mistakes' },
 	{ href: '/retraps', label: 'Retraps' },
 	{ href: '/resightings', label: 'Resightings' },
+	{ href: '/pulli', label: 'Pulli' },
 	{ href: '/ticks', label: 'Ticks' },
 	{ href: '/effort', label: 'Effort' },
 	{ href: '/ring-sequences', label: 'Ring Sequences' },

--- a/app/components/layout/__tests__/GlobalNav.test.tsx
+++ b/app/components/layout/__tests__/GlobalNav.test.tsx
@@ -35,6 +35,7 @@ describe('DesktopNavItems', () => {
 		expect(screen.getByRole('link', { name: 'Mistakes' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Retraps' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Resightings' })).toBeDefined();
+		expect(screen.getByRole('link', { name: 'Pulli' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Ticks' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Effort' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Ring Sequences' })).toBeDefined();
@@ -73,15 +74,20 @@ describe('DesktopNavItems', () => {
 describe('MobileNavItems', () => {
 	afterEach(cleanup);
 
-	it('renders all 9 links in a flat list', () => {
+	it('renders all 10 links in a flat list', () => {
 		render(<MobileNavItems classes="" />);
 		const links = screen.getAllByRole('link');
-		expect(links).toHaveLength(9);
+		expect(links).toHaveLength(10);
 	});
 
 	it('includes Resightings link', () => {
 		render(<MobileNavItems classes="" />);
 		expect(screen.getByRole('link', { name: 'Resightings' })).toBeDefined();
+	});
+
+	it('includes Pulli link', () => {
+		render(<MobileNavItems classes="" />);
+		expect(screen.getByRole('link', { name: 'Pulli' })).toBeDefined();
 	});
 
 	it('includes Ticks link', () => {

--- a/app/group/[groupId]/pulli/page.tsx
+++ b/app/group/[groupId]/pulli/page.tsx
@@ -1,0 +1,10 @@
+import PulliPage from '@/app/(routes)/pulli/page';
+
+export default async function CrossGroupPulliPage({
+	params
+}: {
+	params: Promise<{ groupId: string }>;
+}) {
+	const { groupId } = await params;
+	return <PulliPage viewedGroupId={Number(groupId)} />;
+}

--- a/app/models/session.ts
+++ b/app/models/session.ts
@@ -21,6 +21,15 @@ export type ResightingEncounter = EncounterRow & {
 	};
 };
 
+export type PulliEncounter = EncounterRow & {
+	bird: BirdRow & {
+		species: SpeciesRow;
+	};
+	session: SessionRow & {
+		location: LocationRow;
+	};
+};
+
 export type SessionWithEncountersCount = SessionRow & {
 	encounters: { count: number }[];
 	location: LocationRow;

--- a/test-fixtures/snapshots/fetchPulliEncounters.alpha.json
+++ b/test-fixtures/snapshots/fetchPulliEncounters.alpha.json
@@ -1,0 +1,38 @@
+[
+  {
+    "id": 1,
+    "extra_text": "Nest box 3",
+    "bird": {
+      "ring_no": "APULLI01",
+      "species": { "species_name": "Blue Tit" }
+    },
+    "session": {
+      "visit_date": "2024-03-01",
+      "location": { "location_name": "Garden Feeder Station" }
+    }
+  },
+  {
+    "id": 2,
+    "extra_text": null,
+    "bird": {
+      "ring_no": "APULLI02",
+      "species": { "species_name": "Robin" }
+    },
+    "session": {
+      "visit_date": "2024-06-15",
+      "location": { "location_name": "Garden Feeder Station" }
+    }
+  },
+  {
+    "id": 3,
+    "extra_text": "Nest box 7",
+    "bird": {
+      "ring_no": "APULLI03",
+      "species": { "species_name": "Kingfisher" }
+    },
+    "session": {
+      "visit_date": "2023-11-20",
+      "location": { "location_name": "River Bank" }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Adds `app/(routes)/pulli/page.tsx` with `fetchPulliEncounters` — queries `Encounters` directly, filtered to `ringing_group_id` and joined-and-filtered to `session.session_type = 'PULLI'` via an inner-join embedded filter (`session:Sessions!inner(...)` + `.eq('session.session_type', 'PULLI')`). Verified this returns the expected rows against local Supabase (isolated insert/query/cleanup) — the embedded filter worked as expected, so no RPC fallback was needed.
- Adds `PulliEncountersTable.tsx` — a flat, non-tabbed `SortableTable` (ring/species/visit date/location/notes columns), following `NotableRetrapsTable`'s pattern rather than `ResightingsTable`'s tabbed grouping.
- Adds `app/group/[groupId]/pulli/page.tsx` cross-group wrapper, mirroring `resightings`.
- Adds `PulliEncounter` type to `app/models/session.ts` (same shape as `ResightingEncounter`, defined as its own named type per the ticket).
- Adds `{ href: '/pulli', label: 'Pulli' }` to `GlobalNav`'s `moreLinks`, after `Resightings`.
- Adds `test-fixtures/snapshots/fetchPulliEncounters.alpha.json` fixture and page/query-building tests; extends `GlobalNav.test.tsx` with Pulli link coverage and bumps the mobile flat-link-count assertion.

## Test plan
- [x] `npm run qa` (lint + type-check + app tests) — 633/633 passing
- [x] New `app/(routes)/pulli/__tests__/page.test.tsx` — heading, row rendering, formatted date, ring link, species/location/notes columns, sorting, null-notes placeholder, empty state, `fetchPulliEncounters` query-building (group filter + embedded session_type filter)
- [x] `GlobalNav.test.tsx` extended — Pulli link in both desktop and mobile nav, link-count bumped to 10
- [x] Manually verified the `session:Sessions!inner` + `.eq('session.session_type', 'PULLI')` embedded filter against local Supabase with an isolated, randomly-suffixed insert/query/cleanup — returned exactly the PULLI-session row and excluded FULL_GROWN rows
- [x] Pre-push hook ran full E2E safe suite (95 passed)

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)