### PR TITLE
fix: prune dead-worktree entries from swarm-state.json

### DIFF
--- a/.claude/mcp/swarm-tools/lib/__tests__/state-file.test.ts
+++ b/.claude/mcp/swarm-tools/lib/__tests__/state-file.test.ts
@@ -13,7 +13,10 @@ function makeEntry(overrides: Partial<SwarmWorkerEntry> = {}): SwarmWorkerEntry 
 		pr: null,
 		branch: 'feature/1-example',
 		title: 'Example',
-		worktreePath: '/tmp/example',
+		// listState() now prunes entries whose worktreePath doesn't exist on disk — default to a
+		// path guaranteed to exist (this test process's own cwd) so tests unrelated to staleness
+		// pruning aren't silently pruned; the pruning-specific tests below override this.
+		worktreePath: process.cwd(),
 		agentId: 'agent-1',
 		model: 'sonnet',
 		startedAt: '2026-01-01T00:00:00.000Z',
@@ -127,6 +130,67 @@ describe('state-file', () => {
 			const result = await listState(repoDir);
 			expect(result).toHaveLength(1);
 			expect(result[0].agentId).toBe('agent-1');
+		});
+	});
+
+	describe('listState — stale worktree pruning', () => {
+		async function readRawState(): Promise<SwarmWorkerEntry[]> {
+			const raw = await fs.readFile(path.join(repoDir, '.claude', 'swarm-state.json'), 'utf8');
+			return JSON.parse(raw);
+		}
+
+		// Usual
+		it('omits an entry whose worktreePath no longer exists on disk', async () => {
+			const deadEntry = makeEntry({ agentId: 'agent-dead', worktreePath: path.join(repoDir, 'nonexistent-worktree') });
+			await withStateLock((entries) => ({ entries: [...entries, deadEntry], result: undefined }), repoDir);
+
+			expect(await listState(repoDir)).toEqual([]);
+		});
+
+		it('keeps an entry whose worktreePath still exists on disk', async () => {
+			const liveWorktreePath = path.join(repoDir, 'live-worktree');
+			await fs.mkdir(liveWorktreePath, { recursive: true });
+			const liveEntry = makeEntry({ agentId: 'agent-live', worktreePath: liveWorktreePath });
+			await withStateLock((entries) => ({ entries: [...entries, liveEntry], result: undefined }), repoDir);
+
+			expect(await listState(repoDir)).toEqual([liveEntry]);
+		});
+
+		// Structure
+		it('prunes the stale entry from the on-disk file after listState surfaces it', async () => {
+			const deadEntry = makeEntry({ agentId: 'agent-dead', worktreePath: path.join(repoDir, 'nonexistent-worktree') });
+			await withStateLock((entries) => ({ entries: [...entries, deadEntry], result: undefined }), repoDir);
+
+			await listState(repoDir);
+
+			expect(await readRawState()).toEqual([]);
+		});
+
+		it('prunes only the stale entry when one is stale and one is live, keeping the live one intact', async () => {
+			const liveWorktreePath = path.join(repoDir, 'live-worktree');
+			await fs.mkdir(liveWorktreePath, { recursive: true });
+			const liveEntry = makeEntry({ agentId: 'agent-live', worktreePath: liveWorktreePath });
+			const deadEntry = makeEntry({ agentId: 'agent-dead', worktreePath: path.join(repoDir, 'nonexistent-worktree') });
+			await withStateLock((entries) => ({ entries: [...entries, liveEntry, deadEntry], result: undefined }), repoDir);
+
+			const result = await listState(repoDir);
+
+			expect(result).toEqual([liveEntry]);
+			expect(await readRawState()).toEqual([liveEntry]);
+		});
+
+		// Edge
+		it('does not touch the on-disk file when all entries are live', async () => {
+			const liveWorktreePath = path.join(repoDir, 'live-worktree');
+			await fs.mkdir(liveWorktreePath, { recursive: true });
+			const liveEntry = makeEntry({ agentId: 'agent-live', worktreePath: liveWorktreePath });
+			await withStateLock((entries) => ({ entries: [...entries, liveEntry], result: undefined }), repoDir);
+			const before = await fs.stat(path.join(repoDir, '.claude', 'swarm-state.json'));
+
+			await listState(repoDir);
+
+			const after = await fs.stat(path.join(repoDir, '.claude', 'swarm-state.json'));
+			expect(after.mtimeMs).toBe(before.mtimeMs);
 		});
 	});
 });

