### PR TITLE
fix: swarm_plan_batch crashed resolving maintenance PR model labels

### DIFF
--- a/.claude/mcp/swarm-tools/tools/__tests__/swarm-plan-batch.test.ts
+++ b/.claude/mcp/swarm-tools/tools/__tests__/swarm-plan-batch.test.ts
@@ -1,4 +1,8 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../../lib/gh', () => ({ ghJson: vi.fn() }));
+
+import { ghJson } from '../../lib/gh';
 import {
 	getExclusiveLabel,
 	getModelLabel,
@@ -7,6 +11,7 @@ import {
 	rankMaintenanceCandidates,
 	rankTicketCandidates,
 	allocateBudget,
+	resolveMaintenanceCandidateModel,
 	type MaintenanceCandidate,
 	type TicketCandidate,
 } from '../swarm-plan-batch';
@@ -35,6 +40,68 @@ describe('getModelLabel', () => {
 
 	it('returns null when no model label is present', () => {
 		expect(getModelLabel(['ready'])).toBeNull();
+	});
+});
+
+describe('resolveMaintenanceCandidateModel', () => {
+	const mockGhJson = vi.mocked(ghJson);
+
+	afterEach(() => {
+		mockGhJson.mockReset();
+	});
+
+	// Usual — regression test for the real crash on PR #498: `gh pr view --json
+	// closingIssuesReferences` returns linked-issue objects WITHOUT a `labels` field (only
+	// id/number/repository/url), so the model must come from a separate `gh issue view` call.
+	it('resolves the model label via a separate issue lookup, matching gh\'s actual label-less closingIssuesReferences shape', async () => {
+		mockGhJson
+			.mockResolvedValueOnce({ closingIssuesReferences: [{ number: 488 }] })
+			.mockResolvedValueOnce({ labels: [{ name: 'opus' }] });
+
+		const model = await resolveMaintenanceCandidateModel(498);
+
+		expect(model).toBe('opus');
+		expect(mockGhJson).toHaveBeenNthCalledWith(1, ['pr', 'view', '498', '--json', 'closingIssuesReferences']);
+		expect(mockGhJson).toHaveBeenNthCalledWith(2, ['issue', 'view', '488', '--json', 'labels']);
+	});
+
+	// Structure
+	it('returns null without a second call when the PR has no linked issue', async () => {
+		mockGhJson.mockResolvedValueOnce({ closingIssuesReferences: [] });
+
+		const model = await resolveMaintenanceCandidateModel(499);
+
+		expect(model).toBeNull();
+		expect(mockGhJson).toHaveBeenCalledTimes(1);
+	});
+
+	it('returns null when the linked issue has no model label', async () => {
+		mockGhJson
+			.mockResolvedValueOnce({ closingIssuesReferences: [{ number: 1 }] })
+			.mockResolvedValueOnce({ labels: [{ name: 'ready' }] });
+
+		const model = await resolveMaintenanceCandidateModel(1);
+
+		expect(model).toBeNull();
+	});
+
+	// Edge
+	it('returns null when the closingIssuesReferences lookup itself fails', async () => {
+		mockGhJson.mockRejectedValueOnce(new Error('gh error'));
+
+		const model = await resolveMaintenanceCandidateModel(2);
+
+		expect(model).toBeNull();
+	});
+
+	it('returns null when the issue-view lookup fails', async () => {
+		mockGhJson
+			.mockResolvedValueOnce({ closingIssuesReferences: [{ number: 3 }] })
+			.mockRejectedValueOnce(new Error('gh error'));
+
+		const model = await resolveMaintenanceCandidateModel(3);
+
+		expect(model).toBeNull();
 	});
 });
 

--- a/.claude/mcp/swarm-tools/tools/swarm-plan-batch.ts
+++ b/.claude/mcp/swarm-tools/tools/swarm-plan-batch.ts
@@ -242,6 +242,28 @@ async function findTicketCandidates(runningIssueNumbers: Set<number>): Promise<T
 	return candidates;
 }
 
