### PR TITLE
Add nullable slug column to RingingGroups + slugify util + seed/import-csv updates

### DIFF
--- a/lib/__tests__/slugify.test.ts
+++ b/lib/__tests__/slugify.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { slugify } from '../slugify';
+
+describe('slugify', () => {
+	// Usual
+	it('lowercases and hyphenates a simple multi-word name', () => {
+		expect(slugify('My Group')).toBe('my-group');
+	});
+
+	// Structure (one per transform branch)
+	it('strips leading punctuation', () => {
+		expect(slugify('!!My Group')).toBe('my-group');
+	});
+
+	it('strips trailing punctuation', () => {
+		expect(slugify('My Group!!')).toBe('my-group');
+	});
+
+	it('collapses repeated spaces into a single hyphen', () => {
+		expect(slugify('My   Group')).toBe('my-group');
+	});
+
+	it('collapses repeated hyphens into a single hyphen', () => {
+		expect(slugify('My--Group')).toBe('my-group');
+	});
+
+	it('preserves digits in the name', () => {
+		expect(slugify('Group 42')).toBe('group-42');
+	});
+
+	it('replaces symbols/underscores with a hyphen', () => {
+		expect(slugify('My_Group&Co')).toBe('my-group-co');
+	});
+
+	it('strips non-ASCII/accented characters rather than transliterating them', () => {
+		expect(slugify('Café Ringers')).toBe('caf-ringers');
+	});
+
+	// Edge
+	it('returns an empty string for an empty string input', () => {
+		expect(slugify('')).toBe('');
+	});
+
+	it('returns an empty string for an all-punctuation input', () => {
+		expect(slugify('!!!')).toBe('');
+	});
+
+	it('handles a single-character input', () => {
+		expect(slugify('A')).toBe('a');
+	});
+});

--- a/lib/slugify.ts
+++ b/lib/slugify.ts
@@ -1,0 +1,16 @@
+/**
+ * Convert a display name (e.g. a RingingGroups.group_name) into a URL-safe slug:
+ * lowercase, ASCII alphanumerics only, words separated by a single hyphen.
+ *
+ * Non-ASCII/accented characters are stripped rather than transliterated — e.g.
+ * "Café Ringers" -> "caf-ringers", not "cafe-ringers". No existing repo pattern
+ * transliterates, and the task didn't specify it, so this is the simplest correct
+ * default (see #473).
+ */
+export function slugify(input: string): string {
+	return input
+		.toLowerCase()
+		.replace(/[^\x00-\x7F]/g, '') // strip non-ASCII characters entirely
+		.replace(/[^a-z0-9]+/g, '-') // collapse runs of symbols/whitespace/underscores into a single hyphen
+		.replace(/^-+|-+$/g, ''); // trim leading/trailing hyphens
+}

--- a/scripts/import-csv.ts
+++ b/scripts/import-csv.ts
@@ -12,11 +12,7 @@ import { supabase } from '../lib/supabase';
 import fs from 'fs';
 import path from 'path';
 import csvParser from 'csv-parser';
-import { Database } from '../types/supabase.types';
 import { createUpserter, processEncounterRow } from '../lib/demon-import';