--- a/.claude/mcp/swarm-tools/lib/state-file.ts
+++ b/.claude/mcp/swarm-tools/lib/state-file.ts
@@ -137,25 +137,72 @@ async function writeState(stateFilePath: string, entries: SwarmWorkerEntry[]): P
 	await fs.rename(tmpPath, stateFilePath);
 }
 
-/** Read-only, unlocked — safe for callers that only need a snapshot (e.g. filtering/ranking). */
-export async function listState(cwd: string = process.cwd()): Promise<SwarmWorkerEntry[]> {
-	return readState(await resolveStateFilePath(cwd));
+/** True if `worktreePath` still exists on disk — a plain, local, no-network/no-git liveness check. */
+async function worktreeStillExists(worktreePath: string): Promise<boolean> {
+	try {
+		await fs.access(worktreePath);
+		return true;
+	} catch {
+		return false;
+	}
 }
 
 /**
- * Locked read-modify-write. `mutate` receives the current entries and returns the entries to
- * persist plus a result to hand back to the caller. Holds a filesystem lock for the duration,
- * so concurrent worktrees appending/removing entries never lose an update to each other.
+ * Splits `entries` into those whose `worktreePath` still exists (live) and those whose worktree
+ * is gone (stale — the worker died or finished without its cleanup step running). Order-preserving.
+ */
+async function partitionStaleEntries(
+	entries: SwarmWorkerEntry[]
+): Promise<{ live: SwarmWorkerEntry[]; stale: SwarmWorkerEntry[] }> {
+	const stillExists = await Promise.all(entries.map((entry) => worktreeStillExists(entry.worktreePath)));
+	const live: SwarmWorkerEntry[] = [];
+	const stale: SwarmWorkerEntry[] = [];
+	entries.forEach((entry, i) => (stillExists[i] ? live.push(entry) : stale.push(entry)));
+	return { live, stale };
+}
+
+/**
+ * Self-healing read: filters out any entry whose `worktreePath` no longer exists on disk (a
+ * worker that died or finished without its `swarm_state_remove` cleanup step running — see
+ * the stale-issue-#490 incident) before returning to the caller, so every consumer
+ * (`swarm_state_list`, `swarm_plan_batch`'s `runningIssueNumbers`/`isSoloRunCurrentlyActive`,
+ * `resolve-work-item`) treats a dead worktree as not-running without needing its own fix.
+ *
+ * Cheap and unlocked in the common case (all worktrees live) — just a snapshot read plus local
+ * `fs.access` checks, no lock taken. Only when a stale entry is actually found does it pay for a
+ * locked read-modify-write to prune the file, re-checking staleness against the freshly-locked
+ * read (rather than trusting the pre-lock snapshot) to avoid clobbering a concurrent
+ * append/remove from another worktree.
+ */
+export async function listState(cwd: string = process.cwd()): Promise<SwarmWorkerEntry[]> {
+	const stateFilePath = await resolveStateFilePath(cwd);
+	const snapshot = await readState(stateFilePath);
+	const { stale } = await partitionStaleEntries(snapshot);
+	if (stale.length === 0) return snapshot;
+
+	return withStateLock(async (current) => {
+		const { live } = await partitionStaleEntries(current);
+		return { entries: live, result: live };
+	}, cwd);
+}
+
+/**
+ * Locked read-modify-write. `mutate` receives the current entries and returns (synchronously or
+ * via a Promise) the entries to persist plus a result to hand back to the caller. Holds a
+ * filesystem lock for the duration, so concurrent worktrees appending/removing/pruning entries
+ * never lose an update to each other.
  */
 export async function withStateLock<T>(
-	mutate: (entries: SwarmWorkerEntry[]) => { entries: SwarmWorkerEntry[]; result: T },
+	mutate: (
+		entries: SwarmWorkerEntry[]
+	) => { entries: SwarmWorkerEntry[]; result: T } | Promise<{ entries: SwarmWorkerEntry[]; result: T }>,
 	cwd: string = process.cwd()
 ): Promise<T> {
 	const stateFilePath = await resolveStateFilePath(cwd);
 	const lockPath = await acquireLock(stateFilePath);
 	try {
 		const current = await readState(stateFilePath);
-		const { entries, result } = mutate(current);
+		const { entries, result } = await mutate(current);
 		await writeState(stateFilePath, entries);
 		return result;
 	} finally {


### PR DESCRIPTION
## Summary

- `.claude/swarm-state.json` had a stale entry: a ticket worker for issue #490 died/finished without its `swarm_state_remove` cleanup step running, leaving an entry whose `worktreePath` no longer existed on disk. `listState()` trusted every entry unconditionally, and every consumer inherited that blind trust:
  - `swarm_plan_batch`'s `runningIssueNumbers` treated #490 as in-flight forever, silently excluding it from ready-ticket candidates.
  - `isSoloRunCurrentlyActive` (also in `swarm-plan-batch.ts`) trusts `listState()` to decide whether an exclusive-resource (`db-migration`/`e2e-exclusive`) solo run is active — a stale entry there would have wrongly blocked *all* other work indefinitely, which is worse.
  - The user had to notice and fix it by hand via `swarm_state_remove`.
- `listState()` (`.claude/mcp/swarm-tools/lib/state-file.ts`) is now self-healing: before returning, it checks each entry's `worktreePath` with a cheap local `fs.access` (no network/git calls). When every worktree is live (the common case) it stays unlocked and cheap, matching its prior contract. Only when a stale entry is found does it pay for a locked read-modify-write — reusing the existing `acquireLock`/`withStateLock` machinery — re-checking staleness against the freshly-locked read (not the pre-lock snapshot) to avoid racing a concurrent append/remove from another worktree, then prunes and persists.
- Every consumer (`swarm_state_list`, `swarm_plan_batch`, `resolve-work-item` used by `take-over`) is fixed for free since they all go through `listState()`.
- `withStateLock`'s `mutate` callback now accepts an async return (needed since the staleness check does filesystem I/O); existing synchronous callers are unaffected — awaiting a plain object is a no-op.
- Updated `listState()`'s doc comment to describe the new self-healing/locked-on-staleness behavior instead of "read-only, unlocked" unconditionally.

## Test plan

- [x] Added `listState() — stale worktree pruning` describe block to `.claude/mcp/swarm-tools/lib/__tests__/state-file.test.ts`: omits a stale entry, keeps a live entry, prunes the stale entry from the on-disk file, prunes only the stale one out of a stale+live pair (live entry's data survives intact), and leaves the file untouched (mtime unchanged) when everything is live.
- [x] Fixed the existing `makeEntry()` fixture's default `worktreePath` (was `/tmp/example`, which doesn't exist) to `process.cwd()` so the pre-existing append/concurrency/schema-validation tests aren't accidentally pruned by the new behavior.
- [x] Checked `swarm-plan-batch.test.ts` and `resolve-work-item.test.ts` — neither mocks `listState` directly (they only test pure exported helpers), so no fixture updates were needed there.
- [x] `npx vitest run .claude/mcp/swarm-tools` — 90/90 passing.
- [x] `npm run qa` (lint + typecheck + app tests) — 64/64 test files, 752/752 tests passing.
- [x] `git push` ran the full pre-push hook (app tests + full Playwright E2E suite, since this branch touches `.claude/mcp/swarm-tools`) — 91/91 e2e tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)