### PR TITLE
fix: validate swarm-state.json shape with a clear named error

### DIFF
--- a/.claude/mcp/swarm-tools/lib/__tests__/state-file.test.ts
+++ b/.claude/mcp/swarm-tools/lib/__tests__/state-file.test.ts
@@ -4,7 +4,7 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 import { execa } from 'execa';
-import { withStateLock, listState, type SwarmWorkerEntry } from '../state-file';
+import { withStateLock, listState, SwarmStateSchemaError, type SwarmWorkerEntry } from '../state-file';
 
 function makeEntry(overrides: Partial<SwarmWorkerEntry> = {}): SwarmWorkerEntry {
 	return {
@@ -85,5 +85,48 @@ describe('state-file', () => {
 		const entry = makeEntry();
 		const removed = await withStateLock((entries) => ({ entries: [...entries, entry], result: entry.agentId }), repoDir);
 		expect(removed).toBe('agent-1');
+	});
+
+	describe('schema validation', () => {
+		async function writeRawState(raw: string): Promise<void> {
+			const dir = path.join(repoDir, '.claude');
+			await fs.mkdir(dir, { recursive: true });
+			await fs.writeFile(path.join(dir, 'swarm-state.json'), raw, 'utf8');
+		}
+
+		// Structure
+		it('throws SwarmStateSchemaError when the file holds an object instead of an array', async () => {
+			await writeRawState(JSON.stringify({ workers: [] }));
+			await expect(listState(repoDir)).rejects.toThrow(SwarmStateSchemaError);
+		});
+
+		it('throws SwarmStateSchemaError when an entry is missing a required key', async () => {
+			const { agentId: _agentId, ...withoutAgentId } = makeEntry();
+			await writeRawState(JSON.stringify([withoutAgentId]));
+			await expect(listState(repoDir)).rejects.toThrow(SwarmStateSchemaError);
+		});
+
+		it('throws SwarmStateSchemaError when an entry has the wrong type for a field', async () => {
+			await writeRawState(JSON.stringify([{ ...makeEntry(), issue: 'not-a-number' }]));
+			await expect(listState(repoDir)).rejects.toThrow(SwarmStateSchemaError);
+		});
+
+		it('throws SwarmStateSchemaError when the top level is neither an object nor an array', async () => {
+			await writeRawState(JSON.stringify('just a string'));
+			await expect(listState(repoDir)).rejects.toThrow(SwarmStateSchemaError);
+		});
+
+		// Edge
+		it('accepts an empty array', async () => {
+			await writeRawState('[]');
+			expect(await listState(repoDir)).toEqual([]);
+		});
+
+		it('tolerates unknown extra keys on an otherwise-valid entry', async () => {
+			await writeRawState(JSON.stringify([{ ...makeEntry(), extraField: 'from-a-future-version' }]));
+			const result = await listState(repoDir);
+			expect(result).toHaveLength(1);
+			expect(result[0].agentId).toBe('agent-1');
+		});
 	});
 });

--- a/.claude/mcp/swarm-tools/lib/state-file.ts
+++ b/.claude/mcp/swarm-tools/lib/state-file.ts
@@ -1,17 +1,40 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { execa } from 'execa';
+import { z } from 'zod';
 
-export interface SwarmWorkerEntry {
-	kind: 'ticket' | 'maintenance';
-	issue: number | null;
-	pr: number | null;
-	branch: string;
-	title: string;
-	worktreePath: string;
-	agentId: string;
-	model: string;
-	startedAt: string;
+/**
+ * Single source of truth for a worker entry's shape — used both to validate
+ * .claude/swarm-state.json on read (see readState below) and, via tools/swarm-state.ts, to type
+ * the swarm_state_* MCP tools' stored-entry output. Keeping one definition means a shape change
+ * can't drift between "what we store" and "what we validate".
+ */
+export const swarmWorkerEntrySchema = z.object({
+	kind: z.enum(['ticket', 'maintenance']),
+	issue: z.number().nullable(),
+	pr: z.number().nullable(),
+	branch: z.string(),
+	title: z.string(),
+	worktreePath: z.string(),
+	agentId: z.string(),
+	model: z.string(),
+	startedAt: z.string(),
+});
+
+export type SwarmWorkerEntry = z.infer<typeof swarmWorkerEntrySchema>;
+
+const swarmStateSchema = z.array(swarmWorkerEntrySchema);
+
+/** Thrown when .claude/swarm-state.json on disk doesn't match SwarmWorkerEntry[] — see #484. */
+export class SwarmStateSchemaError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = 'SwarmStateSchemaError';
+	}
+}
+
+function formatZodIssues(error: z.ZodError): string {
+	return error.issues.map((issue) => `${issue.path.length ? issue.path.join('.') : '(root)'}: ${issue.message}`).join('; ');
 }
 
 const LOCK_RETRY_MS = 50;
