### PR TITLE
fix: auto-merge origin/main before push when swarm-tools is stale

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,4 @@
+./scripts/check-swarm-tools-staleness.sh
 npm run lint
 npx tsc --noEmit
 npm run test:nowatch

--- a/scripts/check-swarm-tools-staleness.sh
+++ b/scripts/check-swarm-tools-staleness.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+# Every git worktree of this repo shares one common .git dir, so a branch cut before an infra
+# fix lands on .claude/mcp/swarm-tools keeps re-running the unpatched code (and re-corrupting the
+# shared .claude/swarm-state.json) every time its test suite runs through this hook — see issue
+# #485. Auto-merge origin/main before running tests when the branch is behind on that path.
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT_BRANCH" = "main" ]; then
+	exit 0
+fi
+
+MERGE_BASE=$(git merge-base HEAD origin/main)
+STALE=$(git diff --name-only "$MERGE_BASE" origin/main -- .claude/mcp/swarm-tools/)
+
+if [ -z "$STALE" ]; then
+	exit 0
+fi
+
+echo "check-swarm-tools-staleness: branch is behind origin/main on .claude/mcp/swarm-tools/** — auto-merging origin/main before running tests"
+
+if ! git merge origin/main -m "Merge origin/main: pick up swarm-tools fixes before push"; then
+	git merge --abort
+	echo "check-swarm-tools-staleness: auto-merge failed (conflicts) — resolve manually with 'git merge origin/main' and retry push" >&2
+	exit 1
+fi
+
+echo "check-swarm-tools-staleness: merged origin/main successfully"


### PR DESCRIPTION
## Summary

- Adds `scripts/check-swarm-tools-staleness.sh`, run first in `.husky/pre-push`: if the current branch is behind `origin/main` specifically on `.claude/mcp/swarm-tools/**`, it auto-merges `origin/main` before the rest of the hook (lint/typecheck/tests/e2e) runs.
- Prevents the failure mode documented in #485: a branch cut before a swarm-tools infra fix lands on `main` keeps re-running the unpatched code and re-corrupting the shared `.claude/swarm-state.json` on every push, until someone manually merges `origin/main` by hand.
- On a clean merge: prints a confirmation, continues the push. On a conflicting merge: aborts the merge (`git merge --abort`), prints a message telling the dev to resolve manually, exits 1 (blocks the push rather than leaving a half-merged tree).
- No-op on `main` itself or when the branch is already current on that path.

## Related

- Closes #485
- PR #483 (merged) — the underlying `GIT_DIR` isolation fix this guard protects against recurring
- Issue #484 (open) — separate schema-drift hardening for `readState`/`writeState`
- Issue #491 (opened during this work) — a related gap found in `swarm`'s PR-maintenance worker, which can still run tests against a stale `origin/main` when a PR needs feedback-only maintenance (no textual conflict to trigger its existing merge step)

## Test plan

- [x] `npm run qa` (lint + typecheck + 717 app tests) passes
- [x] Manually verified in a scratch clone: stale branch fast-forward-merges cleanly (exit 0), already-current branch no-ops (HEAD unchanged, exit 0), conflicting stale branch aborts the merge and exits 1 with a clean working tree
- [x] Real `git push` on this branch ran the hook end-to-end (script + lint + typecheck + tests + full e2e suite), all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)