### PR TITLE
Move /highlights (top-performers accordion) page to /records

### DIFF
--- a/app/(routes)/records/__tests__/page.test.tsx
+++ b/app/(routes)/records/__tests__/page.test.tsx
@@ -10,17 +10,17 @@ vi.mock('@/app/actions/top-performers', () => ({
 	getTopStats: mockGetTopStats
 }));
 
-describe('highlights page', () => {
+describe('records page', () => {
 	afterEach(() => {
 		cleanup();
 		mockGetTopStats.mockReset();
 	});
 
-	it('renders a "Highlights" page heading', async () => {
+	it('renders a "Records" page heading', async () => {
 		mockGetTopStats.mockResolvedValue([]);
 		render(await Page());
 		const heading = await screen.findByRole('heading', { level: 1 });
-		expect(heading.textContent).toBe('Highlights');
+		expect(heading.textContent).toBe('Records');
 	});
 
 	it('renders an accordion group per stat panel heading', async () => {

--- a/app/(routes)/records/page.tsx
+++ b/app/(routes)/records/page.tsx
@@ -136,7 +136,7 @@ function getStatConfigs(
 	];
 }
 
-export async function fetchHighlightsData(
+export async function fetchRecordsData(
 	_: DefaultPageParams,
 	viewedGroupId: number
 ): Promise<StatsAccordionModel[]> {
@@ -168,7 +168,7 @@ export async function fetchHighlightsData(
 	);
 }
 
-function HighlightsPageContent({
+function RecordsPageContent({
 	data,
 	viewedGroup
 }: {
@@ -177,13 +177,13 @@ function HighlightsPageContent({
 }) {
 	return (
 		<PageWrapper>
-			<PrimaryHeading>Highlights</PrimaryHeading>
+			<PrimaryHeading>Records</PrimaryHeading>
 			<StatsAccordion data={data} viewedGroup={viewedGroup} />
 		</PageWrapper>
 	);
 }
 
-export default async function HighlightsPage({
+export default async function RecordsPage({
 	viewedGroup
 }: {
 	viewedGroup?: ViewedGroup;
@@ -191,9 +191,9 @@ export default async function HighlightsPage({
 	return (
 		<BootstrapPageData<StatsAccordionModel[]>
 			viewedGroup={viewedGroup}
-			getCacheKeys={() => ['highlights']}
-			dataFetcher={fetchHighlightsData}
-			PageComponent={HighlightsPageContent}
+			getCacheKeys={() => ['records']}
+			dataFetcher={fetchRecordsData}
+			PageComponent={RecordsPageContent}
 		/>
 	);
 }

--- a/app/components/layout/GlobalNav.tsx
+++ b/app/components/layout/GlobalNav.tsx
@@ -7,7 +7,7 @@ import { useSetRingingGroup } from './RingingGroupProvider';
 import { logout } from '@/app/actions/logout';
 import type { RingingGroupRow } from '@/app/models/db';
 const moreLinks = [
-	{ href: '/highlights', label: 'Highlights' },
+	{ href: '/records', label: 'Records' },
 	{ href: '/mistakes', label: 'Mistakes' },
 	{ href: '/retraps', label: 'Retraps' },
 	{ href: '/resightings', label: 'Resightings' },

--- a/app/components/layout/__tests__/GlobalNav.test.tsx
+++ b/app/components/layout/__tests__/GlobalNav.test.tsx
@@ -32,7 +32,7 @@ describe('DesktopNavItems', () => {
 		render(
 			<DesktopNavItems classes="" moreExpanded={true} onMoreClick={noOp} />
 		);
-		expect(screen.getByRole('link', { name: 'Highlights' })).toBeDefined();
+		expect(screen.getByRole('link', { name: 'Records' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Mistakes' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Retraps' })).toBeDefined();
 		expect(screen.getByRole('link', { name: 'Resightings' })).toBeDefined();
@@ -81,9 +81,9 @@ describe('MobileNavItems', () => {
 		expect(links).toHaveLength(11);
 	});
 
-	it('includes Highlights link', () => {
+	it('includes Records link', () => {
 		render(<MobileNavItems classes="" />);
-		expect(screen.getByRole('link', { name: 'Highlights' })).toBeDefined();
+		expect(screen.getByRole('link', { name: 'Records' })).toBeDefined();
 	});
 
 	it('includes Resightings link', () => {


### PR DESCRIPTION
## Why

A separate ticket is about to repurpose the `/highlights` URL for a new period-based highlight landing page family (all-time / year / year-month). The current occupant of that URL — the top-performers accordion page (busiest sessions, most-varied sessions, individual-species records) — needs to move out of the way first so that ticket can claim the URL cleanly.

## What

Pure relocation of the existing page: same data, same `StatsAccordion` rendering, same `BootstrapPageData` bootstrap pattern, different URL and identifiers.

- `git mv app/(routes)/highlights app/(routes)/records`, following the repo convention for default-export naming (`app/(routes)/sessions/page.tsx`):
  - `HighlightsPage` → `RecordsPage`, `fetchHighlightsData` → `fetchRecordsData`, `HighlightsPageContent` → `RecordsPageContent`
  - `getCacheKeys={() => ['highlights']}` → `['records']`
  - Visible copy also renamed: `<PrimaryHeading>` text and nav label `Highlights` → `Records`, so the URL and on-page/nav copy stay in sync
- `app/components/layout/GlobalNav.tsx`: `moreLinks` entry updated from `{ href: '/highlights', label: 'Highlights' }` to `{ href: '/records', label: 'Records' }` (no new `/highlights` entry added — that's the follow-up ticket's job)
- Updated the two test files asserting on the old path/copy (`app/(routes)/records/__tests__/page.test.tsx`, `app/components/layout/__tests__/GlobalNav.test.tsx`)

No change to the top-performers accordion's actual stat panels, `getTopStats` calls, filters, or data shape. The unrelated `session-highlights` feature (per-session highlight cards) is untouched.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)