### PR TITLE
Make Birds.species_id immutable once set (#468)

### DIFF
--- a/supabase/__tests__/triggers.test.ts
+++ b/supabase/__tests__/triggers.test.ts
@@ -1,5 +1,5 @@
 /**
- * Integration tests for custom Postgres triggers on Encounters.
+ * Integration tests for custom Postgres triggers on Encounters and Birds.
  *
  * Requires local Supabase running and e2e seed data loaded:
  *   npm run db:start:local
@@ -12,6 +12,7 @@ import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import { execSync } from 'child_process';
 import { getAuthenticatedSupabaseClientForGroup } from '../../lib/group-auth';
 import { supabase } from '../../lib/supabase';
+import { createUpserter } from '../../lib/demon-import';
 import { randomTestSuffix } from './test-isolation';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
@@ -164,5 +165,144 @@ describe('Encounters — same-session retrap suppression trigger', () => {
 			.single();
 
 		expect(data?.record_type).toBe('S');
+	});
+});
+
+describe('Birds — species_id immutability trigger', () => {
+	let groupClient: SupabaseClient;
+	let speciesIdA: number;
+	let speciesIdB: number;
+	let testSuffix: string;
+
+	// Every ring_no this suite writes shares this prefix + the random suffix, so the
+	// afterAll cleanup can remove exactly this run's rows without colliding with a
+	// concurrent worktree run against the shared local Supabase instance.
+	const ringPrefix = 'SPECIES-IMMUT';
+
+	beforeAll(async () => {
+		const { data: group, error: groupError } = await supabase
+			.from('RingingGroups')
+			.select('id')
+			.eq('group_name', 'Delta')
+			.single();
+		if (groupError || !group)
+			throw new Error('Delta group not found — run npm run db:seed:e2e first');
+
+		groupClient = await getAuthenticatedSupabaseClientForGroup(group.id);
+
+		const { data: species, error: speciesError } = await supabase
+			.from('Species')
+			.select('id')
+			.order('id', { ascending: true })
+			.limit(2);
+		if (speciesError || !species || species.length < 2)
+			throw new Error('Need two Species rows — run npm run db:seed:e2e first');
+		speciesIdA = species[0].id;
+		speciesIdB = species[1].id;
+
+		testSuffix = randomTestSuffix();
+	});
+
+	afterAll(() => {
+		psql(`DELETE FROM "Birds" WHERE ring_no LIKE '${ringPrefix}-%-${testSuffix}';`);
+	});
+
+	it('rejects a direct species_id change on an existing Birds row', async () => {
+		const ringNo = `${ringPrefix}-DIRECT-${testSuffix}`;
+		const { data: bird, error: insertError } = await groupClient
+			.from('Birds')
+			.insert({ ring_no: ringNo, species_id: speciesIdA })
+			.select('id')
+			.single();
+		if (insertError) throw insertError;
+
+		const { error } = await groupClient
+			.from('Birds')
+			.update({ species_id: speciesIdB })
+			.eq('id', bird!.id);
+
+		expect(error).not.toBeNull();
+		expect(error?.code).toBe('23514'); // check_violation
+		expect(error?.message).toContain('immutable');
+
+		// The row must still hold its original species — the change was rejected, not applied.
+		const { data: after } = await groupClient
+			.from('Birds')
+			.select('species_id')
+			.eq('id', bird!.id)
+			.single();
+		expect(after?.species_id).toBe(speciesIdA);
+	});
+
+	it('allows setting species_id to the same value it already has (only a real change is blocked)', async () => {
+		const ringNo = `${ringPrefix}-SAME-${testSuffix}`;
+		const { data: bird, error: insertError } = await groupClient
+			.from('Birds')
+			.insert({ ring_no: ringNo, species_id: speciesIdA })
+			.select('id')
+			.single();
+		if (insertError) throw insertError;
+
+		const { error } = await groupClient
+			.from('Birds')
+			.update({ species_id: speciesIdA })
+			.eq('id', bird!.id);
+
+		expect(error).toBeNull();
+	});
+
+	it('does not block creating a new Bird with a fresh ring_no', async () => {
+		const ringNo = `${ringPrefix}-FRESH-${testSuffix}`;
+		const { data: bird, error } = await groupClient
+			.from('Birds')
+			.insert({ ring_no: ringNo, species_id: speciesIdB })
+			.select('id, species_id')
+			.single();
+
+		expect(error).toBeNull();
+		expect(bird?.species_id).toBe(speciesIdB);
+	});
+
+	describe('import path (createUpserter on ring_no, as processEncounterRow uses)', () => {
+		it('re-importing the same ring_no with the same species is a no-op update, unaffected by the trigger', async () => {
+			const upsert = createUpserter(groupClient);
+			const ringNo = `${ringPrefix}-REIMPORT-SAME-${testSuffix}`;
+
+			const firstId = await upsert(
+				'Birds',
+				{ ring_no: ringNo, species_id: speciesIdA },
+				['ring_no']
+			);
+			const secondId = await upsert(
+				'Birds',
+				{ ring_no: ringNo, species_id: speciesIdA },
+				['ring_no']
+			);
+
+			expect(secondId).toBe(firstId);
+		});
+
+		it('re-importing the same ring_no with a different species no longer silently changes species_id — it errors, and species_id is preserved', async () => {
+			const upsert = createUpserter(groupClient);
+			const ringNo = `${ringPrefix}-REIMPORT-DIFF-${testSuffix}`;
+
+			const birdId = await upsert(
+				'Birds',
+				{ ring_no: ringNo, species_id: speciesIdA },
+				['ring_no']
+			);
+
+			await expect(
+				upsert('Birds', { ring_no: ringNo, species_id: speciesIdB }, ['ring_no'])
+			).rejects.toMatchObject({ code: '23514' });
+
+			// The original species must survive the rejected re-import.
+			const { data: after } = await groupClient
+				.from('Birds')
+				.select('species_id')
+				.eq('id', birdId)
+				.single();
+			expect(after?.species_id).toBe(speciesIdA);
+		});
 	});
 });

--- a/supabase/schema/schemas/public/functions/trg_prevent_bird_species_id_change.sql
+++ b/supabase/schema/schemas/public/functions/trg_prevent_bird_species_id_change.sql
@@ -1,0 +1,21 @@
+CREATE FUNCTION public.trg_prevent_bird_species_id_change () RETURNS TRIGGER LANGUAGE plpgsql AS $function$
+BEGIN
+  -- A physical ring number is assigned to one bird of one species for life, so
+  -- species_id must never change once set. If a re-imported CSV row reuses an
+  -- existing ring_no with a different species it signals a data-quality problem
+  -- in the source data — raise rather than silently overwrite species_id, so the
+  -- import surfaces the bad row (counted as a failed record) instead of masking it.
+  IF NEW.species_id IS DISTINCT FROM OLD.species_id THEN
+    RAISE EXCEPTION 'species_id is immutable once set (ring_no=%): cannot change from % to %',
+      OLD.ring_no, OLD.species_id, NEW.species_id
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$function$;
+
+GRANT ALL ON FUNCTION public.trg_prevent_bird_species_id_change () TO anon;
+
+GRANT ALL ON FUNCTION public.trg_prevent_bird_species_id_change () TO authenticated;
+
+GRANT ALL ON FUNCTION public.trg_prevent_bird_species_id_change () TO service_role;

--- a/supabase/schema/schemas/public/tables/"Birds".sql
+++ b/supabase/schema/schemas/public/tables/"Birds".sql
@@ -11,6 +11,13 @@ CREATE INDEX idx_birds_ringing_group_ids ON public."Birds" USING gin (ringing_gr
 
 CREATE INDEX idx_birds_species_id ON public."Birds" (species_id);
 
+-- species_id is immutable once set: a physical ring number belongs to one bird of
+-- one species for life, so a re-import reusing an existing ring_no with a different
+-- species is a source-data error the import must surface rather than silently apply.
+CREATE TRIGGER trigger_trg_prevent_bird_species_id_change BEFORE
+UPDATE ON public."Birds" FOR EACH ROW
+EXECUTE FUNCTION public.trg_prevent_bird_species_id_change ();
+
 -- SELECT: grants access if any of:
 -- 1. The logged-in group is one of the groups that has ringed this bird (its id is in ringing_group_ids)
 -- 2. The bird has no ringing group yet (empty array, e.g. freshly imported) and the user is authenticated

--- a/test-fixtures/snapshots/fetchMistakes.alpha.json
+++ b/test-fixtures/snapshots/fetchMistakes.alpha.json
@@ -1,10 +1,10 @@
 [
   {
-    "bird_id": 5,
-    "ring_no": "ARRETRAP",
-    "species_name": "Robin",
+    "bird_id": 9,
+    "ring_no": "ABTITMIS",
+    "species_name": "Blue Tit",
     "discrepency_type": "age",
-    "last_encounter_date": "2024-05-10"
+    "last_encounter_date": "2022-06-15"
   },
   {
     "bird_id": 7,
@@ -14,11 +14,11 @@
     "last_encounter_date": "2023-07-08"
   },
   {
-    "bird_id": 9,
-    "ring_no": "ABTITMIS",
-    "species_name": "Blue Tit",
+    "bird_id": 5,
+    "ring_no": "ARRETRAP",
+    "species_name": "Robin",
     "discrepency_type": "age",
-    "last_encounter_date": "2022-06-15"
+    "last_encounter_date": "2024-05-10"
   },
   {
     "bird_id": 9,


### PR DESCRIPTION
> ⚠️ **Database migration — do not merge before pushing.** This PR's schema change must be
> deployed to prod (`npm run db:migration:push`, run via the `take-over` skill) before this
> PR is merged. Merging first triggers a Vercel prod deploy of code that expects a schema
> prod doesn't have yet.

Closes #468

## What this covers

Makes `Birds.species_id` immutable once set. A physical ring number belongs to one bird of one
species for life, so a re-imported CSV row reusing an existing `ring_no` with a *different*
species is a source-data error — not a legitimate update. Previously the import silently
overwrote `species_id`, masking the data-quality problem (see the removed test / review thread
in #466).

### Schema change (`db-migration`)

- New trigger function `public.trg_prevent_bird_species_id_change()` (guard-style, following the
  `trg_suppress_same_session_retrap` convention — plain `plpgsql`, no `SECURITY DEFINER`).
- New `BEFORE UPDATE` trigger `trigger_trg_prevent_bird_species_id_change` on `public."Birds"`.
- Raises `check_violation` (SQLSTATE `23514`) only when `NEW.species_id IS DISTINCT FROM
  OLD.species_id`. Setting `species_id` to its current value, and `INSERT`ing new birds, are
  unaffected. No backfill needed — this only constrains future writes.

The generated migration is pure DDL (`supabase/migrations/` is gitignored per repo convention —
regenerate at deploy time with `npm run db:schema:apply` / the `take-over` flow). For reference it
contains exactly:

```sql
CREATE FUNCTION public.trg_prevent_bird_species_id_change() RETURNS trigger LANGUAGE plpgsql AS $function$
BEGIN
  IF NEW.species_id IS DISTINCT FROM OLD.species_id THEN
    RAISE EXCEPTION 'species_id is immutable once set (ring_no=%): cannot change from % to %',
      OLD.ring_no, OLD.species_id, NEW.species_id
      USING ERRCODE = 'check_violation';
  END IF;
  RETURN NEW;
END;
$function$;
-- (+ GRANTs to anon/authenticated/service_role)
CREATE TRIGGER trigger_trg_prevent_bird_species_id_change BEFORE UPDATE ON public."Birds"
  FOR EACH ROW EXECUTE FUNCTION public.trg_prevent_bird_species_id_change();
```

### Import-path behaviour — no code change needed

Both `createUpserter` callers (`scripts/import-csv.ts` and `app/api/import/route.ts`) already
catch per-row errors and count the row as **failed** (the CLI also logs the error). The `Birds`
upsert on `ring_no` conflict now raises the trigger's exception when the species differs; that
propagates out of `processEncounterRow` into the existing per-row handlers, so the bad row is
surfaced as a failed record instead of silently overwriting `species_id`. This follows the
existing error-handling pattern rather than inventing a new one (per the ticket).

### Tests (`supabase/__tests__/triggers.test.ts`, new `Birds — species_id immutability trigger`
describe block)

Added to the existing DB-trigger integration suite (rather than the `supabase/__tests__/demon-import.test.ts`
/ `db-constraints.test.ts` files referenced in the ticket, since those live in the still-open #466
and unfiled #467 and would create a hard dependency / merge conflict):

- rejects a direct `species_id` change on an existing row (asserts `23514` + `species_id`
  preserved)
- allows setting `species_id` to the value it already has (only a real change is blocked)
- does not block creating a new Bird with a fresh `ring_no`
- import path (`createUpserter` on `ring_no`): re-importing the same species is a no-op update;
  re-importing a different species errors and preserves the original `species_id`

All 116 DB integration tests, 632 app tests, lint, and type-check pass locally; the push ran the
app suite + 91 E2E specs green.

## Incidental fix (separate commit)

`test: refresh fetchMistakes.alpha snapshot to seed-consistent order` — the committed
`fetchMistakes.alpha.json` fixture listed the `age` discrepancies with Robin first, but
`find_discrepencies` has no `ORDER BY` (seed-dependent order) and the mistakes page sorts rows by
species ascending. That left `mistakes/page.test.tsx > "renders ring_no as a link in each row"`
deterministically failing (it derives the expected `ring_no` from the fixture's raw order),
contradicting its sibling `"sorts rows by species ascending"` test — a pre-existing inconsistency
unrelated to the schema change. Regenerated the fixture via `db:generate-snapshots` so its rows are
in the species-sorted order the component renders; row contents are unchanged, only order.
Follow-up worth considering: give `find_discrepencies` a stable `ORDER BY` (or make the test
order-independent) so the fixture can't drift again.

## Assumptions (subagent mode)

- Placed the integration tests in `triggers.test.ts` to avoid depending on the unmerged #466/#467
  files the ticket named.
- Decided the correct import-time behaviour is "let the DB rejection fail the row through the
  existing per-row error handling" (surface, don't mask) rather than adding bespoke skip/validate
  logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
