### PR TITLE
Thread viewedGroup into PageComponents; drop redundant viewedGroupId

### DIFF
--- a/app/(routes)/bird/[ring]/page.tsx
+++ b/app/(routes)/bird/[ring]/page.tsx
@@ -83,11 +83,10 @@ function BirdSummary({
 	data: StandaloneBird;
 	viewedGroup: ViewedGroup;
 }) {
-	const loggedInGroupId = viewedGroup.id;
 	const enrichedBird = bird.encounters.length ? enrichBird(bird) : null;
 	const sharedEncounterCount = enrichedBird
 		? enrichedBird.encounters.filter(
-				(e) => e.ringing_group_id !== loggedInGroupId
+				(e) => e.ringing_group_id !== viewedGroup.id
 			).length
 		: 0;
 	return (

--- a/app/(routes)/bird/[ring]/page.tsx
+++ b/app/(routes)/bird/[ring]/page.tsx
@@ -77,12 +77,13 @@ export async function fetchBirdData(
 function BirdSummary({
 	params: { ring },
 	data: bird,
-	viewedGroupId: loggedInGroupId
+	viewedGroup
 }: {
 	params: PageParams;
 	data: StandaloneBird;
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
+	const loggedInGroupId = viewedGroup.id;
 	const enrichedBird = bird.encounters.length ? enrichBird(bird) : null;
 	const sharedEncounterCount = enrichedBird
 		? enrichedBird.encounters.filter(

--- a/app/(routes)/controls/page.tsx
+++ b/app/(routes)/controls/page.tsx
@@ -19,7 +19,6 @@ async function dataFetcher(
 export default async function ControlsRoute({
 	viewedGroup
 }: {
-	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (

--- a/app/(routes)/effort/page.tsx
+++ b/app/(routes)/effort/page.tsx
@@ -110,7 +110,7 @@ function PayOffPageContent({
 	data
 }: {
 	data: PayOffStatsData;
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
 	return (
 		<PageWrapper>
@@ -130,7 +130,6 @@ function PayOffPageContent({
 export default function PayOffPage({
 	viewedGroup
 }: {
-	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (

--- a/app/(routes)/highlights/page.tsx
+++ b/app/(routes)/highlights/page.tsx
@@ -170,15 +170,15 @@ export async function fetchHighlightsData(
 
 function HighlightsPageContent({
 	data,
-	viewedGroupId
+	viewedGroup
 }: {
 	data: StatsAccordionModel[];
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
 	return (
 		<PageWrapper>
 			<PrimaryHeading>Highlights</PrimaryHeading>
-			<StatsAccordion data={data} viewedGroupId={viewedGroupId} />
+			<StatsAccordion data={data} viewedGroupId={viewedGroup.id} />
 		</PageWrapper>
 	);
 }
@@ -186,7 +186,6 @@ function HighlightsPageContent({
 export default async function HighlightsPage({
 	viewedGroup
 }: {
-	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (

--- a/app/(routes)/mistakes/page.tsx
+++ b/app/(routes)/mistakes/page.tsx
@@ -33,7 +33,6 @@ function ListMistakes({ data }: { data: DiscrepenciesResult[] }) {
 export default async function MistakesPage({
 	viewedGroup
 }: {
-	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (

--- a/app/(routes)/page.tsx
+++ b/app/(routes)/page.tsx
@@ -267,17 +267,17 @@ function TopSpecies({
 }
 function HomePageContent({
 	data,
-	viewedGroupId
+	viewedGroup
 }: {
 	data: PageModel;
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
 	return (
 		<PageWrapper>
 			<SummaryStatsTable data={data.summaryStats} />
 			<RecentSessions
 				data={data.recentSessions}
-				viewedGroupId={viewedGroupId}
+				viewedGroupId={viewedGroup.id}
 			/>
 			<TopSpecies data={data.topSpecies} lastGroupTick={data.lastGroupTick} />
 		</PageWrapper>
@@ -287,7 +287,6 @@ function HomePageContent({
 export default async function Home({
 	viewedGroup
 }: {
-	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (

--- a/app/(routes)/pulli/page.tsx
+++ b/app/(routes)/pulli/page.tsx
@@ -55,7 +55,6 @@ function ListPulliEncounters({ data }: { data: PulliEncounter[] }) {
 export default async function PulliPage({
 	viewedGroup
 }: {
-	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (

--- a/app/(routes)/resightings/page.tsx
+++ b/app/(routes)/resightings/page.tsx
@@ -58,7 +58,6 @@ function ListResightings({ data }: { data: ResightingEncounter[] }) {
 export default async function ResightingsPage({
 	viewedGroup
 }: {
-	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (

--- a/app/(routes)/retraps/page.tsx
+++ b/app/(routes)/retraps/page.tsx
@@ -38,7 +38,6 @@ function ListNotableRetraps({ data }: { data: NotableRetrapsResult[] }) {
 export default async function NotableRetrapsPage({
 	viewedGroup
 }: {
-	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (

--- a/app/(routes)/ring-sequences/page.tsx
+++ b/app/(routes)/ring-sequences/page.tsx
@@ -17,7 +17,6 @@ async function dataFetcher(
 export default async function RingSequencesRoute({
 	viewedGroup
 }: {
-	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (

--- a/app/(routes)/sessions/page.tsx
+++ b/app/(routes)/sessions/page.tsx
@@ -30,15 +30,15 @@ export async function fetchAllSessions(
 
 function ListAllSessions({
 	data,
-	viewedGroupId
+	viewedGroup
 }: {
 	data: SessionWithEncountersCount[];
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
 	return (
 		<PageWrapper>
 			<PrimaryHeading>Session history</PrimaryHeading>
-			<SessionHistoryCalendar sessions={data} viewedGroupId={viewedGroupId} />
+			<SessionHistoryCalendar sessions={data} viewedGroupId={viewedGroup.id} />
 		</PageWrapper>
 	);
 }
@@ -46,7 +46,6 @@ function ListAllSessions({
 export default async function SessionsPage({
 	viewedGroup
 }: {
-	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (

--- a/app/(routes)/species/[speciesName]/page.tsx
+++ b/app/(routes)/species/[speciesName]/page.tsx
@@ -80,7 +80,7 @@ export async function fetchSpPageData(
 }
 
 export default async function SpeciesPage(
-	props: PageProps & { viewedGroupId?: number; viewedGroup?: ViewedGroup }
+	props: PageProps & { viewedGroup?: ViewedGroup }
 ) {
 	return (
 		<BootstrapPageData<PageData, PageProps, PageParams>

--- a/app/(routes)/species/page.tsx
+++ b/app/(routes)/species/page.tsx
@@ -47,7 +47,6 @@ export async function fetchSppListPageData(
 export default async function AllSpeciesPage({
 	viewedGroup
 }: {
-	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (

--- a/app/(routes)/ticks/page.tsx
+++ b/app/(routes)/ticks/page.tsx
@@ -46,7 +46,6 @@ function ListTicks({ data }: { data: GroupTicksResult[] }) {
 export default async function TicksPage({
 	viewedGroup
 }: {
-	viewedGroupId?: number;
 	viewedGroup?: ViewedGroup;
 } = {}) {
 	return (

--- a/app/components/ControlsPage.tsx
+++ b/app/components/ControlsPage.tsx
@@ -1,4 +1,5 @@
 import type { RingSequenceControlRow } from '@/app/actions/ring-sequences';
+import type { ViewedGroup } from '@/lib/group-slug';
 import {
 	InlineTable,
 	PageWrapper,
@@ -11,7 +12,7 @@ export function ControlsPage({
 }: {
 	params: Record<string, string>;
 	data: RingSequenceControlRow[];
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
 	if (!data || data.length === 0) {
 		return (

--- a/app/components/RingSequencesPage.tsx
+++ b/app/components/RingSequencesPage.tsx
@@ -13,6 +13,7 @@ import {
 	SecondaryHeading
 } from './shared/DesignSystem';
 import { RingSequenceDetail } from './RingSequenceDetail';
+import type { ViewedGroup } from '@/lib/group-slug';
 
 type SequenceSummaryModel = {
 	summary: RingSequenceSummary;
@@ -93,11 +94,11 @@ function RingSizeSection({
 
 export function RingSequencesPage({
 	data,
-	viewedGroupId
+	viewedGroup
 }: {
 	params: Record<string, string>;
 	data: RingSequenceSummary[];
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
 	const [expandedId, setExpandedId] = useState<string | false>(false);
 	const ringSizeGroups = groupSummariesByRingSize(data);
@@ -110,7 +111,7 @@ export function RingSequencesPage({
 					<RingSizeSection
 						key={group.name}
 						group={group}
-						viewedGroupId={viewedGroupId}
+						viewedGroupId={viewedGroup.id}
 						expandedId={expandedId}
 						onToggle={setExpandedId}
 					/>

--- a/app/components/SpPage.tsx
+++ b/app/components/SpPage.tsx
@@ -11,6 +11,7 @@ import type {
 	PageData,
 	PageParams
 } from '@/app/(routes)/species/[speciesName]/page';
+import type { ViewedGroup } from '@/lib/group-slug';
 import { SpIndividualsTab } from './SpIndividualsTab';
 import { SpNotableRetrapsTab } from './SpNotableRetrapsTab';
 import { SpStatsHistoryTab } from './SpStatsHistoryTab';
@@ -135,17 +136,17 @@ function fullFatTypeGuard(data: PageData): data is FullFatPageData {
 export function SpPage({
 	params: { speciesName },
 	data,
-	viewedGroupId
+	viewedGroup
 }: {
 	params: PageParams;
 	data: PageData;
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
 	return (
 		<PageWrapper>
 			<PrimaryHeading>{speciesName}</PrimaryHeading>
 			{fullFatTypeGuard(data) ? (
-				<SpeciesData data={data} viewedGroupId={viewedGroupId} />
+				<SpeciesData data={data} viewedGroupId={viewedGroup.id} />
 			) : (
 				<p>Not authorised to view any encounter data for this species</p>
 			)}

--- a/app/components/SppStatsTable.tsx
+++ b/app/components/SppStatsTable.tsx
@@ -3,6 +3,7 @@ import { PageWrapper } from '@/app/components/shared/DesignSystem';
 import { speciesStatConfigs } from '@/app/models/species-stats';
 import type { AggregateStatsResult } from '@/app/models/db';
 import type { PageData } from '@/app/(routes)/species/page';
+import type { ViewedGroup } from '@/lib/group-slug';
 import { useState, useEffect, useRef } from 'react';
 import { fetchSpeciesData } from '@/app/actions/spp-data';
 import {
@@ -49,11 +50,12 @@ const sortableColumnConfigs = speciesStatConfigs.reduce(
 
 export function SppStatsTable({
 	data: { speciesStats: initialSpeciesStats, years },
-	viewedGroupId
+	viewedGroup
 }: {
 	data: PageData;
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
+	const viewedGroupId = viewedGroup.id;
 	const formRef = useRef<HTMLFormElement>(null);
 	const [year, setYear] = useState<number | null>(null);
 	const [cesOnly, setCesOnly] = useState<boolean>(false);

--- a/app/components/__tests__/RingSequencesPage.test.tsx
+++ b/app/components/__tests__/RingSequencesPage.test.tsx
@@ -53,7 +53,7 @@ describe('RingSequencesPage', () => {
 			<RingSequencesPage
 				params={{}}
 				data={mockSummaries}
-				viewedGroupId={viewedGroupId}
+				viewedGroup={{ id: viewedGroupId, slug: 'alpha' }}
 			/>
 		);
 		expect(screen.getByTestId('ring-size-AA')).toBeDefined();
@@ -66,7 +66,7 @@ describe('RingSequencesPage', () => {
 			<RingSequencesPage
 				params={{}}
 				data={mockSummaries}
-				viewedGroupId={viewedGroupId}
+				viewedGroup={{ id: viewedGroupId, slug: 'alpha' }}
 			/>
 		);
 		const aSection = screen.getByTestId('ring-size-A');
@@ -80,7 +80,7 @@ describe('RingSequencesPage', () => {
 			<RingSequencesPage
 				params={{}}
 				data={mockSummaries}
-				viewedGroupId={viewedGroupId}
+				viewedGroup={{ id: viewedGroupId, slug: 'alpha' }}
 			/>
 		);
 		const aaSection = screen.getByTestId('ring-size-AA');
@@ -102,7 +102,7 @@ describe('RingSequencesPage', () => {
 			<RingSequencesPage
 				params={{}}
 				data={mockSummaries}
-				viewedGroupId={viewedGroupId}
+				viewedGroup={{ id: viewedGroupId, slug: 'alpha' }}
 			/>
 		);
 		expect(screen.queryByTestId('ring-size-B, C, C2')).toBeNull();
@@ -114,7 +114,7 @@ describe('RingSequencesPage', () => {
 			<RingSequencesPage
 				params={{}}
 				data={mockSummaries}
-				viewedGroupId={viewedGroupId}
+				viewedGroup={{ id: viewedGroupId, slug: 'alpha' }}
 			/>
 		);
 		const arwItem = screen.getByTestId('sequence-ARW-7');

--- a/app/components/__tests__/SppStatsTable.test.tsx
+++ b/app/components/__tests__/SppStatsTable.test.tsx
@@ -28,7 +28,9 @@ describe('SppStatsTable', () => {
 
 	describe('initial render', () => {
 		it('renders species data rows from initial data', () => {
-			render(<SppStatsTable data={pageData} viewedGroupId={1} />);
+			render(
+				<SppStatsTable data={pageData} viewedGroup={{ id: 1, slug: 'alpha' }} />
+			);
 			const rows = document.querySelectorAll('tbody tr');
 			expect(rows.length).toBe(speciesDataSnapshot.length);
 		});
@@ -36,7 +38,9 @@ describe('SppStatsTable', () => {
 
 	describe('year filter', () => {
 		it('CES only checkbox is disabled when no year selected', () => {
-			render(<SppStatsTable data={pageData} viewedGroupId={1} />);
+			render(
+				<SppStatsTable data={pageData} viewedGroup={{ id: 1, slug: 'alpha' }} />
+			);
 			const cesCheckbox = screen.getByRole('checkbox') as HTMLInputElement;
 			expect(cesCheckbox.disabled).toBe(true);
 		});
@@ -46,7 +50,9 @@ describe('SppStatsTable', () => {
 			vi.mocked(fetchSpeciesData).mockResolvedValue(
 				speciesDataSnapshot as unknown as AggregateStatsResult[]
 			);
-			render(<SppStatsTable data={pageData} viewedGroupId={1} />);
+			render(
+				<SppStatsTable data={pageData} viewedGroup={{ id: 1, slug: 'alpha' }} />
+			);
 			const yearSelect = screen.getByLabelText('select') as HTMLSelectElement;
 			fireEvent.change(yearSelect, { target: { value: '2022' } });
 			const cesCheckbox = screen.getByRole('checkbox') as HTMLInputElement;
@@ -58,7 +64,9 @@ describe('SppStatsTable', () => {
 			vi.mocked(fetchSpeciesData).mockResolvedValue(
 				speciesDataSnapshot as unknown as AggregateStatsResult[]
 			);
-			render(<SppStatsTable data={pageData} viewedGroupId={1} />);
+			render(
+				<SppStatsTable data={pageData} viewedGroup={{ id: 1, slug: 'alpha' }} />
+			);
 			const yearSelect = screen.getByLabelText('select') as HTMLSelectElement;
 			fireEvent.change(yearSelect, { target: { value: '2022' } });
 			await waitFor(() => {

--- a/app/components/layout/BootstrapPageData.tsx
+++ b/app/components/layout/BootstrapPageData.tsx
@@ -21,7 +21,7 @@ export type BootstrapPageDataProps<DataType, PagePropsType, ParamsType> = {
 	PageComponent: (props: {
 		params: ParamsType;
 		data: DataType;
-		viewedGroupId: number;
+		viewedGroup: ViewedGroup;
 	}) => React.ReactNode;
 };
 
@@ -93,28 +93,24 @@ export async function LoadWithData<DataType, PagePropsType, ParamsType>({
 					slug: await resolveGroupSlugById(loggedInGroupId)
 				}
 			: null);
-	const viewedGroupId = viewedGroup?.id;
-	const cacheKeys = getCacheKeys(params);
-	const groupScopedCacheKeys = viewedGroupId
-		? [String(viewedGroupId), ...cacheKeys]
-		: cacheKeys;
-
-	if (!viewedGroupId) {
+	if (!viewedGroup) {
 		// TODO this should trigger a proper authorisation flow
 		return <p>Select a group to view data on this site</p>;
 	}
+	const cacheKeys = getCacheKeys(params);
+	const groupScopedCacheKeys = [String(viewedGroup.id), ...cacheKeys];
 	const data = await fetchDataWithCache<DataType, ParamsType>({
 		params,
 		dataFetcher,
 		cacheKeys: groupScopedCacheKeys,
-		ttl,
-		viewedGroupId
+		viewedGroupId: viewedGroup.id,
+		ttl
 	});
 	if (!data) {
 		notFound();
 	}
 	return (
-		<PageComponent params={params} data={data} viewedGroupId={viewedGroupId} />
+		<PageComponent params={params} data={data} viewedGroup={viewedGroup} />
 	);
 }
 

--- a/app/components/layout/__mocks__/BootstrapPageData.tsx
+++ b/app/components/layout/__mocks__/BootstrapPageData.tsx
@@ -64,7 +64,7 @@ export function BootstrapPageData<
 		<bootstrapProps.PageComponent
 			params={params}
 			data={data}
-			viewedGroupId={1}
+			viewedGroup={{ id: 1, slug: 'alpha' }}
 		/>
 	);
 }

--- a/app/components/layout/__tests__/BootstrapPageData.test.tsx
+++ b/app/components/layout/__tests__/BootstrapPageData.test.tsx
@@ -27,13 +27,13 @@ vi.mock('@/lib/group-slug', () => ({
 type TestData = { ok: boolean };
 
 function TestPageComponent({
-	viewedGroupId
+	viewedGroup
 }: {
 	params: DefaultPageParams;
 	data: TestData;
-	viewedGroupId: number;
+	viewedGroup: { id: number; slug: string | null };
 }) {
-	return <div data-testid="page-content">{viewedGroupId}</div>;
+	return <div data-testid="page-content">{viewedGroup.id}</div>;
 }
 
 describe('LoadWithData', () => {

--- a/app/group/[groupId]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/__tests__/page.test.tsx
@@ -41,7 +41,6 @@ describe('cross-group home page', () => {
 			expect(mockResolveGroupSlugById).toHaveBeenCalledWith(2);
 			expect(vi.mocked(Home).mock.calls[0][0]).toEqual(
 				expect.objectContaining({
-					viewedGroupId: 2,
 					viewedGroup: { id: 2, slug: 'viewed-group-slug' }
 				})
 			);

--- a/app/group/[groupId]/effort/page.tsx
+++ b/app/group/[groupId]/effort/page.tsx
@@ -12,5 +12,5 @@ export default async function CrossGroupEffortPage({
 		id: viewedGroupId,
 		slug: await resolveGroupSlugById(viewedGroupId)
 	};
-	return <PayOffPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />;
+	return <PayOffPage viewedGroup={viewedGroup} />;
 }

--- a/app/group/[groupId]/mistakes/page.tsx
+++ b/app/group/[groupId]/mistakes/page.tsx
@@ -12,7 +12,5 @@ export default async function CrossGroupMistakesPage({
 		id: viewedGroupId,
 		slug: await resolveGroupSlugById(viewedGroupId)
 	};
-	return (
-		<MistakesPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />
-	);
+	return <MistakesPage viewedGroup={viewedGroup} />;
 }

--- a/app/group/[groupId]/page.tsx
+++ b/app/group/[groupId]/page.tsx
@@ -18,5 +18,5 @@ export default async function CrossGroupHome({
 		id: viewedGroupId,
 		slug: await resolveGroupSlugById(viewedGroupId)
 	};
-	return <Home viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />;
+	return <Home viewedGroup={viewedGroup} />;
 }

--- a/app/group/[groupId]/pulli/page.tsx
+++ b/app/group/[groupId]/pulli/page.tsx
@@ -12,5 +12,5 @@ export default async function CrossGroupPulliPage({
 		id: viewedGroupId,
 		slug: await resolveGroupSlugById(viewedGroupId)
 	};
-	return <PulliPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />;
+	return <PulliPage viewedGroup={viewedGroup} />;
 }

--- a/app/group/[groupId]/resightings/page.tsx
+++ b/app/group/[groupId]/resightings/page.tsx
@@ -12,7 +12,5 @@ export default async function CrossGroupResightingsPage({
 		id: viewedGroupId,
 		slug: await resolveGroupSlugById(viewedGroupId)
 	};
-	return (
-		<ResightingsPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />
-	);
+	return <ResightingsPage viewedGroup={viewedGroup} />;
 }

--- a/app/group/[groupId]/retraps/page.tsx
+++ b/app/group/[groupId]/retraps/page.tsx
@@ -12,10 +12,5 @@ export default async function CrossGroupRetrapsPage({
 		id: viewedGroupId,
 		slug: await resolveGroupSlugById(viewedGroupId)
 	};
-	return (
-		<NotableRetrapsPage
-			viewedGroupId={viewedGroupId}
-			viewedGroup={viewedGroup}
-		/>
-	);
+	return <NotableRetrapsPage viewedGroup={viewedGroup} />;
 }

--- a/app/group/[groupId]/sessions/page.tsx
+++ b/app/group/[groupId]/sessions/page.tsx
@@ -12,7 +12,5 @@ export default async function CrossGroupSessionsPage({
 		id: viewedGroupId,
 		slug: await resolveGroupSlugById(viewedGroupId)
 	};
-	return (
-		<SessionsPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />
-	);
+	return <SessionsPage viewedGroup={viewedGroup} />;
 }

--- a/app/group/[groupId]/species/[speciesName]/__tests__/page.test.tsx
+++ b/app/group/[groupId]/species/[speciesName]/__tests__/page.test.tsx
@@ -37,7 +37,6 @@ describe('cross-group single-species page', () => {
 		expect(mockResolveGroupSlugById).toHaveBeenCalledWith(2);
 		expect(vi.mocked(SpeciesPage).mock.calls[0][0]).toEqual(
 			expect.objectContaining({
-				viewedGroupId: 2,
 				viewedGroup: { id: 2, slug: 'viewed-group-slug' }
 			})
 		);

--- a/app/group/[groupId]/species/[speciesName]/page.tsx
+++ b/app/group/[groupId]/species/[speciesName]/page.tsx
@@ -13,7 +13,6 @@ export default async function CrossGroupSingleSpeciesPage(props: {
 	return (
 		<SpeciesPage
 			params={Promise.resolve({ speciesName })}
-			viewedGroupId={viewedGroupId}
 			viewedGroup={viewedGroup}
 		/>
 	);

--- a/app/group/[groupId]/species/page.tsx
+++ b/app/group/[groupId]/species/page.tsx
@@ -12,7 +12,5 @@ export default async function CrossGroupSpeciesPage({
 		id: viewedGroupId,
 		slug: await resolveGroupSlugById(viewedGroupId)
 	};
-	return (
-		<AllSpeciesPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />
-	);
+	return <AllSpeciesPage viewedGroup={viewedGroup} />;
 }

--- a/app/group/[groupId]/ticks/page.tsx
+++ b/app/group/[groupId]/ticks/page.tsx
@@ -12,5 +12,5 @@ export default async function CrossGroupTicksPage({
 		id: viewedGroupId,
 		slug: await resolveGroupSlugById(viewedGroupId)
 	};
-	return <TicksPage viewedGroupId={viewedGroupId} viewedGroup={viewedGroup} />;
+	return <TicksPage viewedGroup={viewedGroup} />;
 }


### PR DESCRIPTION
## What this covers

Step 3 of 3 in the "Group slugs in URLs" effort (#472), building directly on #486 (`lib/group-slug.ts` resolver + `ViewedGroup` type) and #487 (`BootstrapPageData` accepts a `viewedGroup` input prop), both already merged.

This is where `viewedGroupId` disappears from the `PageComponent` boundary and from the `/group` wrapper layer's calls:

- **`BootstrapPageData`**: `PageComponent`'s prop type changes `viewedGroupId: number` → `viewedGroup: ViewedGroup`; `LoadWithData` now narrows on the resolved `viewedGroup` object directly (so the non-null object flows to the render) and passes `viewedGroup={viewedGroup}`. The `__mocks__` copy and its test render with `viewedGroup={{ id: 1, slug: 'alpha' }}`.
- **The 9 `PageComponent` implementations** (`HomePageContent`, `PayOffPageContent`, `ListAllSessions`, `BirdSummary`, `HighlightsPageContent`, `SpPage`, `SppStatsTable`, `ControlsPage`, `RingSequencesPage`) take `viewedGroup: ViewedGroup` and read `viewedGroup.id` where they previously used the plain id. Grandchildren (`SpStats`, `SessionHistoryCalendar`, `RingSizeSection`, …) keep receiving a plain `viewedGroupId: number` — the object shape does not cascade past the boundary.
- **The 10 `/group/[groupId]/**` wrapper files** drop the now-redundant `viewedGroupId={viewedGroupId}` prop, passing only `viewedGroup`.
- **The route-page override prop types** drop `viewedGroupId?: number` entirely — `viewedGroup` is the sole override input.

## Notes / assumptions (subagent mode)

- Used the shared `ViewedGroup` type (from `@/lib/group-slug`) for the new prop rather than re-spelling the inline `{ id: number; slug: string | null }` literal each time — it is exactly that shape, and the route pages already import it (DRY / consistency per CLAUDE.md). Client components import it type-only, so it is erased from the client bundle.
- `SessionSummary` (the session route's `PageComponent`) reads `viewedGroupId` from `params`, not a top-level prop, so it stays assignable to the boundary unchanged and needs no edit — consistent with the ticket excluding it.

## Tests

- `BootstrapPageData` test's `TestPageComponent` consumes `viewedGroup`; the two boundary-component tests (`SppStatsTable`, `RingSequencesPage`) render with `viewedGroup={{ id, slug }}`; the two `/group` wrapper tests drop the stale `viewedGroupId` assertion.
- Full app suite green (738 passing), `type:check` clean, lint 0 errors, E2E safe suite (91) green via the pre-push hook.

Closes #488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)