### PR TITLE
Cascade viewedGroup into the href-adjacent component tree (no behaviour change)

### DIFF
--- a/app/(routes)/highlights/page.tsx
+++ b/app/(routes)/highlights/page.tsx
@@ -178,7 +178,7 @@ function HighlightsPageContent({
 	return (
 		<PageWrapper>
 			<PrimaryHeading>Highlights</PrimaryHeading>
-			<StatsAccordion data={data} viewedGroupId={viewedGroup.id} />
+			<StatsAccordion data={data} viewedGroup={viewedGroup} />
 		</PageWrapper>
 	);
 }

--- a/app/(routes)/page.tsx
+++ b/app/(routes)/page.tsx
@@ -133,10 +133,10 @@ export async function fetchHomePageData(
 
 function RecentSessions({
 	data,
-	viewedGroupId
+	viewedGroup
 }: {
 	data: SessionWithEncountersCount[];
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
 	return (
 		<div>
@@ -152,7 +152,7 @@ function RecentSessions({
 			<BoxyList>
 				<SessionsByDay
 					sessions={data}
-					viewedGroupId={viewedGroupId}
+					viewedGroup={viewedGroup}
 					dateFormat="EEEE do MMMM"
 				/>
 			</BoxyList>
@@ -275,10 +275,7 @@ function HomePageContent({
 	return (
 		<PageWrapper>
 			<SummaryStatsTable data={data.summaryStats} />
-			<RecentSessions
-				data={data.recentSessions}
-				viewedGroupId={viewedGroup.id}
-			/>
+			<RecentSessions data={data.recentSessions} viewedGroup={viewedGroup} />
 			<TopSpecies data={data.topSpecies} lastGroupTick={data.lastGroupTick} />
 		</PageWrapper>
 	);

--- a/app/(routes)/sessions/page.tsx
+++ b/app/(routes)/sessions/page.tsx
@@ -38,7 +38,7 @@ function ListAllSessions({
 	return (
 		<PageWrapper>
 			<PrimaryHeading>Session history</PrimaryHeading>
-			<SessionHistoryCalendar sessions={data} viewedGroupId={viewedGroup.id} />
+			<SessionHistoryCalendar sessions={data} viewedGroup={viewedGroup} />
 		</PageWrapper>
 	);
 }

--- a/app/components/MonthSessions.tsx
+++ b/app/components/MonthSessions.tsx
@@ -2,6 +2,7 @@
 import { type SessionWithEncountersCount } from '@/app/models/session';
 import { format as formatDate } from 'date-fns';
 import { SessionsByDay } from './SessionHistoryCalendar';
+import type { ViewedGroup } from '@/lib/group-slug';
 
 export function MonthSessionsHeading({
 	model: { monthData: month }
@@ -23,16 +24,16 @@ export function MonthSessionsHeading({
 }
 
 export function MonthSessionsContent({
-	model: { viewedGroupId, monthData: month }
+	model: { viewedGroup, monthData: month }
 }: {
-	model: { viewedGroupId: number; monthData: SessionWithEncountersCount[] };
+	model: { viewedGroup: ViewedGroup; monthData: SessionWithEncountersCount[] };
 }) {
 	return (
 		<ol className="list-inside list-none py-3">
 			<SessionsByDay
 				sessions={month}
 				wrapperClasses="mb-2"
-				viewedGroupId={viewedGroupId}
+				viewedGroup={viewedGroup}
 				dateFormat="EEEE do"
 			/>
 		</ol>

--- a/app/components/SessionHistoryCalendar.tsx
+++ b/app/components/SessionHistoryCalendar.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect } from 'react';
 import { StatOutput } from './shared/StatOutput';
 import { NoPrefetchLink } from './shared/NoPrefetchLink';
 import { YearSessions } from './YearSessions';
+import type { ViewedGroup } from '@/lib/group-slug';
 
 function groupByDateMethod(methodName: 'getFullYear' | 'getMonth') {
 	return function (
@@ -38,12 +39,12 @@ const groupByMonth = groupByDateMethod('getMonth');
 export function SessionsByDay({
 	sessions,
 	wrapperClasses = '',
-	viewedGroupId,
+	viewedGroup,
 	dateFormat
 }: {
 	sessions: SessionWithEncountersCount[];
 	wrapperClasses?: string;
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 	dateFormat: string;
 }) {
 	const sessionsByDate: Record<string, SessionWithEncountersCount[]> = {};
@@ -66,7 +67,7 @@ export function SessionsByDay({
 							showUnit={true}
 							temporalUnit="day"
 							dateFormat={dateFormat}
-							viewedGroupId={viewedGroupId}
+							viewedGroup={viewedGroup}
 						/>
 					) : (
 						<>
@@ -81,7 +82,7 @@ export function SessionsByDay({
 								showUnit={true}
 								temporalUnit="day"
 								dateFormat={dateFormat}
-								viewedGroupId={viewedGroupId}
+								viewedGroup={viewedGroup}
 							/>{' '}
 							at{' '}
 							{daySessions.map((session, index) => (
@@ -89,7 +90,7 @@ export function SessionsByDay({
 									{index > 0 ? ', ' : null}
 									<NoPrefetchLink
 										className="link"
-										href={`/group/${viewedGroupId}/session/${session.visit_date}/site/${session.location.id}`}
+										href={`/group/${viewedGroup.id}/session/${session.visit_date}/site/${session.location.id}`}
 									>
 										{printLocationName(session.location.location_name)}
 									</NoPrefetchLink>
@@ -109,10 +110,10 @@ function getYearString(year: SessionWithEncountersCount[][]) {
 
 export function SessionHistoryCalendar({
 	sessions,
-	viewedGroupId
+	viewedGroup
 }: {
 	sessions: SessionWithEncountersCount[] | null;
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
 	const calendar = groupByYear(sessions || []).map(groupByMonth);
 	const thisYearString = calendar[0] ? getYearString(calendar[0]) : false;
@@ -137,7 +138,7 @@ export function SessionHistoryCalendar({
 						key={yearString}
 						year={year}
 						yearString={yearString}
-						viewedGroupId={viewedGroupId}
+						viewedGroup={viewedGroup}
 						expandedYear={expandedYear}
 						onToggle={setExpandedYear}
 					/>

--- a/app/components/SpPage.tsx
+++ b/app/components/SpPage.tsx
@@ -44,10 +44,10 @@ function ConditionalTabPanel({
 
 function SpeciesData({
 	data,
-	viewedGroupId
+	viewedGroup
 }: {
 	data: FullFatPageData;
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
 	const [loadedTabs, setLoadedTabs] = useState<Set<string>>(
 		new Set(['bird-list'])
@@ -61,7 +61,7 @@ function SpeciesData({
 
 	return (
 		<>
-			<SpStats {...data} viewedGroupId={viewedGroupId} />
+			<SpStats {...data} viewedGroup={viewedGroup} />
 			<TabNav
 				tabs={[
 					{ id: 'bird-list', label: 'Bird list' },
@@ -80,7 +80,7 @@ function SpeciesData({
 			>
 				<SpIndividualsTab
 					speciesId={data.speciesId}
-					viewedGroupId={viewedGroupId}
+					viewedGroupId={viewedGroup.id}
 					birds={data.birds}
 					birdCount={data.speciesStats.bird_count ?? 0}
 				/>
@@ -92,7 +92,7 @@ function SpeciesData({
 			>
 				<SpNotableRetrapsTab
 					speciesName={data.speciesName}
-					viewedGroupId={viewedGroupId}
+					viewedGroupId={viewedGroup.id}
 				/>
 			</ConditionalTabPanel>
 			<ConditionalTabPanel
@@ -102,7 +102,7 @@ function SpeciesData({
 			>
 				<SpStatsHistoryTab
 					speciesName={data.speciesName}
-					viewedGroupId={viewedGroupId}
+					viewedGroupId={viewedGroup.id}
 				/>
 			</ConditionalTabPanel>
 			<ConditionalTabPanel
@@ -112,7 +112,7 @@ function SpeciesData({
 			>
 				<SpYearComparisonTab
 					speciesName={data.speciesName}
-					viewedGroupId={viewedGroupId}
+					viewedGroupId={viewedGroup.id}
 				/>
 			</ConditionalTabPanel>
 			<ConditionalTabPanel
@@ -122,7 +122,7 @@ function SpeciesData({
 			>
 				<SpWeightWingTab
 					speciesId={data.speciesId}
-					viewedGroupId={viewedGroupId}
+					viewedGroupId={viewedGroup.id}
 				/>
 			</ConditionalTabPanel>
 		</>
@@ -146,7 +146,7 @@ export function SpPage({
 		<PageWrapper>
 			<PrimaryHeading>{speciesName}</PrimaryHeading>
 			{fullFatTypeGuard(data) ? (
-				<SpeciesData data={data} viewedGroupId={viewedGroup.id} />
+				<SpeciesData data={data} viewedGroup={viewedGroup} />
 			) : (
 				<p>Not authorised to view any encounter data for this species</p>
 			)}

--- a/app/components/SpStats.tsx
+++ b/app/components/SpStats.tsx
@@ -5,6 +5,7 @@ import { UnwrappedBadgeList } from './shared/DesignSystem';
 import type { AggregateStatsResult } from '@/app/models/db';
 import type { SpeciesStatConfig } from '@/app/models/species-stats';
 import { speciesStatConfigs } from '@/app/models/species-stats';
+import type { ViewedGroup } from '@/lib/group-slug';
 
 const categoryOrder: string[] = [];
 const statsByCategory: Record<string, SpeciesStatConfig[]> =
@@ -99,8 +100,8 @@ export function SpStats({
 	topSessions,
 	birds,
 	speciesStats,
-	viewedGroupId
-}: FullFatPageData & { viewedGroupId: number }) {
+	viewedGroup
+}: FullFatPageData & { viewedGroup: ViewedGroup }) {
 	if (!speciesStats) return null;
 	// const NotableRetrapsBirds =
 	// 	speciesStats.max_encountered_bird && speciesStats.max_encountered_bird > 1
@@ -164,7 +165,7 @@ export function SpStats({
 						temporalUnit="day"
 						classes="badge badge-outline"
 						dateFormat="d MMM yyyy"
-						viewedGroupId={viewedGroupId}
+						viewedGroup={viewedGroup}
 					/>
 				))}
 			</li>

--- a/app/components/StatsAccordion.tsx
+++ b/app/components/StatsAccordion.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { SecondaryHeading, BoxyList } from './shared/DesignSystem';
 import type { TopPeriodsResult, TopSpeciesResult } from '@/app/models/db';
 import type { UserTopStatsArgs } from '@/app/actions/top-performers';
+import type { ViewedGroup } from '@/lib/group-slug';
 import { StatsAccordionItem } from './StatsAccordionItem';
 
 export type StatConfig = {
@@ -25,15 +26,15 @@ export type StatsAccordionModel = {
 
 export function StatsAccordion({
 	data,
-	viewedGroupId
+	viewedGroup
 }: {
 	data: StatsAccordionModel[];
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 }) {
 	const [expanded, setExpanded] = useState<string | false>(false);
 	useEffect(() => {
 		setExpanded(false);
-	}, [viewedGroupId]);
+	}, [viewedGroup.id]);
 	return (
 		<>
 			{data.map(({ heading, stats }) => (
@@ -42,9 +43,9 @@ export function StatsAccordion({
 					<BoxyList>
 						{stats.map((item) => (
 							<StatsAccordionItem
-								key={`${viewedGroupId}-${item.definition.id}`}
+								key={`${viewedGroup.id}-${item.definition.id}`}
 								item={item}
-								viewedGroupId={viewedGroupId}
+								viewedGroup={viewedGroup}
 								expanded={expanded}
 								onToggle={setExpanded}
 							/>

--- a/app/components/StatsAccordionItem.tsx
+++ b/app/components/StatsAccordionItem.tsx
@@ -6,9 +6,10 @@ import type { TopPeriodsResult, TopSpeciesResult } from '@/app/models/db';
 import { getTopStats } from '@/app/actions/top-performers';
 import type { TemporalUnit } from './shared/StatOutput';
 import type { AccordionItemModel } from './StatsAccordion';
+import type { ViewedGroup } from '@/lib/group-slug';
 
 type AccordionItemModelWithGroupId = AccordionItemModel & {
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 };
 
 function hasData(data: TopPeriodsResult[] | null): data is TopPeriodsResult[] {
@@ -40,7 +41,7 @@ function ItemContent({
 					...model.definition.dataArguments,
 					filters: {
 						...(model.definition.dataArguments.filters ?? {}),
-						ringing_group_filter: model.viewedGroupId
+						ringing_group_filter: model.viewedGroup.id
 					},
 					result_limit: 5
 				})
@@ -64,7 +65,7 @@ function ItemContent({
 		model.definition.id,
 		model.definition.bySpecies,
 		model.definition.dataArguments,
-		model.viewedGroupId
+		model.viewedGroup.id
 	]);
 
 	return hasData(data) ? (
@@ -83,7 +84,7 @@ function ItemContent({
 						temporalUnit={
 							model.definition.dataArguments.temporal_unit as TemporalUnit
 						}
-						viewedGroupId={model.viewedGroupId}
+						viewedGroup={model.viewedGroup}
 					/>
 				</li>
 			))}
@@ -113,22 +114,22 @@ function ItemHeading({ model }: { model: AccordionItemModelWithGroupId }) {
 
 export function StatsAccordionItem({
 	item,
-	viewedGroupId,
+	viewedGroup,
 	expanded,
 	onToggle
 }: {
 	item: AccordionItemModel;
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 	expanded: string | false;
 	onToggle: (id: string | false) => void;
 }) {
 	return (
 		<AccordionItem
-			key={`${viewedGroupId}-${item.definition.id}`}
+			key={`${viewedGroup.id}-${item.definition.id}`}
 			id={item.definition.id}
 			HeadingComponent={ItemHeading}
 			ContentComponent={ItemContent}
-			model={{ ...item, viewedGroupId }}
+			model={{ ...item, viewedGroup }}
 			onToggle={onToggle}
 			expandedId={expanded}
 		/>

--- a/app/components/YearSessions.tsx
+++ b/app/components/YearSessions.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/app/components/shared/DesignSystem';
 import { format as formatDate } from 'date-fns';
 import { MonthSessionsHeading, MonthSessionsContent } from './MonthSessions';
+import type { ViewedGroup } from '@/lib/group-slug';
 
 function YearHeading({
 	model: { yearString }
@@ -18,13 +19,13 @@ function YearHeading({
 }
 
 function YearContent({
-	model: { yearData, expandedMonth, setExpandedMonth, viewedGroupId }
+	model: { yearData, expandedMonth, setExpandedMonth, viewedGroup }
 }: {
 	model: {
 		yearData: SessionWithEncountersCount[][];
 		expandedMonth: string | false;
 		setExpandedMonth: (month: string | false) => void;
-		viewedGroupId: number;
+		viewedGroup: ViewedGroup;
 	};
 }) {
 	return (
@@ -38,7 +39,7 @@ function YearContent({
 							id={id}
 							HeadingComponent={MonthSessionsHeading}
 							ContentComponent={MonthSessionsContent}
-							model={{ monthData: month, viewedGroupId }}
+							model={{ monthData: month, viewedGroup }}
 							onToggle={setExpandedMonth}
 							expandedId={expandedMonth}
 							icon="calendar-week"
@@ -53,13 +54,13 @@ function YearContent({
 export function YearSessions({
 	year,
 	yearString,
-	viewedGroupId,
+	viewedGroup,
 	expandedYear,
 	onToggle
 }: {
 	year: SessionWithEncountersCount[][];
 	yearString: string;
-	viewedGroupId: number;
+	viewedGroup: ViewedGroup;
 	expandedYear: string | false;
 	onToggle: (id: string | false) => void;
 }) {
@@ -82,7 +83,7 @@ export function YearSessions({
 				yearData: year,
 				expandedMonth,
 				setExpandedMonth,
-				viewedGroupId
+				viewedGroup
 			}}
 			onToggle={onToggle}
 			expandedId={expandedYear}

--- a/app/components/__tests__/SpStats.test.tsx
+++ b/app/components/__tests__/SpStats.test.tsx
@@ -21,7 +21,7 @@ describe('SpStats', () => {
 					speciesStats={speciesStats}
 					speciesId={1}
 					speciesName="Robin"
-					viewedGroupId={1}
+					viewedGroup={{ id: 1, slug: 'alpha' }}
 				/>
 			);
 			expect(
@@ -39,7 +39,7 @@ describe('SpStats', () => {
 					speciesStats={speciesStats}
 					speciesId={1}
 					speciesName="Robin"
-					viewedGroupId={1}
+					viewedGroup={{ id: 1, slug: 'alpha' }}
 				/>
 			);
 			expect(

--- a/app/components/__tests__/StatsAccordionItem.test.tsx
+++ b/app/components/__tests__/StatsAccordionItem.test.tsx
@@ -55,7 +55,7 @@ describe('StatsAccordionItem', () => {
 		render(
 			<StatsAccordionItem
 				item={mockItemModel}
-				viewedGroupId={1}
+				viewedGroup={{ id: 1, slug: 'alpha' }}
 				expanded={false}
 				onToggle={mockOnToggle}
 			/>
@@ -69,7 +69,7 @@ describe('StatsAccordionItem', () => {
 			render(
 				<StatsAccordionItem
 					item={mockItemModel}
-					viewedGroupId={1}
+					viewedGroup={{ id: 1, slug: 'alpha' }}
 					expanded={false}
 					onToggle={mockOnToggle}
 				/>
@@ -84,7 +84,7 @@ describe('StatsAccordionItem', () => {
 			render(
 				<StatsAccordionItem
 					item={emptyItem}
-					viewedGroupId={1}
+					viewedGroup={{ id: 1, slug: 'alpha' }}
 					expanded={false}
 					onToggle={mockOnToggle}
 				/>
@@ -105,7 +105,7 @@ describe('StatsAccordionItem', () => {
 			render(
 				<StatsAccordionItem
 					item={itemWithNoData}
-					viewedGroupId={1}
+					viewedGroup={{ id: 1, slug: 'alpha' }}
 					expanded="test-metric"
 					onToggle={mockOnToggle}
 				/>

--- a/app/components/__tests__/YearSessions.test.tsx
+++ b/app/components/__tests__/YearSessions.test.tsx
@@ -28,7 +28,7 @@ describe('YearSessions', () => {
 			<YearSessions
 				year={yearData}
 				yearString="2022"
-				viewedGroupId={1}
+				viewedGroup={{ id: 1, slug: 'alpha' }}
 				expandedYear={false}
 				onToggle={mockOnToggle}
 			/>
@@ -42,7 +42,7 @@ describe('YearSessions', () => {
 			<YearSessions
 				year={yearData}
 				yearString="2022"
-				viewedGroupId={1}
+				viewedGroup={{ id: 1, slug: 'alpha' }}
 				expandedYear={false}
 				onToggle={mockOnToggle}
 			/>
@@ -57,7 +57,7 @@ describe('YearSessions', () => {
 			<YearSessions
 				year={yearData}
 				yearString="2022"
-				viewedGroupId={1}
+				viewedGroup={{ id: 1, slug: 'alpha' }}
 				expandedYear="2022"
 				onToggle={mockOnToggle}
 			/>
@@ -65,5 +65,26 @@ describe('YearSessions', () => {
 		const monthsContainer = screen.getByTestId('months-of-year');
 		const monthButtons = monthsContainer.querySelectorAll('button');
 		expect(monthButtons.length).toBe(4);
+	});
+
+	// Regression: viewedGroupId (number) became a viewedGroup object, but the
+	// session hrefs threaded down the calendar tree must still be built from
+	// the numeric id — byte-identical to before, not the slug.
+	it('threads viewedGroup.id into session hrefs (numeric, unchanged)', () => {
+		render(
+			<YearSessions
+				year={yearData}
+				yearString="2022"
+				viewedGroup={{ id: 1, slug: 'alpha' }}
+				expandedYear="2022"
+				onToggle={mockOnToggle}
+			/>
+		);
+		const sessionLink = document.querySelector(
+			'a[href="/group/1/session/2022-10-20"]'
+		);
+		expect(sessionLink).not.toBeNull();
+		// No href in the tree leaks the slug.
+		expect(document.querySelector('a[href*="/group/alpha/"]')).toBeNull();
 	});
 });

--- a/app/components/shared/StatOutput.tsx
+++ b/app/components/shared/StatOutput.tsx
@@ -1,6 +1,7 @@
 import { NoPrefetchLink } from '@/app/components/shared/NoPrefetchLink';
 import { format as formatDate } from 'date-fns';
 import type { LocationRow } from '@/app/models/db';
+import type { ViewedGroup } from '@/lib/group-slug';
 import { printLocationName } from './DesignSystem';
 export type TemporalUnit = 'day' | 'month' | 'year';
 export type StatOutputModel = {
@@ -13,7 +14,7 @@ export type StatOutputModel = {
 	dateFormat?: string;
 	classes?: string;
 	location?: LocationRow;
-	viewedGroupId?: number;
+	viewedGroup?: ViewedGroup;
 	link?: boolean;
 };
 
@@ -39,12 +40,12 @@ export function StatOutput({
 	temporalUnit,
 	classes,
 	location,
-	viewedGroupId,
+	viewedGroup,
 	link = true
 }: StatOutputModel) {
-	if (temporalUnit === 'day' && !viewedGroupId) {
+	if (temporalUnit === 'day' && !viewedGroup) {
 		throw new Error(
-			'viewedGroupId is required to output stats for day temporal unit'
+			'viewedGroup is required to output stats for day temporal unit'
 		);
 	}
 	return (
@@ -56,7 +57,7 @@ export function StatOutput({
 			{temporalUnit === 'day' && link ? (
 				<NoPrefetchLink
 					className="link"
-					href={`/group/${viewedGroupId}/session/${visitDate}${location ? `/site/${location.id}` : ''}`}
+					href={`/group/${viewedGroup?.id}/session/${visitDate}${location ? `/site/${location.id}` : ''}`}
 				>
 					{formatDate(
 						new Date(visitDate as string),

--- a/app/components/shared/__tests__/StatOutput.test.tsx
+++ b/app/components/shared/__tests__/StatOutput.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { StatOutput } from '../StatOutput';
+import type { LocationRow } from '@/app/models/db';
+
+afterEach(() => {
+	cleanup();
+});
+
+describe('StatOutput', () => {
+	describe('day temporal unit href', () => {
+		// Regression: this ticket swaps viewedGroupId (a number) for a
+		// viewedGroup object but the session href must still be built from the
+		// numeric id — byte-identical to before.
+		it('builds the session href from viewedGroup.id (numeric, unchanged)', () => {
+			render(
+				<StatOutput
+					value={11}
+					visitDate="2022-10-20"
+					temporalUnit="day"
+					viewedGroup={{ id: 1, slug: 'alpha' }}
+				/>
+			);
+			const link = screen.getByRole('link') as HTMLAnchorElement;
+			expect(link.getAttribute('href')).toBe('/group/1/session/2022-10-20');
+		});
+
+		it('appends the site segment from location.id when a location is given', () => {
+			const location = {
+				id: 31,
+				location_name: 'Alpha Site B'
+			} as LocationRow;
+			render(
+				<StatOutput
+					value={5}
+					visitDate="2022-10-20"
+					temporalUnit="day"
+					location={location}
+					viewedGroup={{ id: 1, slug: 'alpha' }}
+				/>
+			);
+			const link = screen.getByRole('link') as HTMLAnchorElement;
+			expect(link.getAttribute('href')).toBe(
+				'/group/1/session/2022-10-20/site/31'
+			);
+		});
+
+		it('throws when viewedGroup is missing for a day temporal unit', () => {
+			expect(() =>
+				render(
+					<StatOutput value={11} visitDate="2022-10-20" temporalUnit="day" />
+				)
+			).toThrow(/viewedGroup is required/);
+		});
+	});
+});


### PR DESCRIPTION
## What this covers

Cascades the `viewedGroup` `{ id, slug }` object (introduced upstream in #486–#488) one or two levels deeper into the specific component chain that eventually builds an `href`, swapping each component's `viewedGroupId: number` prop for `viewedGroup: ViewedGroup`. Every `href`, accordion key, `useEffect` dependency and `ringing_group_filter` still reads `viewedGroup.id` — so the rendered output is **byte-identical** to before. This is a deliberate no-op behaviourally, independently shippable to prod; the slug flip and route rename land together in the following ticket (#490).

Implements #489 (child of #472).

### Components swapped (`viewedGroupId` → `viewedGroup`)
- `app/components/shared/StatOutput.tsx` — session `href` still `/group/${viewedGroup?.id}/...`
- `app/components/StatsAccordion.tsx` — `useEffect` dep + `key` use `viewedGroup.id`
- `app/components/StatsAccordionItem.tsx` — `ringing_group_filter: model.viewedGroup.id`
- `app/components/SessionHistoryCalendar.tsx` (incl. `SessionsByDay`) — `href` still `/group/${viewedGroup.id}/...`
- `app/components/YearSessions.tsx` — threads the object through the recursive year/month accordion models
- `app/components/MonthSessions.tsx`
- `app/components/SpStats.tsx`
- `app/components/SpPage.tsx` (`SpeciesData`) — passes the object to `SpStats`, the plain `viewedGroup.id` to the other species tabs (unchanged)

### Caller edits (necessary consequence of the prop swaps)
The pages/components that render the swapped components now pass the object they already hold:
- `app/(routes)/highlights/page.tsx` → `StatsAccordion`
- `app/(routes)/sessions/page.tsx` → `SessionHistoryCalendar`
- `app/(routes)/page.tsx` (`RecentSessions`) → `SessionsByDay` (home page also consumes `SessionsByDay`)

## Tests

- Updated existing component tests to render with `viewedGroup={{ id, slug: 'alpha' }}` instead of `viewedGroupId={id}` (`SpStats`, `StatsAccordionItem`, `YearSessions`).
- Added `app/components/shared/__tests__/StatOutput.test.tsx` — byte-exact href assertions (`/group/1/session/2022-10-20`, plus the `/site/31` variant) and the missing-`viewedGroup` throw.
- Added a `YearSessions` regression test asserting the calendar's threaded session href stays `/group/1/session/...` and no href leaks the slug.
- `npm run qa` (lint + type-check + 742 app tests) green; pre-push E2E suite (91 tests) green.

## Assumptions (subagent mode)
- `SessionsByDay` (living in `SessionHistoryCalendar.tsx`) is the actual href-builder the ticket's item 6 refers to, so it was swapped too; this necessarily threaded `viewedGroup` into its second consumer, the home page's `RecentSessions`. The home page's `BootstrapPageData` boundary (from #488) already supplies the object, so no behaviour changed.
- The ticket's "Files touched" list under-counted these two caller pages; they are unavoidable given the prop swaps and were kept minimal (passing the already-available object).

🤖 Generated with [Claude Code](https://claude.com/claude-code)