-
-type RingingGroupsInsert =
-	Database['public']['Tables']['RingingGroups']['Insert'];
 
 interface ImportOptions {
 	csvFilePath: string;
@@ -47,9 +43,9 @@ async function importCSV(options: ImportOptions): Promise<void> {
 	let failedRecords = 0;
 	const pendingRows: (Promise<void> | null)[] = [];
 
-	// 0. Upsert Ringing Group (create if doesn't exist) and get ID
-	// client just needs to have a group id - doenst need to be valid
-	let ringingGroupId: number;
+	// 0. Look up the Ringing Group by name and get its ID. This script no longer
+	// creates a missing group on the fly (#473) — groups are created via the seed
+	// script or Supabase Studio, so an unrecognised name is almost always a typo.
 	const { data: ringingGroupData, error: ringingGroupError } = await supabase
 		.from('RingingGroups')
 		.select('id')
@@ -58,17 +54,13 @@ async function importCSV(options: ImportOptions): Promise<void> {
 	if (ringingGroupError) {
 		throw ringingGroupError;
 	}
-	if (ringingGroupData) {
-		ringingGroupId = ringingGroupData.id;
-	} else {
-		ringingGroupId = await createUpserter(supabase)<RingingGroupsInsert>(
-			'RingingGroups',
-			{
-				group_name: ringingGroupName
-			},
-			['group_name']
+	if (!ringingGroupData) {
+		console.error(
+			`Error: Ringing group "${ringingGroupName}" not found. Create it first (e.g. via Supabase Studio) before importing — this script no longer creates groups automatically.`
 		);
+		process.exit(1);
 	}
+	const ringingGroupId: number = ringingGroupData.id;
 
 	const groupSupabaseClient =
 		await getAuthenticatedSupabaseClientForGroup(ringingGroupId);

--- a/scripts/seed-e2e-data.ts
+++ b/scripts/seed-e2e-data.ts
@@ -13,6 +13,7 @@ import { execSync } from 'child_process';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { supabase } from '../lib/supabase';
+import { slugify } from '../lib/slugify';
 import { generateSnapshots } from './generate-snapshots';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -39,24 +40,22 @@ async function getGroupId(name: string): Promise<number> {
 }
 
 async function main() {
-	// Step 1: Import Alpha CSV (creates Alpha group + all data)
-	run(`npm run db:import:local -- test-fixtures/csv/alpha.csv "Alpha"`);
-
-	// Step 2: Get Alpha ID
-	const alphaId = await getGroupId('Alpha');
-
-	// Step 3: Pre-create Beta, Gamma, and Delta groups (INSERT is allowed for all; UPDATE is restricted)
-	// Use ignoreDuplicates so re-running doesn't fail when group already exists.
-	for (const name of ['Beta', 'Gamma', 'Delta']) {
+	// Step 1: Pre-create all four groups with slugs, before any CSV import runs.
+	// scripts/import-csv.ts no longer creates a RingingGroups row when the given name
+	// isn't found (#473), so Alpha must exist here too, not just Beta/Gamma/Delta.
+	// INSERT is allowed for all; UPDATE is restricted. Use ignoreDuplicates-via-23505 so
+	// re-running doesn't fail when a group already exists.
+	for (const name of ['Alpha', 'Beta', 'Gamma', 'Delta']) {
 		await supabase
 			.from('RingingGroups')
-			.insert({ group_name: name })
+			.insert({ group_name: name, slug: slugify(name) })
 			.then(({ error }) => {
 				// Ignore unique constraint violation (group already exists)
 				if (error && error.code !== '23505')
 					throw new Error(`Failed to create ${name}: ${error.message}`);
 			});
 	}
+	const alphaId = await getGroupId('Alpha');
 	const betaId = await getGroupId('Beta');
 	const gammaId = await getGroupId('Gamma');
 	const deltaId = await getGroupId('Delta');
@@ -65,7 +64,10 @@ async function main() {
 		`Groups: Alpha(${alphaId}), Beta(${betaId}), Gamma(${gammaId}), Delta(${deltaId})`
 	);
 
-	// Step 4: Insert GroupDataSharing via direct Postgres (bypasses RLS — no INSERT policy exists)
+	// Step 2: Import Alpha CSV (Alpha group already exists from step 1)
+	run(`npm run db:import:local -- test-fixtures/csv/alpha.csv "Alpha"`);
+
+	// Step 3: Insert GroupDataSharing via direct Postgres (bypasses RLS — no INSERT policy exists)
 	// Alpha shares with Beta; Beta shares with Gamma. Not transitive.
 	execSync(
 		`psql "${LOCAL_DB_URL}" -c "INSERT INTO \\"GroupDataSharing\\" (granter_group_id, recipient_group_id) VALUES (${alphaId}, ${betaId}), (${betaId}, ${gammaId}) ON CONFLICT (granter_group_id, recipient_group_id) DO NOTHING;"`,
@@ -73,16 +75,16 @@ async function main() {
 	);
 	console.log(`GroupDataSharing: Alpha→Beta, Beta→Gamma created`);
 
-	// Step 5: Import Beta CSV (GroupDataSharing must exist first so SHARED01 is accessible to Beta)
+	// Step 4: Import Beta CSV (GroupDataSharing must exist first so SHARED01 is accessible to Beta)
 	run(`npm run db:import:local -- test-fixtures/csv/beta.csv "Beta"`);
 
-	// Step 6: Set group passwords
+	// Step 5: Set group passwords
 	run(`npm run set-group-password:local -- "Alpha" "alphapassword"`);
 	run(`npm run set-group-password:local -- "Beta" "betapassword"`);
 	run(`npm run set-group-password:local -- "Gamma" "gammapassword"`);
 	run(`npm run set-group-password:local -- "Delta" "deltapassword"`);
 
-	// Step 7: Generate snapshot JSON fixtures
+	// Step 6: Generate snapshot JSON fixtures
 	await generateSnapshots(alphaId, betaId, gammaId);
 }
 

--- a/supabase/__tests__/db-constraints.test.ts
+++ b/supabase/__tests__/db-constraints.test.ts
@@ -327,3 +327,56 @@ describe('DB constraints — Encounters uniqueness (bird_id, session_id)', () =>
 		expect(duplicate.error?.code).toBe('23505');
 	});
 });
+
+describe('DB constraints — RingingGroups uniqueness (slug)', () => {
+	const suffix = randomTestSuffix();
+	let groupId: number;
+	let groupClient: SupabaseClient;
+
+	beforeAll(async () => {
+		groupId = createIsolatedGroup(`db-constraints-${suffix}-slug`);
+		groupClient = await getAuthenticatedSupabaseClientForGroup(groupId);
+	});
+
+	afterAll(() => {
+		psql(
+			`DELETE FROM "RingingGroups" WHERE group_name LIKE 'DbConstraintsGroup-${suffix}-%';` +
+				`DELETE FROM "RingingGroups" WHERE id = ${groupId};`
+		);
+	});
+
+	it('allows inserting a RingingGroups row with a unique slug', async () => {
+		const { error } = await groupClient.from('RingingGroups').insert({
+			group_name: `DbConstraintsGroup-${suffix}-unique`,
+			slug: `db-constraints-${suffix}-unique`
+		});
+		expect(error).toBeNull();
+	});
+
+	it('rejects a raw duplicate slug insert with a unique-violation error', async () => {
+		const slug = `db-constraints-${suffix}-dup`;
+		const first = await groupClient.from('RingingGroups').insert({
+			group_name: `DbConstraintsGroup-${suffix}-dup-1`,
+			slug
+		});
+		expect(first.error).toBeNull();
+
+		const duplicate = await groupClient.from('RingingGroups').insert({
+			group_name: `DbConstraintsGroup-${suffix}-dup-2`,
+			slug
+		});
+		expect(duplicate.error?.code).toBe('23505');
+	});
+
+	it('allows inserting multiple RingingGroups rows with a null slug', async () => {
+		const first = await groupClient.from('RingingGroups').insert({
+			group_name: `DbConstraintsGroup-${suffix}-null-1`
+		});
+		expect(first.error).toBeNull();
+
+		const second = await groupClient.from('RingingGroups').insert({
+			group_name: `DbConstraintsGroup-${suffix}-null-2`
+		});
+		expect(second.error).toBeNull();
+	});
+});

--- a/supabase/schema/schemas/public/tables/"RingingGroups".sql
+++ b/supabase/schema/schemas/public/tables/"RingingGroups".sql
@@ -2,7 +2,8 @@ CREATE TABLE public."RingingGroups" (
 	group_name text NOT NULL,
 	id bigint DEFAULT nextval('public."RingingGroups_id_seq"'::regclass) NOT NULL,
 	password_hash text,
-	password_salt text
+	password_salt text,
+	slug text
 );
 
 CREATE POLICY ringing_groups_access ON public."RingingGroups" FOR
@@ -46,6 +47,9 @@ ADD CONSTRAINT "RingingGroups_group_name_unique" UNIQUE (group_name);
 
 ALTER TABLE public."RingingGroups"
 ADD CONSTRAINT "RingingGroups_pkey" PRIMARY KEY (id);
+
+ALTER TABLE public."RingingGroups"
+ADD CONSTRAINT "RingingGroups_slug_unique" UNIQUE (slug);
 
 GRANT ALL ON public."RingingGroups" TO anon;
 

--- a/types/supabase.types.ts
+++ b/types/supabase.types.ts
@@ -206,18 +206,21 @@ export type Database = {
           id: number
           password_hash: string | null
           password_salt: string | null
+          slug: string | null
         }
         Insert: {
           group_name: string
           id?: number
           password_hash?: string | null
           password_salt?: string | null
+          slug?: string | null
         }
         Update: {
           group_name?: string
           id?: number
           password_hash?: string | null
           password_salt?: string | null
+          slug?: string | null
         }
         Relationships: []
       }


### PR DESCRIPTION
⚠️ **Database migration — do not merge before pushing.** This PR's schema change must be
deployed to prod (`npm run db:migration:push`, run via the `take-over` skill) before this
PR is merged. Merging first triggers a Vercel prod deploy of code that expects a schema
prod doesn't have yet.

## Summary

First branch of the "group slugs in URLs" effort. Adds the schema groundwork and two script
updates — no route/URL changes here (that's a later branch).

- `RingingGroups` gets a nullable `slug text` column plus a unique constraint
  (`RingingGroups_slug_unique`), mirroring the existing `RingingGroups_group_name_unique`
  pattern. Postgres treats each `NULL` as distinct under a `UNIQUE` constraint, so this is safe
  pre-backfill.
- New `lib/slugify.ts` — pure `slugify(input: string): string`, fully unit tested.
- `scripts/seed-e2e-data.ts` now pre-creates all four groups (Alpha included, not just
  Beta/Gamma/Delta) with `slug: slugify(name)` before any CSV import runs — Alpha's import
  previously ran before the group existed, relying on the fallback removed below.
- `scripts/import-csv.ts` no longer creates a `RingingGroups` row when the given group name isn't
  found — it exits with a clear, actionable error instead. Confirmed via investigation that
  `lib/demon-import.ts` and `app/api/import/route.ts` never had this fallback, so no changes
  needed there.
- New DB integration test describe block (`DB constraints — RingingGroups uniqueness (slug)`) in
  `supabase/__tests__/db-constraints.test.ts`, matching the existing style in that file: unique
  insert, duplicate-slug `23505` rejection, and the nullable-slug edge case (multiple `NULL`
  slugs coexist under the constraint).

## Assumption flagged for review

`slugify` strips non-ASCII/accented characters rather than transliterating them (e.g.
`"Café Ringers"` → `"caf-ringers"`, not `"cafe-ringers"`). The task brief didn't specify
transliteration and no existing repo pattern does it, so this is the simplest correct default.
Flag in case a transliteration library is preferred instead.

## Out of scope (tracked separately)

- Making `slug` `NOT NULL` — hard-blocked on a manual, human-only prod backfill after this ships.
- `lib/group-slug.ts` resolver + `app/group/[groupId]/` → `app/group/[groupSlug]/` rename.
- Threading `slug` through href-building components.
- Any UI surface that displays or edits `slug`.
- Auto-deduplicating colliding slugs — the unique constraint rejects a collision with `23505`;
  nothing this PR touches can produce one (seed script uses four fixed, distinct names).

## Verification

- `npm run db:schema:apply` — generated migration inspected before applying (pure DDL, no
  backfill needed since `slug` stays nullable):
  ```sql
  ALTER TABLE public."RingingGroups" ADD COLUMN slug text;
  ALTER TABLE public."RingingGroups" ADD CONSTRAINT "RingingGroups_slug_unique" UNIQUE (slug);
  ```
- `npm run db:types` — `slug: string | null` confirmed in `types/supabase.types.ts`.
- `npm run db:seed:e2e` — full seed run succeeds with the restructured group-creation order.
- `npm run test:integration` — 140 passed, including the 3 new slug-uniqueness tests.
- `npm run test:nowatch` — 643 passed, including the 11 new `slugify` unit tests.
- `npm run test:e2e` (full suite, since this branch touches an `@mutates` trigger path) — 94
  passed, including the `import.spec.ts` flow.
- `npm run qa` — lint + type-check + app tests all clean.

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)