+/**
+ * Resolves a maintenance PR's model label via its linked issue. `gh pr view --json
+ * closingIssuesReferences` does not return `labels` on the linked-issue objects (only
+ * `id`/`number`/`repository`/`url`), so this needs a second `gh issue view --json labels`
+ * call keyed off the issue number — mirroring isSoloRunCurrentlyActive's two-call pattern
+ * below, rather than assuming labels ride along on the first response.
+ */
+export async function resolveMaintenanceCandidateModel(prNumber: number): Promise<ModelLabel | null> {
+	const closing = await ghJson<{ closingIssuesReferences?: { number: number }[] }>([
+		'pr',
+		'view',
+		String(prNumber),
+		'--json',
+		'closingIssuesReferences',
+	]).catch(() => ({ closingIssuesReferences: [] }));
+	const linkedIssueNumber = closing.closingIssuesReferences?.[0]?.number;
+	if (linkedIssueNumber === undefined) return null;
+	return ghJson<{ labels: { name: string }[] }>(['issue', 'view', String(linkedIssueNumber), '--json', 'labels'])
+		.then((result) => getModelLabel(result.labels.map((l) => l.name)))
+		.catch(() => null);
+}
+
 async function isSoloRunCurrentlyActive(): Promise<ExclusiveLabel | null> {
 	const running = await listState();
 	for (const entry of running) {
@@ -314,11 +336,7 @@ export function registerSwarmPlanBatchTool(server: McpServer) {
 
 			const prsNeedingMaintenance = await Promise.all(
 				allocation.maintenance.map(async (pr) => {
-					const closing = await ghJson<{ closingIssuesReferences?: { number: number; labels: { name: string }[] }[] }>(
-						['pr', 'view', String(pr.number), '--json', 'closingIssuesReferences']
-					).catch(() => ({ closingIssuesReferences: [] }));
-					const linkedIssue = closing.closingIssuesReferences?.[0];
-					const model = linkedIssue ? getModelLabel(linkedIssue.labels.map((l) => l.name)) : null;
+					const model = await resolveMaintenanceCandidateModel(pr.number);
 					return { ...pr, model: model ?? 'sonnet', blockedBySoloRun: false };
 				})
 			);


### PR DESCRIPTION
## Summary
- `swarm_plan_batch`'s maintenance-model resolution crashed with `Cannot read properties of undefined (reading 'map')` on every real PR needing maintenance. Hit live this session on PR #498 (feedback-linked to issue #488, labelled `opus` — the tool should have resolved `model: 'opus'` but crashed instead).
- Root cause: `gh pr view --json closingIssuesReferences` returns linked-issue objects containing only `id`/`number`/`repository`/`url` — **not** `labels`, despite the code's `labels: { name: string }[]` type claiming otherwise. That type was aspirational and never actually populated, so `linkedIssue.labels.map(...)` threw on `undefined`.
- Verified directly against this repo's actual `gh` output (`gh pr view <n> --json closingIssuesReferences` on PRs #498/#499/#481) — confirms no `labels` field is ever present.

## Fix
- Extracted the model resolution into `resolveMaintenanceCandidateModel(prNumber)`, which fetches `closingIssuesReferences` for the number only, then makes a **second** `gh issue view --json labels` call keyed off the linked issue's number — mirroring the existing `isSoloRunCurrentlyActive` two-call pattern already in this file.
- Replaced the inline (buggy) resolution in `registerSwarmPlanBatchTool`'s handler with a call to the new function.

## Tests
- The existing test suite's mock never included a `labels` field on the linked-issue object either (so it never exercised the crash path) — added `resolveMaintenanceCandidateModel` regression tests that mock `ghJson` with gh's *actual* label-less `closingIssuesReferences` shape and a separate `gh issue view` call for labels, asserting the tool resolves the model correctly through two calls rather than crashing or silently dropping the label. Also covers: no linked issue, linked issue without a model label, and both gh calls failing.
- `npm run test:ci` (full app suite): 63 files / 743 tests passing.
- `npx tsc --noEmit`: clean.
- `npx eslint`: clean (0 errors; pre-existing unrelated warnings only).
- Pre-push hook: full app tests + E2E safe suite (91 tests) passed.

No linked issue — this is a live-bug fix caught mid-session, not tied to a tracked ticket.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>