### PR TITLE
Add lib/group-slug.ts resolver + compute viewedGroup for /group route pages

### DIFF
--- a/app/(routes)/bird/[ring]/page.tsx
+++ b/app/(routes)/bird/[ring]/page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/app/models/bird';
 import { NoPrefetchLink } from '@/app/components/shared/NoPrefetchLink';
 import { EncountersTimeline } from '@/app/components/EncountersTimeline';
+import type { ViewedGroup } from '@/lib/group-slug';
 
 type PageParams = { ring: string };
 type PageProps = { params: Promise<PageParams> };
@@ -128,7 +129,9 @@ function BirdSummary({
 	);
 }
 
-export default async function BirdPage(props: PageProps) {
+export default async function BirdPage(
+	props: PageProps & { viewedGroup?: ViewedGroup }
+) {
 	return (
 		<BootstrapPageData<StandaloneBird, PageProps, PageParams>
 			pageProps={props}

--- a/app/(routes)/bird/page.tsx
+++ b/app/(routes)/bird/page.tsx
@@ -6,6 +6,7 @@ import {
 	BirdSearchResults,
 	type SearchResult
 } from '@/app/components/BirdSearchResults';
+import type { ViewedGroup } from '@/lib/group-slug';
 
 type SearchParams = { q: string };
 type PageProps = { searchParams: Promise<SearchParams> };
@@ -28,7 +29,9 @@ async function searchByRing({ q }: SearchParams, _viewedGroupId: number) {
 		.then(catchSupabaseErrors);
 }
 
-export default async function BirdPage(props: PageProps) {
+export default async function BirdPage(
+	props: PageProps & { viewedGroup?: ViewedGroup }
+) {
 	return (
 		<BootstrapPageData<SearchResult[], PageProps, SearchParams>
 			pageProps={props}

--- a/app/(routes)/controls/page.tsx
+++ b/app/(routes)/controls/page.tsx
@@ -7,6 +7,7 @@ import {
 	type RingSequenceControlRow
 } from '@/app/actions/ring-sequences';
 import { ControlsPage } from '@/app/components/ControlsPage';
+import type { ViewedGroup } from '@/lib/group-slug';
 
 async function dataFetcher(
 	_: DefaultPageParams,
@@ -19,6 +20,7 @@ export default async function ControlsRoute({
 	viewedGroupId
 }: {
 	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<RingSequenceControlRow[]>

--- a/app/(routes)/effort/page.tsx
+++ b/app/(routes)/effort/page.tsx
@@ -13,6 +13,7 @@ import {
 	type PayOffStatsData
 } from '@/app/actions/pay-off-stats';
 import type { AggregateStatsResult } from '@/app/models/db';
+import type { ViewedGroup } from '@/lib/group-slug';
 import { formatPostgresIntervalForDisplay } from '@/lib/postgres-interval';
 import { PayOffEffortChart } from '@/app/components/PayOffEffortChart';
 
@@ -130,6 +131,7 @@ export default function PayOffPage({
 	viewedGroupId
 }: {
 	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<PayOffStatsData>

--- a/app/(routes)/highlights/page.tsx
+++ b/app/(routes)/highlights/page.tsx
@@ -16,6 +16,7 @@ import {
 	getTopStats,
 	type UserTopStatsArgs
 } from '@/app/actions/top-performers';
+import type { ViewedGroup } from '@/lib/group-slug';
 
 function getStatConfigs(
 	date: Date
@@ -186,6 +187,7 @@ export default async function HighlightsPage({
 	viewedGroupId
 }: {
 	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<StatsAccordionModel[]>

--- a/app/(routes)/mistakes/page.tsx
+++ b/app/(routes)/mistakes/page.tsx
@@ -1,6 +1,7 @@
 import { DiscrepenciesResult } from '@/app/models/db';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
+import type { ViewedGroup } from '@/lib/group-slug';
 import {
 	BootstrapPageData,
 	DefaultPageParams
@@ -33,6 +34,7 @@ export default async function MistakesPage({
 	viewedGroupId
 }: {
 	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<DiscrepenciesResult[]>

--- a/app/(routes)/page.tsx
+++ b/app/(routes)/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '../components/shared/DesignSystem';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
+import type { ViewedGroup } from '@/lib/group-slug';
 import type { SessionWithEncountersCount } from '../models/session';
 import type {
 	AggregateStatsResult,
@@ -287,6 +288,7 @@ export default async function Home({
 	viewedGroupId
 }: {
 	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<PageModel>

--- a/app/(routes)/pulli/page.tsx
+++ b/app/(routes)/pulli/page.tsx
@@ -1,6 +1,7 @@
 import { PulliEncounter } from '@/app/models/session';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
+import type { ViewedGroup } from '@/lib/group-slug';
 import {
 	BootstrapPageData,
 	DefaultPageParams
@@ -55,6 +56,7 @@ export default async function PulliPage({
 	viewedGroupId
 }: {
 	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<PulliEncounter[]>

--- a/app/(routes)/resightings/page.tsx
+++ b/app/(routes)/resightings/page.tsx
@@ -2,6 +2,7 @@ import { ResightingEncounter } from '@/app/models/session';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
 import { RESIGHTING_RECORD_TYPES } from '@/lib/demon-import';
+import type { ViewedGroup } from '@/lib/group-slug';
 import {
 	BootstrapPageData,
 	DefaultPageParams
@@ -58,6 +59,7 @@ export default async function ResightingsPage({
 	viewedGroupId
 }: {
 	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<ResightingEncounter[]>

--- a/app/(routes)/retraps/page.tsx
+++ b/app/(routes)/retraps/page.tsx
@@ -1,6 +1,7 @@
 import { NotableRetrapsResult } from '@/app/models/db';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
+import type { ViewedGroup } from '@/lib/group-slug';
 import {
 	BootstrapPageData,
 	DefaultPageParams
@@ -38,6 +39,7 @@ export default async function NotableRetrapsPage({
 	viewedGroupId
 }: {
 	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<NotableRetrapsResult[]>

--- a/app/(routes)/ring-sequences/page.tsx
+++ b/app/(routes)/ring-sequences/page.tsx
@@ -5,6 +5,7 @@ import {
 import { fetchRingSequenceSummaries } from '@/app/actions/ring-sequences';
 import type { RingSequenceSummary } from '@/app/actions/ring-sequences';
 import { RingSequencesPage } from '@/app/components/RingSequencesPage';
+import type { ViewedGroup } from '@/lib/group-slug';
 
 async function dataFetcher(
 	_: DefaultPageParams,
@@ -17,6 +18,7 @@ export default async function RingSequencesRoute({
 	viewedGroupId
 }: {
 	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<RingSequenceSummary[]>

--- a/app/(routes)/sessions/page.tsx
+++ b/app/(routes)/sessions/page.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/app/components/layout/BootstrapPageData';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
+import type { ViewedGroup } from '@/lib/group-slug';
 import type { SessionWithEncountersCount } from '@/app/models/session';
 import {
 	PageWrapper,
@@ -46,6 +47,7 @@ export default async function SessionsPage({
 	viewedGroupId
 }: {
 	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<SessionWithEncountersCount[]>

--- a/app/(routes)/species/[speciesName]/page.tsx
+++ b/app/(routes)/species/[speciesName]/page.tsx
@@ -11,6 +11,7 @@ import type {
 	TopMetricsFilterParams,
 	TopPeriodsResult
 } from '@/app/models/db';
+import type { ViewedGroup } from '@/lib/group-slug';
 export type PageParams = { speciesName: string };
 type PageProps = { params: Promise<PageParams> };
 
@@ -79,7 +80,7 @@ export async function fetchSpPageData(
 }
 
 export default async function SpeciesPage(
-	props: PageProps & { viewedGroupId?: number }
+	props: PageProps & { viewedGroupId?: number; viewedGroup?: ViewedGroup }
 ) {
 	return (
 		<BootstrapPageData<PageData, PageProps, PageParams>

--- a/app/(routes)/species/page.tsx
+++ b/app/(routes)/species/page.tsx
@@ -6,6 +6,7 @@ import { SppStatsTable } from '@/app/components/SppStatsTable';
 import { fetchSpeciesData } from '@/app/actions/spp-data';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
+import type { ViewedGroup } from '@/lib/group-slug';
 import type { AggregateStatsResult } from '@/app/models/db';
 
 //TODO get year/date range from URL params
@@ -47,6 +48,7 @@ export default async function AllSpeciesPage({
 	viewedGroupId
 }: {
 	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<PageData>

--- a/app/(routes)/ticks/page.tsx
+++ b/app/(routes)/ticks/page.tsx
@@ -1,6 +1,7 @@
 import { GroupTicksResult } from '@/app/models/db';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
 import { catchSupabaseErrors } from '@/lib/supabase';
+import type { ViewedGroup } from '@/lib/group-slug';
 import {
 	BootstrapPageData,
 	DefaultPageParams
@@ -46,6 +47,7 @@ export default async function TicksPage({
 	viewedGroupId
 }: {
 	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<GroupTicksResult[]>

--- a/app/group/[groupId]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/__tests__/page.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { redirect } from 'next/navigation';
+import { getGroupCookie } from '@/app/actions/group-cookie';
+import CrossGroupHome from '../page';
+
+const { mockResolveGroupSlugById } = vi.hoisted(() => ({
+	mockResolveGroupSlugById: vi.fn()
+}));
+
+vi.mock('@/lib/group-slug', () => ({
+	resolveGroupSlugById: mockResolveGroupSlugById
+}));
+
+vi.mock('@/app/(routes)/page', () => ({
+	default: vi.fn(() => <div data-testid="mock-home" />)
+}));
+
+import Home from '@/app/(routes)/page';
+
+function renderPage(groupId: string) {
+	return CrossGroupHome({ params: Promise.resolve({ groupId }) });
+}
+
+describe('cross-group home page', () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	describe('viewing a different group than the logged-in one', () => {
+		beforeEach(() => {
+			vi.mocked(getGroupCookie).mockResolvedValue(1);
+			mockResolveGroupSlugById.mockResolvedValue('viewed-group-slug');
+		});
+
+		it('passes viewedGroup matching { id, slug } resolved from resolveGroupSlugById to the underlying route page', async () => {
+			render(await renderPage('2'));
+			screen.getByTestId('mock-home');
+
+			expect(mockResolveGroupSlugById).toHaveBeenCalledWith(2);
+			expect(vi.mocked(Home).mock.calls[0][0]).toEqual(
+				expect.objectContaining({
+					viewedGroupId: 2,
+					viewedGroup: { id: 2, slug: 'viewed-group-slug' }
+				})
+			);
+		});
+	});
+
+	describe('viewedGroupId equals the logged-in group id', () => {
+		beforeEach(() => {
+			vi.mocked(getGroupCookie).mockResolvedValue(1);
+			vi.mocked(redirect).mockImplementationOnce(() => {
+				throw new Error('NEXT_REDIRECT');
+			});
+		});
+
+		it('redirects to "/" without resolving a slug or rendering the route page (regression, unchanged by this ticket)', async () => {
+			await expect(renderPage('1')).rejects.toThrow('NEXT_REDIRECT');
+
+			expect(vi.mocked(redirect)).toHaveBeenCalledWith('/');
+			expect(mockResolveGroupSlugById).not.toHaveBeenCalled();
+			expect(vi.mocked(Home)).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/app/group/[groupId]/effort/page.tsx
+++ b/app/group/[groupId]/effort/page.tsx
@@ -1,3 +1,4 @@
+import { resolveGroupSlugById } from '@/lib/group-slug';
 import PayOffPage from '@/app/(routes)/effort/page';
 
 export default async function CrossGroupEffortPage({
@@ -6,5 +7,10 @@ export default async function CrossGroupEffortPage({
 	params: Promise<{ groupId: string }>;
 }) {
 	const { groupId } = await params;
-	return <PayOffPage viewedGroupId={Number(groupId)} />;
+	const viewedGroupId = Number(groupId);
+	const viewedGroup = {
+		id: viewedGroupId,
+		slug: await resolveGroupSlugById(viewedGroupId)
+	};
+	return <PayOffPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />;
 }

--- a/app/group/[groupId]/mistakes/page.tsx
+++ b/app/group/[groupId]/mistakes/page.tsx
@@ -1,3 +1,4 @@
+import { resolveGroupSlugById } from '@/lib/group-slug';
 import MistakesPage from '@/app/(routes)/mistakes/page';
 
 export default async function CrossGroupMistakesPage({
@@ -6,5 +7,12 @@ export default async function CrossGroupMistakesPage({
 	params: Promise<{ groupId: string }>;
 }) {
 	const { groupId } = await params;
-	return <MistakesPage viewedGroupId={Number(groupId)} />;
+	const viewedGroupId = Number(groupId);
+	const viewedGroup = {
+		id: viewedGroupId,
+		slug: await resolveGroupSlugById(viewedGroupId)
+	};
+	return (
+		<MistakesPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />
+	);
 }

--- a/app/group/[groupId]/page.tsx
+++ b/app/group/[groupId]/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation';
 import { getGroupCookie } from '@/app/actions/group-cookie';
+import { resolveGroupSlugById } from '@/lib/group-slug';
 import Home from '@/app/(routes)/page';
 
 export default async function CrossGroupHome({
@@ -13,5 +14,9 @@ export default async function CrossGroupHome({
 	if (viewedGroupId === loggedInGroupId) {
 		redirect('/');
 	}
-	return <Home viewedGroupId={viewedGroupId} />;
+	const viewedGroup = {
+		id: viewedGroupId,
+		slug: await resolveGroupSlugById(viewedGroupId)
+	};
+	return <Home viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />;
 }

--- a/app/group/[groupId]/pulli/page.tsx
+++ b/app/group/[groupId]/pulli/page.tsx
@@ -1,3 +1,4 @@
+import { resolveGroupSlugById } from '@/lib/group-slug';
 import PulliPage from '@/app/(routes)/pulli/page';
 
 export default async function CrossGroupPulliPage({
@@ -6,5 +7,10 @@ export default async function CrossGroupPulliPage({
 	params: Promise<{ groupId: string }>;
 }) {
 	const { groupId } = await params;
-	return <PulliPage viewedGroupId={Number(groupId)} />;
+	const viewedGroupId = Number(groupId);
+	const viewedGroup = {
+		id: viewedGroupId,
+		slug: await resolveGroupSlugById(viewedGroupId)
+	};
+	return <PulliPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />;
 }

--- a/app/group/[groupId]/resightings/page.tsx
+++ b/app/group/[groupId]/resightings/page.tsx
@@ -1,3 +1,4 @@
+import { resolveGroupSlugById } from '@/lib/group-slug';
 import ResightingsPage from '@/app/(routes)/resightings/page';
 
 export default async function CrossGroupResightingsPage({
@@ -6,5 +7,12 @@ export default async function CrossGroupResightingsPage({
 	params: Promise<{ groupId: string }>;
 }) {
 	const { groupId } = await params;
-	return <ResightingsPage viewedGroupId={Number(groupId)} />;
+	const viewedGroupId = Number(groupId);
+	const viewedGroup = {
+		id: viewedGroupId,
+		slug: await resolveGroupSlugById(viewedGroupId)
+	};
+	return (
+		<ResightingsPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />
+	);
 }

--- a/app/group/[groupId]/retraps/page.tsx
+++ b/app/group/[groupId]/retraps/page.tsx
@@ -1,3 +1,4 @@
+import { resolveGroupSlugById } from '@/lib/group-slug';
 import NotableRetrapsPage from '@/app/(routes)/retraps/page';
 
 export default async function CrossGroupRetrapsPage({
@@ -6,5 +7,15 @@ export default async function CrossGroupRetrapsPage({
 	params: Promise<{ groupId: string }>;
 }) {
 	const { groupId } = await params;
-	return <NotableRetrapsPage viewedGroupId={Number(groupId)} />;
+	const viewedGroupId = Number(groupId);
+	const viewedGroup = {
+		id: viewedGroupId,
+		slug: await resolveGroupSlugById(viewedGroupId)
+	};
+	return (
+		<NotableRetrapsPage
+			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
+		/>
+	);
 }

--- a/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/__tests__/page.test.tsx
@@ -107,20 +107,38 @@ function makeChain(data: unknown) {
 		gt: vi.fn().mockReturnThis(),
 		order: vi.fn().mockReturnThis(),
 		limit: vi.fn().mockReturnThis(),
+		maybeSingle: vi.fn().mockReturnThis(),
 		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
 			Promise.resolve({ data, error: null }).then(resolve)
 	};
 }
 
-function makeSessionClient() {
-	return {
-		from: vi
-			.fn()
-			.mockReturnValueOnce(makeChain(mockSessions))
-			.mockReturnValueOnce(makeChain(mockPreviousSession))
-			.mockReturnValueOnce(makeChain(mockNextSession))
-			.mockReturnValueOnce(makeChain(mockEncounters))
-	};
+// The wrapper page also resolves the group's slug (RingingGroups) — via a
+// module-scope cache in lib/group-slug.ts, so it's only fetched once per
+// group id for the lifetime of this test file, not once per test. Dispatch
+// on table name so RingingGroups is served on demand regardless of whether
+// a given test hits the cache, without disturbing the ordered queue below
+// that the Sessions/Encounters calls are matched against.
+function makeSessionClient(
+	sessionAndEncounterChains: ReturnType<typeof makeChain>[]
+) {
+	let nextChainIndex = 0;
+	const from = vi.fn((table: string) => {
+		if (table === 'RingingGroups') {
+			return makeChain({ slug: 'test-group-slug' });
+		}
+		return sessionAndEncounterChains[nextChainIndex++];
+	});
+	return { from, sessionAndEncounterChains };
+}
+
+function makeDefaultSessionClient() {
+	return makeSessionClient([
+		makeChain(mockSessions),
+		makeChain(mockPreviousSession),
+		makeChain(mockNextSession),
+		makeChain(mockEncounters)
+	]);
 }
 
 function renderPage() {
@@ -135,7 +153,9 @@ describe('session detail page', () => {
 	});
 
 	beforeEach(() => {
-		mockGetAuthenticatedSupabaseClient.mockResolvedValue(makeSessionClient());
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+			makeDefaultSessionClient()
+		);
 	});
 
 	it('renders date as heading', async () => {
@@ -145,11 +165,11 @@ describe('session detail page', () => {
 	});
 
 	it('excludes non-FULL_GROWN sessions from the main Sessions query', async () => {
-		const client = makeSessionClient();
+		const client = makeDefaultSessionClient();
 		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
 		render(await renderPage());
 		await screen.findByTestId('session-stats');
-		const mainSessionsChain = client.from.mock.results[0].value;
+		const mainSessionsChain = client.sessionAndEncounterChains[0];
 		expect(mainSessionsChain.eq).toHaveBeenCalledWith(
 			'session_type',
 			'FULL_GROWN'
@@ -158,11 +178,11 @@ describe('session detail page', () => {
 
 	describe('adjacent session date lookups', () => {
 		it('excludes non-FULL_GROWN sessions from the previous-session lookup', async () => {
-			const client = makeSessionClient();
+			const client = makeDefaultSessionClient();
 			mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
 			render(await renderPage());
 			await screen.findByTestId('session-stats');
-			const previousChain = client.from.mock.results[1].value;
+			const previousChain = client.sessionAndEncounterChains[1];
 			expect(previousChain.eq).toHaveBeenCalledWith(
 				'session_type',
 				'FULL_GROWN'
@@ -170,24 +190,22 @@ describe('session detail page', () => {
 		});
 
 		it('excludes non-FULL_GROWN sessions from the next-session lookup', async () => {
-			const client = makeSessionClient();
+			const client = makeDefaultSessionClient();
 			mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
 			render(await renderPage());
 			await screen.findByTestId('session-stats');
-			const nextChain = client.from.mock.results[2].value;
+			const nextChain = client.sessionAndEncounterChains[2];
 			expect(nextChain.eq).toHaveBeenCalledWith('session_type', 'FULL_GROWN');
 		});
 	});
 
 	describe('a date whose only Sessions row is PULLI or FIELD_OBSERVATION', () => {
 		it('renders the "No session found" empty state instead of 404ing', async () => {
-			const client = {
-				from: vi
-					.fn()
-					.mockReturnValueOnce(makeChain([]))
-					.mockReturnValueOnce(makeChain(mockPreviousSession))
-					.mockReturnValueOnce(makeChain(mockNextSession))
-			};
+			const client = makeSessionClient([
+				makeChain([]),
+				makeChain(mockPreviousSession),
+				makeChain(mockNextSession)
+			]);
 			mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
 			render(await renderPage());
 			await screen.findByText(/No session found/i);

--- a/app/group/[groupId]/session/[date]/page.tsx
+++ b/app/group/[groupId]/session/[date]/page.tsx
@@ -1,4 +1,5 @@
 import { BootstrapPageData } from '@/app/components/layout/BootstrapPageData';
+import { resolveGroupSlugById } from '@/lib/group-slug';
 import {
 	fetchSessionData,
 	SessionSummary,
@@ -14,7 +15,15 @@ export default async function CrossGroupSessionPage({ params }: PageProps) {
 	return (
 		<BootstrapPageData<DayData, PageProps, PageParams>
 			viewedGroupId={viewedGroupId}
-			getParams={async () => ({ viewedGroupId, date, locationId: undefined })}
+			getParams={async () => ({
+				viewedGroupId,
+				date,
+				locationId: undefined,
+				viewedGroup: {
+					id: viewedGroupId,
+					slug: await resolveGroupSlugById(viewedGroupId)
+				}
+			})}
 			getCacheKeys={() => ['session', date]}
 			dataFetcher={fetchSessionData}
 			PageComponent={SessionSummary}

--- a/app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/session/[date]/site/[locationId]/__tests__/page.test.tsx
@@ -61,8 +61,8 @@ const mockEncounters = [
 const mockPreviousSession = [{ visit_date: '2024-03-01' }];
 const mockNextSession = [{ visit_date: '2024-04-01' }];
 
-function makeSessionClient() {
-	const makeChain = (data: unknown) => ({
+function makeChain(data: unknown) {
+	return {
 		select: vi.fn().mockReturnThis(),
 		eq: vi.fn().mockReturnThis(),
 		in: vi.fn().mockReturnThis(),
@@ -70,17 +70,33 @@ function makeSessionClient() {
 		gt: vi.fn().mockReturnThis(),
 		order: vi.fn().mockReturnThis(),
 		limit: vi.fn().mockReturnThis(),
+		maybeSingle: vi.fn().mockReturnThis(),
 		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
 			Promise.resolve({ data, error: null }).then(resolve)
-	});
-	return {
-		from: vi
-			.fn()
-			.mockReturnValueOnce(makeChain(mockSessions))
-			.mockReturnValueOnce(makeChain(mockPreviousSession))
-			.mockReturnValueOnce(makeChain(mockNextSession))
-			.mockReturnValueOnce(makeChain(mockEncounters))
 	};
+}
+
+// The wrapper page also resolves the group's slug (RingingGroups) — via a
+// module-scope cache in lib/group-slug.ts, so it's only fetched once per
+// group id for the lifetime of this test file, not once per test. Dispatch
+// on table name so RingingGroups is served on demand regardless of whether
+// a given test hits the cache, without disturbing the ordered queue below
+// that the Sessions/Encounters calls are matched against.
+function makeSessionClient() {
+	const sessionAndEncounterChains = [
+		makeChain(mockSessions),
+		makeChain(mockPreviousSession),
+		makeChain(mockNextSession),
+		makeChain(mockEncounters)
+	];
+	let nextChainIndex = 0;
+	const from = vi.fn((table: string) => {
+		if (table === 'RingingGroups') {
+			return makeChain({ slug: 'test-group-slug' });
+		}
+		return sessionAndEncounterChains[nextChainIndex++];
+	});
+	return { from, sessionAndEncounterChains };
 }
 
 function renderPage() {
@@ -113,7 +129,7 @@ describe('session site page', () => {
 		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
 		render(await renderPage());
 		await screen.findByTestId('session-stats');
-		const mainSessionsChain = client.from.mock.results[0].value;
+		const mainSessionsChain = client.sessionAndEncounterChains[0];
 		expect(mainSessionsChain.eq).toHaveBeenCalledWith(
 			'session_type',
 			'FULL_GROWN'

--- a/app/group/[groupId]/session/[date]/site/[locationId]/page.tsx
+++ b/app/group/[groupId]/session/[date]/site/[locationId]/page.tsx
@@ -1,4 +1,5 @@
 import { BootstrapPageData } from '@/app/components/layout/BootstrapPageData';
+import { resolveGroupSlugById } from '@/lib/group-slug';
 import {
 	fetchSessionData,
 	SessionSummary,
@@ -19,7 +20,11 @@ export default async function CrossGroupSessionSitePage({ params }: PageProps) {
 			getParams={async () => ({
 				viewedGroupId,
 				date,
-				locationId: Number(locationId)
+				locationId: Number(locationId),
+				viewedGroup: {
+					id: viewedGroupId,
+					slug: await resolveGroupSlugById(viewedGroupId)
+				}
 			})}
 			getCacheKeys={() => ['session', date, `loc-${locationId}`]}
 			dataFetcher={fetchSessionData}

--- a/app/group/[groupId]/session/_shared.tsx
+++ b/app/group/[groupId]/session/_shared.tsx
@@ -18,11 +18,15 @@ import { Fragment } from 'react';
 import { calculateSessionChronology } from '@/app/models/session-chronology';
 import { formatMinutesForDisplay } from '@/lib/postgres-interval';
 import { SessionHighlights } from '@/app/components/SessionHighlights';
+import type { ViewedGroup } from '@/lib/group-slug';
 
 export type PageParams = {
 	viewedGroupId: number;
 	date: string;
 	locationId: number | undefined;
+	// Carried alongside viewedGroupId for the /group wrapper pages below —
+	// unused here (and by SessionSummary) until a later ticket consumes it.
+	viewedGroup?: ViewedGroup;
 };
 
 export type AdjacentSessionDates = {

--- a/app/group/[groupId]/sessions/page.tsx
+++ b/app/group/[groupId]/sessions/page.tsx
@@ -1,3 +1,4 @@
+import { resolveGroupSlugById } from '@/lib/group-slug';
 import SessionsPage from '@/app/(routes)/sessions/page';
 
 export default async function CrossGroupSessionsPage({
@@ -6,5 +7,12 @@ export default async function CrossGroupSessionsPage({
 	params: Promise<{ groupId: string }>;
 }) {
 	const { groupId } = await params;
-	return <SessionsPage viewedGroupId={Number(groupId)} />;
+	const viewedGroupId = Number(groupId);
+	const viewedGroup = {
+		id: viewedGroupId,
+		slug: await resolveGroupSlugById(viewedGroupId)
+	};
+	return (
+		<SessionsPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />
+	);
 }

--- a/app/group/[groupId]/species/[speciesName]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/species/[speciesName]/__tests__/page.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import CrossGroupSingleSpeciesPage from '../page';
+
+const { mockResolveGroupSlugById } = vi.hoisted(() => ({
+	mockResolveGroupSlugById: vi.fn()
+}));
+
+vi.mock('@/lib/group-slug', () => ({
+	resolveGroupSlugById: mockResolveGroupSlugById
+}));
+
+vi.mock('@/app/(routes)/species/[speciesName]/page', () => ({
+	default: vi.fn(() => <div data-testid="mock-species-page" />)
+}));
+
+import SpeciesPage from '@/app/(routes)/species/[speciesName]/page';
+
+describe('cross-group single-species page', () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	beforeEach(() => {
+		mockResolveGroupSlugById.mockResolvedValue('viewed-group-slug');
+	});
+
+	it('passes viewedGroup matching { id, slug } resolved from resolveGroupSlugById to the underlying route page', async () => {
+		render(
+			await CrossGroupSingleSpeciesPage({
+				params: Promise.resolve({ groupId: '2', speciesName: 'Robin' })
+			})
+		);
+		screen.getByTestId('mock-species-page');
+
+		expect(mockResolveGroupSlugById).toHaveBeenCalledWith(2);
+		expect(vi.mocked(SpeciesPage).mock.calls[0][0]).toEqual(
+			expect.objectContaining({
+				viewedGroupId: 2,
+				viewedGroup: { id: 2, slug: 'viewed-group-slug' }
+			})
+		);
+	});
+});

--- a/app/group/[groupId]/species/[speciesName]/page.tsx
+++ b/app/group/[groupId]/species/[speciesName]/page.tsx
@@ -1,13 +1,20 @@
+import { resolveGroupSlugById } from '@/lib/group-slug';
 import SpeciesPage from '@/app/(routes)/species/[speciesName]/page';
 
 export default async function CrossGroupSingleSpeciesPage(props: {
 	params: Promise<{ groupId: string; speciesName: string }>;
 }) {
 	const { groupId, speciesName } = await props.params;
+	const viewedGroupId = Number(groupId);
+	const viewedGroup = {
+		id: viewedGroupId,
+		slug: await resolveGroupSlugById(viewedGroupId)
+	};
 	return (
 		<SpeciesPage
 			params={Promise.resolve({ speciesName })}
-			viewedGroupId={Number(groupId)}
+			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 		/>
 	);
 }

--- a/app/group/[groupId]/species/page.tsx
+++ b/app/group/[groupId]/species/page.tsx
@@ -1,3 +1,4 @@
+import { resolveGroupSlugById } from '@/lib/group-slug';
 import AllSpeciesPage from '@/app/(routes)/species/page';
 
 export default async function CrossGroupSpeciesPage({
@@ -6,5 +7,12 @@ export default async function CrossGroupSpeciesPage({
 	params: Promise<{ groupId: string }>;
 }) {
 	const { groupId } = await params;
-	return <AllSpeciesPage viewedGroupId={Number(groupId)} />;
+	const viewedGroupId = Number(groupId);
+	const viewedGroup = {
+		id: viewedGroupId,
+		slug: await resolveGroupSlugById(viewedGroupId)
+	};
+	return (
+		<AllSpeciesPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />
+	);
 }

--- a/app/group/[groupId]/ticks/page.tsx
+++ b/app/group/[groupId]/ticks/page.tsx
@@ -1,3 +1,4 @@
+import { resolveGroupSlugById } from '@/lib/group-slug';
 import TicksPage from '@/app/(routes)/ticks/page';
 
 export default async function CrossGroupTicksPage({
@@ -6,5 +7,10 @@ export default async function CrossGroupTicksPage({
 	params: Promise<{ groupId: string }>;
 }) {
 	const { groupId } = await params;
-	return <TicksPage viewedGroupId={Number(groupId)} />;
+	const viewedGroupId = Number(groupId);
+	const viewedGroup = {
+		id: viewedGroupId,
+		slug: await resolveGroupSlugById(viewedGroupId)
+	};
+	return <TicksPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />;
 }

--- a/lib/__tests__/group-slug.test.ts
+++ b/lib/__tests__/group-slug.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest';
+
+const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
+	mockGetAuthenticatedSupabaseClient: vi.fn()
+}));
+
+vi.mock('../group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+import { resolveGroupIdBySlug, resolveGroupSlugById } from '../group-slug';
+
+function makeGroupChain(data: unknown) {
+	return {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		maybeSingle: vi.fn().mockReturnThis(),
+		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+			Promise.resolve({ data, error: null }).then(resolve)
+	};
+}
+
+function makeClient(data: unknown) {
+	return { from: vi.fn().mockReturnValue(makeGroupChain(data)) };
+}
+
+// Each test uses its own slug/id, distinct from every other test's — the
+// resolver caches are module-scoped (matching production behaviour where a
+// process caches across requests), so reusing a key across tests would leak
+// a cache hit from one test into another.
+
+describe('resolveGroupIdBySlug', () => {
+	it('resolves a slug matching an existing RingingGroups row to its numeric id', async () => {
+		const client = makeClient({ id: 42 });
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+
+		const result = await resolveGroupIdBySlug('resolves-slug');
+
+		expect(result).toBe(42);
+		expect(client.from).toHaveBeenCalledWith('RingingGroups');
+	});
+
+	it('returns null when no row matches the given slug', async () => {
+		const client = makeClient(null);
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+
+		const result = await resolveGroupIdBySlug('no-match-slug');
+
+		expect(result).toBeNull();
+	});
+
+	it('does not issue a second Supabase query for a second call with the same resolved slug', async () => {
+		const client = makeClient({ id: 43 });
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+
+		await resolveGroupIdBySlug('cache-hit-slug');
+		await resolveGroupIdBySlug('cache-hit-slug');
+
+		expect(client.from).toHaveBeenCalledTimes(1);
+	});
+
+	it('re-queries Supabase for a second call with the same unresolved slug (no negative caching)', async () => {
+		const client = makeClient(null);
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+
+		await resolveGroupIdBySlug('no-negative-cache-slug');
+		await resolveGroupIdBySlug('no-negative-cache-slug');
+
+		expect(client.from).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe('resolveGroupSlugById', () => {
+	it('resolves an id matching an existing row to its slug', async () => {
+		const client = makeClient({ slug: 'resolved-slug' });
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+
+		const result = await resolveGroupSlugById(101);
+
+		expect(result).toBe('resolved-slug');
+		expect(client.from).toHaveBeenCalledWith('RingingGroups');
+	});
+
+	it('returns null when no row matches the id', async () => {
+		const client = makeClient(null);
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+
+		const result = await resolveGroupSlugById(102);
+
+		expect(result).toBeNull();
+	});
+
+	it("returns null when the matching row's slug is null", async () => {
+		const client = makeClient({ slug: null });
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+
+		const result = await resolveGroupSlugById(103);
+
+		expect(result).toBeNull();
+	});
+
+	it('does not issue a second Supabase query for a second call with the same resolved id', async () => {
+		const client = makeClient({ slug: 'cache-hit-by-id' });
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+
+		await resolveGroupSlugById(104);
+		await resolveGroupSlugById(104);
+
+		expect(client.from).toHaveBeenCalledTimes(1);
+	});
+});

--- a/lib/group-slug.ts
+++ b/lib/group-slug.ts
@@ -1,0 +1,60 @@
+import { getAuthenticatedSupabaseClient } from './group-auth';
+import { catchSupabaseErrors } from './supabase';
+
+// A resolved { id, slug } pair for the group whose data is currently being
+// viewed. Carried alongside the existing numeric viewedGroupId through the
+// /group/[groupId]/** wrapper layer and the route pages it calls.
+export type ViewedGroup = { id: number; slug: string | null };
+
+// Module-scope caches, one per resolution direction. Only successful
+// (non-null) resolutions are cached — there's no eviction/TTL here (unlike
+// the JWT client cache), so caching a miss would permanently 404 a group
+// created or backfilled later in the same server process lifetime.
+const groupIdBySlug = new Map<string, number>();
+const groupSlugById = new Map<number, string>();
+
+export async function resolveGroupIdBySlug(
+	slug: string
+): Promise<number | null> {
+	const cached = groupIdBySlug.get(slug);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	const supabase = await getAuthenticatedSupabaseClient();
+	const group = await supabase
+		.from('RingingGroups')
+		.select('id')
+		.eq('slug', slug)
+		.maybeSingle()
+		.then(catchSupabaseErrors);
+
+	if (!group) {
+		return null;
+	}
+
+	groupIdBySlug.set(slug, group.id);
+	return group.id;
+}
+
+export async function resolveGroupSlugById(id: number): Promise<string | null> {
+	const cached = groupSlugById.get(id);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	const supabase = await getAuthenticatedSupabaseClient();
+	const group = await supabase
+		.from('RingingGroups')
+		.select('slug')
+		.eq('id', id)
+		.maybeSingle()
+		.then(catchSupabaseErrors);
+
+	if (!group?.slug) {
+		return null;
+	}
+
+	groupSlugById.set(id, group.slug);
+	return group.slug;
+}


### PR DESCRIPTION
## Summary

Step 1 of the "Group slugs in URLs" effort's re-split (supersedes the scope of #482). This ticket only computes and *carries* a `{ id, slug }` object through the `/group/[groupId]/...` wrapper layer and widens the type of the route pages they call — it does not change any rendering/routing/caching behaviour. Tickets 2 and 3 will consume it.

- Adds `lib/group-slug.ts` (`resolveGroupIdBySlug` / `resolveGroupSlugById`, each backed by a module-scope, cache-only-on-hit `Map`) and `lib/__tests__/group-slug.test.ts`, reused verbatim from the closed PR #482 (branch `feature/475-add-lib-group-slug-ts`). Also exports a shared `ViewedGroup` type (`{ id: number; slug: string | null }`), used by every call site below rather than repeating the inline shape 28 times.
- Updates the 13 files under `app/group/[groupId]/**` (12 `page.tsx` + `session/_shared.tsx`) that parse the numeric `groupId` param and call the corresponding `app/(routes)/*` page: each now computes `const viewedGroup = { id: viewedGroupId, slug: await resolveGroupSlugById(viewedGroupId) }` and passes it as a new, additional `viewedGroup` prop alongside the existing `viewedGroupId`.
- Widens the prop type of the 15 `app/(routes)/*/page.tsx` files these wrappers call to accept an optional `viewedGroup?: ViewedGroup` prop — deliberately not destructured or consumed anywhere yet (TypeScript's excess-property check on JSX requires the type to exist even though nothing reads it).

## Assumptions / notes

- `lib/group-slug.ts` assumed `RingingGroups.slug` already exists in the schema (it does — the DB-migration steps of the "Group slugs" effort landed separately).
- Fixed the two pre-existing session wrapper test suites (`app/group/[groupId]/session/[date]/__tests__/page.test.tsx` and its `site/[locationId]` sibling), whose mocked Supabase clients queued `.from()` responses positionally. The extra `RingingGroups` slug lookup broke that ordering — and, because `resolveGroupSlugById`'s cache is module-scoped, later tests reusing the same group id skip the query entirely, which made simple index-shifting the wrong fix. Reworked the mocks to dispatch on table name instead, so they're robust regardless of whether a given test hits the cache.
- Added two new regression tests per the ticket's enumerated test list: `app/group/[groupId]/__tests__/page.test.tsx` (root wrapper — Usual: `viewedGroup` threading; Edge: own-group redirect regression, unchanged) and `app/group/[groupId]/species/[speciesName]/__tests__/page.test.tsx` (nested route — Usual: `viewedGroup` threading).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (no new warnings; pre-existing unrelated ones only)
- [x] `npx vitest run --config vitest.config.ts` — 734/734 passing (62 files)
- [x] `npm run test:e2e:safe` (pre-push hook, diff-aware) — 91/91 passing

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)