@@ -87,13 +110,23 @@ async function releaseLock(lockPath: string): Promise<void> {
 }
 
 async function readState(stateFilePath: string): Promise<SwarmWorkerEntry[]> {
+	let raw: string;
 	try {
-		const raw = await fs.readFile(stateFilePath, 'utf8');
-		return raw.trim() ? (JSON.parse(raw) as SwarmWorkerEntry[]) : [];
+		raw = await fs.readFile(stateFilePath, 'utf8');
 	} catch (err) {
 		if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
 		throw err;
 	}
+	if (!raw.trim()) return [];
+
+	const parsed: unknown = JSON.parse(raw);
+	const result = swarmStateSchema.safeParse(parsed);
+	if (!result.success) {
+		throw new SwarmStateSchemaError(
+			`${stateFilePath} does not match the expected SwarmWorkerEntry[] shape: ${formatZodIssues(result.error)}`
+		);
+	}
+	return result.data;
 }
 
 async function writeState(stateFilePath: string, entries: SwarmWorkerEntry[]): Promise<void> {

--- a/.claude/mcp/swarm-tools/tools/swarm-state.ts
+++ b/.claude/mcp/swarm-tools/tools/swarm-state.ts
@@ -1,18 +1,6 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { withStateLock, listState, type SwarmWorkerEntry } from '../lib/state-file';
-
-export const swarmWorkerEntrySchema = z.object({
-	kind: z.enum(['ticket', 'maintenance']),
-	issue: z.number().nullable(),
-	pr: z.number().nullable(),
-	branch: z.string(),
-	title: z.string(),
-	worktreePath: z.string(),
-	agentId: z.string(),
-	model: z.string(),
-	startedAt: z.string(),
-});
+import { withStateLock, listState, swarmWorkerEntrySchema, type SwarmWorkerEntry } from '../lib/state-file';
 
 export function registerSwarmStateTools(server: McpServer) {
 	server.registerTool(


### PR DESCRIPTION
## Summary

- `readState` (`lib/state-file.ts`) previously cast `JSON.parse`'s result straight to `SwarmWorkerEntry[]` with no runtime check — a malformed file round-tripped as "valid" until a caller iterated it and hit a generic `TypeError` (`entries.filter is not a function`, `running is not iterable`).
- Validates with a `zod` schema instead, throwing a named `SwarmStateSchemaError` with a specific path/message for both top-level shape mismatches (object instead of array) and per-entry problems (missing/mistyped fields).
- The same schema (`swarmWorkerEntrySchema`, moved to `lib/state-file.ts`) now backs the `swarm_state_*` tools' output typing too, replacing a duplicate hand-written zod object that previously lived in `tools/swarm-state.ts`.
- Audited the test suite per the ticket's second suggestion: the only fixture that could write to the real repo path was already fixed in #483 (`state-file.test.ts` isolates via an `mkdtemp`'d temp repo with `GIT_DIR` stripped) — no other source of corruption found.

## Verification

Ran the fixed `readState` against the actual corrupted `.claude/swarm-state.json` on disk (`{"workers":[]}`):

```
name: SwarmStateSchemaError
message: .../.claude/swarm-state.json does not match the expected SwarmWorkerEntry[] shape: (root): Invalid input: expected array, received object
```

vs. the previous generic `entries.filter is not a function`.

## Related

- Closes #484
- Issue #485 / PR #492 — the other half of the swarm-state corruption story (stops branches from re-hitting an already-fixed swarm-tools bug on push)

## Test plan

- [x] `npm run qa` — lint + typecheck + all 723 app tests (6 new: object-wrapper, missing key, wrong type, non-array/non-object top level, empty array accepted, unknown extra keys tolerated)
- [x] Manually verified against the real corrupted state file (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)