### PR TITLE
BootstrapPageData accepts viewedGroup input prop

### DIFF
--- a/app/(routes)/bird/[ring]/page.tsx
+++ b/app/(routes)/bird/[ring]/page.tsx
@@ -135,6 +135,7 @@ export default async function BirdPage(
 	return (
 		<BootstrapPageData<StandaloneBird, PageProps, PageParams>
 			pageProps={props}
+			viewedGroup={props.viewedGroup}
 			getParams={async (pageProps: PageProps) => ({
 				ring: (await pageProps.params).ring.toUpperCase()
 			})}

--- a/app/(routes)/bird/page.tsx
+++ b/app/(routes)/bird/page.tsx
@@ -35,6 +35,7 @@ export default async function BirdPage(
 	return (
 		<BootstrapPageData<SearchResult[], PageProps, SearchParams>
 			pageProps={props}
+			viewedGroup={props.viewedGroup}
 			getParams={async (pageProps: PageProps) => ({
 				q: (await pageProps.searchParams).q
 			})}

--- a/app/(routes)/controls/page.tsx
+++ b/app/(routes)/controls/page.tsx
@@ -17,14 +17,14 @@ async function dataFetcher(
 }
 
 export default async function ControlsRoute({
-	viewedGroupId
+	viewedGroup
 }: {
 	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<RingSequenceControlRow[]>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getCacheKeys={() => ['controls']}
 			dataFetcher={dataFetcher}
 			PageComponent={ControlsPage}

--- a/app/(routes)/effort/page.tsx
+++ b/app/(routes)/effort/page.tsx
@@ -128,14 +128,14 @@ function PayOffPageContent({
 }
 
 export default function PayOffPage({
-	viewedGroupId
+	viewedGroup
 }: {
 	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<PayOffStatsData>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getCacheKeys={() => ['sessions', 'pay-off']}
 			dataFetcher={fetchPayOffPageData}
 			PageComponent={PayOffPageContent}

--- a/app/(routes)/highlights/page.tsx
+++ b/app/(routes)/highlights/page.tsx
@@ -184,14 +184,14 @@ function HighlightsPageContent({
 }
 
 export default async function HighlightsPage({
-	viewedGroupId
+	viewedGroup
 }: {
 	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<StatsAccordionModel[]>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getCacheKeys={() => ['highlights']}
 			dataFetcher={fetchHighlightsData}
 			PageComponent={HighlightsPageContent}

--- a/app/(routes)/mistakes/page.tsx
+++ b/app/(routes)/mistakes/page.tsx
@@ -31,14 +31,14 @@ function ListMistakes({ data }: { data: DiscrepenciesResult[] }) {
 	);
 }
 export default async function MistakesPage({
-	viewedGroupId
+	viewedGroup
 }: {
 	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<DiscrepenciesResult[]>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getCacheKeys={() => ['mistakes']}
 			dataFetcher={fetchMistakes}
 			PageComponent={ListMistakes}

--- a/app/(routes)/page.tsx
+++ b/app/(routes)/page.tsx
@@ -285,14 +285,14 @@ function HomePageContent({
 }
 
 export default async function Home({
-	viewedGroupId
+	viewedGroup
 }: {
 	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<PageModel>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getCacheKeys={() => ['home-stats']}
 			dataFetcher={fetchHomePageData}
 			PageComponent={HomePageContent}

--- a/app/(routes)/pulli/page.tsx
+++ b/app/(routes)/pulli/page.tsx
@@ -53,14 +53,14 @@ function ListPulliEncounters({ data }: { data: PulliEncounter[] }) {
 }
 
 export default async function PulliPage({
-	viewedGroupId
+	viewedGroup
 }: {
 	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<PulliEncounter[]>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getCacheKeys={() => ['pulli']}
 			dataFetcher={fetchPulliEncounters}
 			PageComponent={ListPulliEncounters}

--- a/app/(routes)/resightings/page.tsx
+++ b/app/(routes)/resightings/page.tsx
@@ -56,14 +56,14 @@ function ListResightings({ data }: { data: ResightingEncounter[] }) {
 }
 
 export default async function ResightingsPage({
-	viewedGroupId
+	viewedGroup
 }: {
 	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<ResightingEncounter[]>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getCacheKeys={() => ['resightings']}
 			dataFetcher={fetchResightings}
 			PageComponent={ListResightings}

--- a/app/(routes)/retraps/page.tsx
+++ b/app/(routes)/retraps/page.tsx
@@ -36,14 +36,14 @@ function ListNotableRetraps({ data }: { data: NotableRetrapsResult[] }) {
 	);
 }
 export default async function NotableRetrapsPage({
-	viewedGroupId
+	viewedGroup
 }: {
 	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<NotableRetrapsResult[]>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getCacheKeys={() => ['notable-retraps']}
 			dataFetcher={fetchNotableRetraps}
 			PageComponent={ListNotableRetraps}

--- a/app/(routes)/ring-sequences/page.tsx
+++ b/app/(routes)/ring-sequences/page.tsx
@@ -15,14 +15,14 @@ async function dataFetcher(
 }
 
 export default async function RingSequencesRoute({
-	viewedGroupId
+	viewedGroup
 }: {
 	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<RingSequenceSummary[]>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getCacheKeys={() => ['ring-sequences']}
 			dataFetcher={dataFetcher}
 			PageComponent={RingSequencesPage}

--- a/app/(routes)/sessions/page.tsx
+++ b/app/(routes)/sessions/page.tsx
@@ -44,14 +44,14 @@ function ListAllSessions({
 }
 
 export default async function SessionsPage({
-	viewedGroupId
+	viewedGroup
 }: {
 	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<SessionWithEncountersCount[]>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getCacheKeys={() => ['sessions']}
 			dataFetcher={fetchAllSessions}
 			PageComponent={ListAllSessions}

--- a/app/(routes)/species/[speciesName]/page.tsx
+++ b/app/(routes)/species/[speciesName]/page.tsx
@@ -85,7 +85,7 @@ export default async function SpeciesPage(
 	return (
 		<BootstrapPageData<PageData, PageProps, PageParams>
 			pageProps={props}
-			viewedGroupId={props.viewedGroupId}
+			viewedGroup={props.viewedGroup}
 			getCacheKeys={(params: PageParams) => ['species', params.speciesName]}
 			dataFetcher={fetchSpPageData}
 			PageComponent={SpPage}

--- a/app/(routes)/species/page.tsx
+++ b/app/(routes)/species/page.tsx
@@ -45,14 +45,14 @@ export async function fetchSppListPageData(
 }
 
 export default async function AllSpeciesPage({
-	viewedGroupId
+	viewedGroup
 }: {
 	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<PageData>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getCacheKeys={() => ['species']}
 			dataFetcher={fetchSppListPageData}
 			PageComponent={SppStatsTable}

--- a/app/(routes)/ticks/page.tsx
+++ b/app/(routes)/ticks/page.tsx
@@ -44,14 +44,14 @@ function ListTicks({ data }: { data: GroupTicksResult[] }) {
 }
 
 export default async function TicksPage({
-	viewedGroupId
+	viewedGroup
 }: {
 	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (
 		<BootstrapPageData<GroupTicksResult[]>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getCacheKeys={() => ['ticks']}
 			dataFetcher={fetchGroupTicks}
 			PageComponent={ListTicks}

--- a/app/components/layout/BootstrapPageData.tsx
+++ b/app/components/layout/BootstrapPageData.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import { notFound } from 'next/navigation';
 import { connection } from 'next/server';
 import { getGroupCookie } from '@/app/actions/group-cookie';
+import { resolveGroupSlugById, type ViewedGroup } from '@/lib/group-slug';
 
 export type DefaultPageParams = Record<string, string>;
 export type DefaultPageProps = { params: Promise<DefaultPageParams> };
@@ -10,7 +11,7 @@ export type BootstrapPageDataProps<DataType, PagePropsType, ParamsType> = {
 	pageProps?: PagePropsType;
 	loading?: React.ReactNode;
 	ttl?: number;
-	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 	getCacheKeys: (params: ParamsType) => string[];
 	getParams?: (pageProps: PagePropsType) => Promise<ParamsType>;
 	dataFetcher: (
@@ -71,7 +72,7 @@ export async function LoadWithData<DataType, PagePropsType, ParamsType>({
 	getCacheKeys,
 	PageComponent,
 	ttl,
-	viewedGroupId: viewedGroupIdProp
+	viewedGroup: viewedGroupProp
 }: BootstrapPageDataProps<DataType, PagePropsType, ParamsType>) {
 	let params: ParamsType;
 	if (getParams) {
@@ -84,7 +85,15 @@ export async function LoadWithData<DataType, PagePropsType, ParamsType>({
 
 	await connection();
 	const loggedInGroupId = await getGroupCookie();
-	const viewedGroupId = viewedGroupIdProp ?? loggedInGroupId;
+	const viewedGroup: ViewedGroup | null =
+		viewedGroupProp ??
+		(loggedInGroupId
+			? {
+					id: loggedInGroupId,
+					slug: await resolveGroupSlugById(loggedInGroupId)
+				}
+			: null);
+	const viewedGroupId = viewedGroup?.id;
 	const cacheKeys = getCacheKeys(params);
 	const groupScopedCacheKeys = viewedGroupId
 		? [String(viewedGroupId), ...cacheKeys]

--- a/app/components/layout/__tests__/BootstrapPageData.test.tsx
+++ b/app/components/layout/__tests__/BootstrapPageData.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { LoadWithData, type DefaultPageParams } from '../BootstrapPageData';
+
+vi.unmock('@/app/components/layout/BootstrapPageData');
+
+vi.mock('next/server', () => ({
+	connection: vi.fn().mockResolvedValue(undefined)
+}));
+
+const { mockGetGroupCookie } = vi.hoisted(() => ({
+	mockGetGroupCookie: vi.fn()
+}));
+
+vi.mock('@/app/actions/group-cookie', () => ({
+	getGroupCookie: mockGetGroupCookie
+}));
+
+const { mockResolveGroupSlugById } = vi.hoisted(() => ({
+	mockResolveGroupSlugById: vi.fn()
+}));
+
+vi.mock('@/lib/group-slug', () => ({
+	resolveGroupSlugById: mockResolveGroupSlugById
+}));
+
+type TestData = { ok: boolean };
+
+function TestPageComponent({
+	viewedGroupId
+}: {
+	params: DefaultPageParams;
+	data: TestData;
+	viewedGroupId: number;
+}) {
+	return <div data-testid="page-content">{viewedGroupId}</div>;
+}
+
+describe('LoadWithData', () => {
+	afterEach(() => {
+		cleanup();
+		vi.clearAllMocks();
+	});
+
+	it('uses an explicitly passed viewedGroup as-is, without triggering cookie-based resolution', async () => {
+		mockGetGroupCookie.mockResolvedValue(1);
+		const dataFetcher = vi.fn().mockResolvedValue({ ok: true } as TestData);
+
+		const element = await LoadWithData<TestData, undefined, DefaultPageParams>({
+			viewedGroup: { id: 42, slug: 'explicit-slug' },
+			getCacheKeys: () => ['key'],
+			dataFetcher,
+			PageComponent: TestPageComponent
+		});
+		render(element);
+
+		expect((await screen.findByTestId('page-content')).textContent).toBe('42');
+		expect(dataFetcher).toHaveBeenCalledWith({}, 42);
+		expect(mockResolveGroupSlugById).not.toHaveBeenCalled();
+	});
+
+	it('derives viewedGroup from the logged-in group cookie when omitted', async () => {
+		mockGetGroupCookie.mockResolvedValue(7);
+		mockResolveGroupSlugById.mockResolvedValue('cookie-slug');
+		const dataFetcher = vi.fn().mockResolvedValue({ ok: true } as TestData);
+
+		const element = await LoadWithData<TestData, undefined, DefaultPageParams>({
+			getCacheKeys: () => ['key'],
+			dataFetcher,
+			PageComponent: TestPageComponent
+		});
+		render(element);
+
+		expect((await screen.findByTestId('page-content')).textContent).toBe('7');
+		expect(mockResolveGroupSlugById).toHaveBeenCalledWith(7);
+		expect(dataFetcher).toHaveBeenCalledWith({}, 7);
+	});
+
+	it('renders the "select a group" fallback when there is no viewedGroup and no logged-in group', async () => {
+		mockGetGroupCookie.mockResolvedValue(null);
+		const dataFetcher = vi.fn();
+
+		const element = await LoadWithData<TestData, undefined, DefaultPageParams>({
+			getCacheKeys: () => ['key'],
+			dataFetcher,
+			PageComponent: TestPageComponent
+		});
+		render(element);
+
+		expect(
+			await screen.findByText('Select a group to view data on this site')
+		).not.toBeNull();
+		expect(dataFetcher).not.toHaveBeenCalled();
+	});
+
+	it('does not crash when the derived slug resolves to null', async () => {
+		mockGetGroupCookie.mockResolvedValue(9);
+		mockResolveGroupSlugById.mockResolvedValue(null);
+		const dataFetcher = vi.fn().mockResolvedValue({ ok: true } as TestData);
+
+		const element = await LoadWithData<TestData, undefined, DefaultPageParams>({
+			getCacheKeys: () => ['key'],
+			dataFetcher,
+			PageComponent: TestPageComponent
+		});
+		render(element);
+
+		expect((await screen.findByTestId('page-content')).textContent).toBe('9');
+		expect(mockResolveGroupSlugById).toHaveBeenCalledWith(9);
+	});
+});

--- a/app/group/[groupId]/session/[date]/page.tsx
+++ b/app/group/[groupId]/session/[date]/page.tsx
@@ -12,17 +12,18 @@ type PageProps = { params: Promise<{ groupId: string; date: string }> };
 export default async function CrossGroupSessionPage({ params }: PageProps) {
 	const { groupId, date } = await params;
 	const viewedGroupId = Number(groupId);
+	const viewedGroup = {
+		id: viewedGroupId,
+		slug: await resolveGroupSlugById(viewedGroupId)
+	};
 	return (
 		<BootstrapPageData<DayData, PageProps, PageParams>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getParams={async () => ({
 				viewedGroupId,
 				date,
 				locationId: undefined,
-				viewedGroup: {
-					id: viewedGroupId,
-					slug: await resolveGroupSlugById(viewedGroupId)
-				}
+				viewedGroup
 			})}
 			getCacheKeys={() => ['session', date]}
 			dataFetcher={fetchSessionData}

--- a/app/group/[groupId]/session/[date]/site/[locationId]/page.tsx
+++ b/app/group/[groupId]/session/[date]/site/[locationId]/page.tsx
@@ -14,17 +14,18 @@ type PageProps = {
 export default async function CrossGroupSessionSitePage({ params }: PageProps) {
 	const { groupId, date, locationId } = await params;
 	const viewedGroupId = Number(groupId);
+	const viewedGroup = {
+		id: viewedGroupId,
+		slug: await resolveGroupSlugById(viewedGroupId)
+	};
 	return (
 		<BootstrapPageData<DayData, PageProps, PageParams>
-			viewedGroupId={viewedGroupId}
+			viewedGroup={viewedGroup}
 			getParams={async () => ({
 				viewedGroupId,
 				date,
 				locationId: Number(locationId),
-				viewedGroup: {
-					id: viewedGroupId,
-					slug: await resolveGroupSlugById(viewedGroupId)
-				}
+				viewedGroup
 			})}
 			getCacheKeys={() => ['session', date, `loc-${locationId}`]}
 			dataFetcher={fetchSessionData}


### PR DESCRIPTION
## Summary

Part of the "Group slugs in URLs" effort (#472), step 2 of 3 — depends on #486
(`lib/group-slug.ts` + the `viewedGroup` object already computed by the `/group`
wrapper layer, merged via #495).

- `app/components/layout/BootstrapPageData.tsx`: `BootstrapPageDataProps`'s input
  changes from `viewedGroupId?: number` to `viewedGroup?: { id: number; slug: string | null }`.
  In `LoadWithData`, when `viewedGroup` isn't passed it's derived from the logged-in
  group cookie: `loggedInGroupId ? { id: loggedInGroupId, slug: await resolveGroupSlugById(loggedInGroupId) } : null`.
  The existing "Select a group to view data on this site" fallback is preserved.
  The internal numeric `viewedGroupId` (used for cache keys and `dataFetcher`) now
  derives from `viewedGroup.id` — `dataFetcher`'s own signature is unchanged.
- `PageComponent`'s prop type stays `viewedGroupId: number` in this ticket — unchanged
  until ticket 3 (#488).
- Updated the 15 `app/(routes)/*/page.tsx` files (from #486) to pass their
  already-accepted `viewedGroup` prop into `<BootstrapPageData>` instead of
  `viewedGroupId`.
- Also updated the two cross-group `/group/[groupId]/session/[date]{,/site/[locationId]}/page.tsx`
  wrapper pages, which call `BootstrapPageData` directly with `viewedGroupId` — these
  needed the same wiring change to keep compiling against the new contract (not one
  of the enumerated 15 files, but a direct consequence of the interface change).
- `app/components/layout/__mocks__/BootstrapPageData.tsx` needed no code change — it
  never destructures `viewedGroupId` on the input side, only inherits the (now updated)
  shared `BootstrapPageDataProps` type; its `viewedGroupId={1}` call into `PageComponent`
  stays as-is (that's ticket 3).

## Out of scope

- `PageComponent`'s own prop shape (ticket 3, #488).
- The `/group` wrapper files' route-page calls still pass both `viewedGroup` and
  `viewedGroupId` into the 15 route pages, per #486 — ticket 3 drops the redundant one.
- Route rename.

## Tests

`app/components/layout/__tests__/BootstrapPageData.test.tsx` (new) — exercises the real
`LoadWithData` (unmocked) via the USE cases from the ticket:
- Usual: explicit `viewedGroup` used as-is, no cookie-based resolution triggered.
- Structure: `viewedGroup` omitted → derives `{ id: loggedInGroupId, slug }` from the
  cookie + `resolveGroupSlugById`.
- Edge: no `viewedGroup` and no logged-in-group cookie → "Select a group" fallback
  (regression).
- Edge: `viewedGroup` omitted, `loggedInGroupId` present but `resolveGroupSlugById`
  resolves `null` → no crash.

`npm run qa` passes (lint, type-check, 738 app tests). Pre-push hook (91 E2E tests) passes.

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)