### PR TITLE
feat: add /session-temp/[date] heading-only route

### DIFF
--- a/app/group/[groupSlug]/session-temp/[date]/__tests__/page.test.tsx
+++ b/app/group/[groupSlug]/session-temp/[date]/__tests__/page.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import Page from '../page';
+
+const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
+	mockGetAuthenticatedSupabaseClient: vi.fn()
+}));
+
+vi.mock('@/lib/group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+const TEST_DATE = '2024-03-15';
+const TEST_GROUP_ID = 1;
+const TEST_GROUP_SLUG = 'test-group-slug';
+
+function makeChain(data: unknown) {
+	return {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		maybeSingle: vi.fn().mockReturnThis(),
+		then: (resolve: (v: { data: unknown; error: null }) => unknown) =>
+			Promise.resolve({ data, error: null }).then(resolve)
+	};
+}
+
+function makeGroupSlugOnlyClient() {
+	const from = vi.fn((table: string) => {
+		if (table === 'RingingGroups') {
+			return makeChain({ id: TEST_GROUP_ID });
+		}
+		throw new Error(`Unexpected table query in session-temp page: ${table}`);
+	});
+	return { from };
+}
+
+function renderPage() {
+	return Page({
+		params: Promise.resolve({ groupSlug: TEST_GROUP_SLUG, date: TEST_DATE })
+	});
+}
+
+describe('session-temp detail page', () => {
+	afterEach(() => {
+		cleanup();
+	});
+
+	beforeEach(() => {
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(
+			makeGroupSlugOnlyClient()
+		);
+	});
+
+	it('renders the formatted date as a level-1 heading', async () => {
+		render(await renderPage());
+		const heading = await screen.findByRole('heading', { level: 1 });
+		expect(heading.textContent).toContain('Fri 15th March 2024');
+	});
+
+	it('does not query Sessions or Encounters tables', async () => {
+		const client = makeGroupSlugOnlyClient();
+		mockGetAuthenticatedSupabaseClient.mockResolvedValue(client);
+		render(await renderPage());
+		await screen.findByRole('heading', { level: 1 });
+		const queriedTables = client.from.mock.calls.map(([table]) => table);
+		expect(queriedTables).not.toContain('Sessions');
+		expect(queriedTables).not.toContain('Encounters');
+	});
+
+	it('renders a heading for a date with no matching session in the database', async () => {
+		// The stubbed dataFetcher never checks Sessions/Encounters, so a date
+		// with no corresponding session row still renders successfully.
+		render(await renderPage());
+		const heading = await screen.findByRole('heading', { level: 1 });
+		expect(heading.textContent).toContain('15th March 2024');
+	});
+});

--- a/app/group/[groupSlug]/session-temp/[date]/page.tsx
+++ b/app/group/[groupSlug]/session-temp/[date]/page.tsx
@@ -1,0 +1,47 @@
+import { notFound } from 'next/navigation';
+import { BootstrapPageData } from '@/app/components/layout/BootstrapPageData';
+import { resolveGroupIdBySlug } from '@/lib/group-slug';
+import {
+	PageWrapper,
+	PrimaryHeading
+} from '@/app/components/shared/DesignSystem';
+import { format as formatDate } from 'date-fns';
+
+type PageParams = { date: string };
+
+// No session data exists to fetch yet — this page derives its heading
+// entirely from the date route param. BootstrapPageData's LoadWithData
+// calls notFound() when data is falsy, so this stub must stay truthy.
+async function fetchSessionTempData(): Promise<{ loaded: true }> {
+	return { loaded: true };
+}
+
+function SessionTempSummary({ params: { date } }: { params: PageParams }) {
+	return (
+		<PageWrapper>
+			<PrimaryHeading>
+				{formatDate(new Date(date), 'EEE do MMMM yyyy')}
+			</PrimaryHeading>
+		</PageWrapper>
+	);
+}
+
+type PageProps = { params: Promise<{ groupSlug: string; date: string }> };
+
+export default async function SessionTempPage({ params }: PageProps) {
+	const { groupSlug, date } = await params;
+	const viewedGroupId = await resolveGroupIdBySlug(groupSlug);
+	if (viewedGroupId === null) {
+		notFound();
+	}
+	const viewedGroup = { id: viewedGroupId, slug: groupSlug };
+	return (
+		<BootstrapPageData<{ loaded: true }, PageProps, PageParams>
+			viewedGroup={viewedGroup}
+			getParams={async () => ({ date })}
+			getCacheKeys={() => ['session-temp', date]}
+			dataFetcher={fetchSessionTempData}
+			PageComponent={SessionTempSummary}
+		/>
+	);
+}


### PR DESCRIPTION
## Why

Part of a batch adding a temporary `/session-temp` route family so upcoming highlights pages (task B) can link out to a lightweight per-session page (task E) without depending on the full `SessionSummary` build-out. This ticket only creates the destination page — a heading, nothing else.

## What

Adds `app/group/[groupSlug]/session-temp/[date]/page.tsx`, a single-file `BootstrapPageData`-wired route that renders `PageWrapper` > `PrimaryHeading` with only the formatted date (`EEE do MMMM yyyy`, matching `SessionSummary`'s format). No DB fetch — the `dataFetcher` is a trivial stub returning a truthy value so `LoadWithData` doesn't 404. No nested `site/[locationId]` variant, per spec.

### Assumption / deviation from the ticket text

The ticket body (written before recent refactors landed) describes the mirror target as `app/group/[groupId]/session/[date]/page.tsx`, resolving `viewedGroup` via `resolveGroupSlugById`. The actual current route is `app/group/[groupSlug]/session/[date]/page.tsx`, which takes `groupSlug` from the URL and resolves the numeric id via `resolveGroupIdBySlug` (group identity moved from id-in-URL to slug-in-URL in the meantime — see `app/group/[groupSlug]/session/[date]/page.tsx` and `lib/group-slug.ts`). This PR mirrors the *current* route shape (`[groupSlug]/session-temp/[date]`) rather than the ticket's now-stale path, since that's what "mirror the session detail page" means today.

## Details

- New route: `app/group/[groupSlug]/session-temp/[date]/page.tsx`
- New tests: `app/group/[groupSlug]/session-temp/[date]/__tests__/page.test.tsx` (heading renders with correct format; Sessions/Encounters are never queried; a date with no matching session still renders successfully)
- `npm run qa` passes (lint, type-check, 776 app tests including the 3 new ones)
- Pre-push hook: app tests + `test:e2e:safe` (91 passed)

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)