### PR TITLE
fix: state-file test isolation escapes to real swarm-state.json under GIT_DIR

### DIFF
--- a/.claude/mcp/swarm-tools/lib/__tests__/state-file.test.ts
+++ b/.claude/mcp/swarm-tools/lib/__tests__/state-file.test.ts
@@ -26,7 +26,13 @@ describe('state-file', () => {
 
 	beforeEach(async () => {
 		repoDir = await fs.mkdtemp(path.join(os.tmpdir(), 'swarm-state-test-'));
-		await execa('git', ['init', '--quiet'], { cwd: repoDir });
+		// `git init` honours an inherited GIT_DIR over cwd — git sets GIT_DIR when invoking hooks,
+		// so running this suite from the pre-push hook would otherwise re-target the real repo's
+		// .git instead of creating an isolated one here. Strip it (and disable execa's default
+		// extendEnv, which would otherwise re-merge it back in from process.env) so the temp repo
+		// is genuinely isolated regardless of what invoked the test run.
+		const { GIT_DIR: _GIT_DIR, GIT_WORK_TREE: _GIT_WORK_TREE, GIT_INDEX_FILE: _GIT_INDEX_FILE, ...env } = process.env;
+		await execa('git', ['init', '--quiet'], { cwd: repoDir, env, extendEnv: false });
 	});
 
 	afterEach(async () => {

--- a/.claude/mcp/swarm-tools/lib/__tests__/state-file.test.ts
+++ b/.claude/mcp/swarm-tools/lib/__tests__/state-file.test.ts
@@ -31,7 +31,10 @@ describe('state-file', () => {
 		// .git instead of creating an isolated one here. Strip it (and disable execa's default
 		// extendEnv, which would otherwise re-merge it back in from process.env) so the temp repo
 		// is genuinely isolated regardless of what invoked the test run.
-		const { GIT_DIR: _GIT_DIR, GIT_WORK_TREE: _GIT_WORK_TREE, GIT_INDEX_FILE: _GIT_INDEX_FILE, ...env } = process.env;
+		const env = { ...process.env };
+		delete env.GIT_DIR;
+		delete env.GIT_WORK_TREE;
+		delete env.GIT_INDEX_FILE;
 		await execa('git', ['init', '--quiet'], { cwd: repoDir, env, extendEnv: false });
 	});
 

--- a/.claude/mcp/swarm-tools/lib/state-file.ts
+++ b/.claude/mcp/swarm-tools/lib/state-file.ts
@@ -25,12 +25,34 @@ const LOCK_TIMEOUT_MS = 5000;
  * since it can't change during the server's lifetime.
  */
 const projectRootCache = new Map<string, Promise<string>>();
+
+/**
+ * `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` in the environment make git skip cwd-based repo
+ * discovery entirely and operate on whatever repo those vars name — git itself sets `GIT_DIR`
+ * when invoking hooks (e.g. this repo's `.husky/pre-push`), so a `git rev-parse` shelled out
+ * during a pre-push run inherits it. Without stripping these, a caller passing an isolated
+ * temp-repo `cwd` (as `state-file.test.ts` does) still resolves to the *real* repo whenever this
+ * runs under a git hook, silently escaping the isolation and hitting the real
+ * `.claude/swarm-state.json`. `extendEnv: false` is required alongside this — execa's default
+ * `extendEnv: true` re-merges the spawned process's env on top of whatever `env` object is
+ * passed, which would otherwise silently reintroduce the very vars just deleted from our copy.
+ */
+function envWithoutGitDiscoveryOverrides(): NodeJS.ProcessEnv {
+	const env = { ...process.env };
+	delete env.GIT_DIR;
+	delete env.GIT_WORK_TREE;
+	delete env.GIT_INDEX_FILE;
+	return env;
+}
+
 async function resolveProjectRoot(cwd: string): Promise<string> {
 	let cached = projectRootCache.get(cwd);
 	if (!cached) {
-		cached = execa('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], { cwd }).then((result) =>
-			path.dirname(result.stdout.trim())
-		);
+		cached = execa('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'], {
+			cwd,
+			env: envWithoutGitDiscoveryOverrides(),
+			extendEnv: false,
+		}).then((result) => path.dirname(result.stdout.trim()));
 		projectRootCache.set(cwd, cached);
 	}
 	return cached;


### PR DESCRIPTION
## Summary

`.claude/mcp/swarm-tools/lib/__tests__/state-file.test.ts` is supposed to isolate itself in a fresh temp git repo per test (`fs.mkdtemp` + `git init`), but `resolveProjectRoot()`'s `git rev-parse --git-common-dir` call silently escaped that isolation whenever `GIT_DIR` was present in the environment — which git itself sets when invoking hooks, so any `npm run test:nowatch` run through `.husky/pre-push` inherited it. With `GIT_DIR` set, `git rev-parse`/`git init` ignore the `cwd` passed via `execa` and operate on whatever `GIT_DIR` names instead, so the test ended up reading/writing the **real, shared, gitignored `.claude/swarm-state.json`** (used by the live `/swarm` workflow to track running workers) instead of its own fixture. The test's own assertions (`toHaveLength(8)`, `toEqual([])`) then failed whenever real swarm state was non-empty — which is the normal operating condition, since multiple worktrees run this workflow concurrently.

Root-caused by the #475 worker while investigating a reported flake in this test (ticket #478's local `--no-verify` bypass); I independently reproduced the exact escape (`git -C <tmpdir> rev-parse --git-common-dir` returning the real repo's `.git` when `GIT_DIR` is inherited) and confirmed a zombie-vitest-process theory floated in parallel was not the cause — only one stale orphaned vitest fork worker was found on the machine, holding no locks and unrelated to this failure mode.

## Fix

- `resolveProjectRoot()` in `lib/state-file.ts` now strips `GIT_DIR`/`GIT_WORK_TREE`/`GIT_INDEX_FILE` from the env passed to `git rev-parse --git-common-dir`, with `extendEnv: false` — execa's default `extendEnv: true` re-merges the passed `env` on top of `process.env`, which would otherwise silently reintroduce the very vars just deleted.
- The test's own `git init` in `beforeEach` gets the identical treatment — `git init` also honours an inherited `GIT_DIR` over `cwd`, so without stripping it there the temp repo itself could be mis-targeted even after the production-code fix.

## Verification

- Normal run: `npm run test:nowatch -- .claude/mcp/swarm-tools/lib/__tests__/state-file.test.ts` — 6/6 pass.
- Repro of the bug: ran the *pre-fix* code with `GIT_DIR` set to the real repo's common dir (simulating a pre-push hook run) — confirmed the real shared `.claude/swarm-state.json` grew by exactly the fixture count each time (e.g. 1 real entry + 8 concurrent-test fixtures = 9), matching the reported failure mode exactly.
- Same repro against the *post-fix* code, run 5x in a loop under the hostile `GIT_DIR` env — all 5 runs pass, and the real shared state file (snapshotted before/after) is byte-identical across every run.
- Full swarm-tools suite (`.claude/mcp/swarm-tools`): 74/74 pass. Full app suite + `npx tsc --noEmit`: clean.
- Cleaned up fixture pollution left in the real `.claude/swarm-state.json` by my own pre-fix repro runs, using the proper `swarm_state_remove` MCP tool rather than hand-writing the file.

Unblocks the pre-push hook for everyone using the shared local swarm state file.

## Test plan

- [x] `npm run test:nowatch -- .claude/mcp/swarm-tools` — 74/74 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] Repro'd the bug pre-fix, confirmed fixed post-fix (5x under hostile `GIT_DIR` env)
- [x] Full pre-push hook (lint, tsc, app tests, E2E) passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)