### PR TITLE
feat: add lib/underlying-stats.ts with a copy of fetchSessionStats

### DIFF
--- a/app/actions/session-highlights.ts
+++ b/app/actions/session-highlights.ts
@@ -1,6 +1,7 @@
 'use server';
 import { getAuthenticatedSupabaseClient } from '@/lib/group-auth';
-import { catchSupabaseErrors, fetchAllPaginatedRows } from '@/lib/supabase';
+import { catchSupabaseErrors } from '@/lib/supabase';
+import { fetchSessionStats } from '@/lib/underlying-stats';
 import { runHighlightMachine } from '@/app/models/highlight-refinement-machine';
 import {
 	deriveFirstEverSpecies,
@@ -13,82 +14,9 @@ import {
 	deriveSpeciesRecords,
 	deriveSpeciesJuvRecords,
 	deriveWeightRecordBreakers,
-	type SessionHighlight,
-	type SessionStatsData
+	type SessionHighlight
 } from '@/app/models/session-highlights';
-import type {
-	LongAbsenceRetrapsResult,
-	StatsPerDayAndSpeciesResult
-} from '@/app/models/db';
-
-// The stats blob only changes when new data is imported. The cache entry
-// carries a version token (max Encounters.id for the group) so that a new
-// import invalidates the cache immediately, even across lambda instances.
-// The 60-min TTL is retained as a backstop for rare in-place re-imports
-// that edit existing encounters without adding rows.
-const SESSION_STATS_CACHE_TTL_MS = 60 * 60 * 1000;
-const sessionStatsCache = new Map<
-	number,
-	{ version: number; expiresAt: number; stats: SessionStatsData }
->();
-
-async function fetchStatsVersion(
-	supabase: Awaited<ReturnType<typeof getAuthenticatedSupabaseClient>>,
-	viewedGroupId: number
-): Promise<number> {
-	const { data } = await supabase
-		.from('Encounters')
-		.select('id')
-		.eq('ringing_group_id', viewedGroupId)
-		.order('id', { ascending: false })
-		.limit(1);
-	return data?.[0]?.id ?? 0;
-}
-
-async function fetchSessionStats(
-	viewedGroupId: number
-): Promise<SessionStatsData> {
-	const supabase = await getAuthenticatedSupabaseClient();
-	const currentVersion = await fetchStatsVersion(supabase, viewedGroupId);
-	const cached = sessionStatsCache.get(viewedGroupId);
-	if (
-		cached &&
-		cached.version === currentVersion &&
-		cached.expiresAt > Date.now()
-	) {
-		return cached.stats;
-	}
-	const [daySpeciesStats, sessionRows] = await Promise.all([
-		fetchAllPaginatedRows<StatsPerDayAndSpeciesResult>((fromRow, toRow) =>
-			supabase
-				.rpc('stats_per_day_and_species', {
-					ringing_group_filter: viewedGroupId
-				})
-				.order('visit_date')
-				.order('species_name')
-				.range(fromRow, toRow)
-		),
-		fetchAllPaginatedRows<{ visit_date: string }>((fromRow, toRow) =>
-			supabase
-				.from('Sessions')
-				.select('visit_date')
-				.eq('ringing_group_id', viewedGroupId)
-				.eq('session_type', 'FULL_GROWN')
-				.order('visit_date')
-				.range(fromRow, toRow)
-		)
-	]);
-	const stats: SessionStatsData = {
-		daySpeciesStats,
-		sessionDates: sessionRows.map((row) => row.visit_date)
-	};
-	sessionStatsCache.set(viewedGroupId, {
-		version: currentVersion,
-		expiresAt: Date.now() + SESSION_STATS_CACHE_TTL_MS,
-		stats
-	});
-	return stats;
-}
+import type { LongAbsenceRetrapsResult } from '@/app/models/db';
 
 export async function fetchSessionHighlights({
 	date,

--- a/lib/__tests__/underlying-stats.test.ts
+++ b/lib/__tests__/underlying-stats.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { StatsPerDayAndSpeciesResult } from '@/app/models/db';
+
+const { mockGetAuthenticatedSupabaseClient } = vi.hoisted(() => ({
+	mockGetAuthenticatedSupabaseClient: vi.fn()
+}));
+
+vi.mock('../group-auth', () => ({
+	getAuthenticatedSupabaseClient: mockGetAuthenticatedSupabaseClient
+}));
+
+const GROUP_ID = 1;
+const OTHER_GROUP_ID = 2;
+const PAGE_SIZE = 1000;
+const TTL_MS = 60 * 60 * 1000;
+
+// Queries are paginated (PostgREST caps responses at 1000 rows), so the
+// mock builders serve rows page by page from these arrays
+let rpcPages: StatsPerDayAndSpeciesResult[][];
+let sessionPages: { visit_date: string }[][];
+
+function statsRow(
+	species_name: string,
+	visit_date: string,
+	encounter_count: number
+): StatsPerDayAndSpeciesResult {
+	return {
+		species_name,
+		visit_date,
+		encounter_count,
+		juv_count: 0,
+		weighed_birds_count: 0,
+		min_weight: 0,
+		max_weight: 0
+	};
+}
+
+function pageForRange(pages: unknown[][], fromRow: number) {
+	return Promise.resolve({
+		data: pages[fromRow / PAGE_SIZE] ?? [],
+		error: null
+	});
+}
+
+const mockRpcOrder = vi.fn();
+const mockRpcRange = vi.fn();
+const paginatedRpcQueryBuilder = { order: mockRpcOrder, range: mockRpcRange };
+const mockRpc = vi.fn(() => paginatedRpcQueryBuilder);
+
+const mockSessionsOrder = vi.fn();
+const mockSessionsRange = vi.fn();
+const mockSessionsEq = vi.fn();
+// eq is also on the builder itself so it self-chains — fetchSessionStats
+// calls .eq() twice (ringing_group_id, then session_type) before .order()
+const sessionsQueryBuilder = {
+	eq: mockSessionsEq,
+	order: mockSessionsOrder,
+	range: mockSessionsRange
+};
+const mockSessionsSelect = vi.fn(() => ({ eq: mockSessionsEq }));
+
+let statsVersion = 100;
+const mockEncountersLimit = vi.fn();
+const mockEncountersOrder = vi.fn(() => ({ limit: mockEncountersLimit }));
+const mockEncountersEq = vi.fn(() => ({ order: mockEncountersOrder }));
+const mockEncountersSelect = vi.fn(() => ({ eq: mockEncountersEq }));
+
+const mockFrom = vi.fn((table: string) => {
+	if (table === 'Sessions') {
+		return { select: mockSessionsSelect };
+	}
+	// Encounters — version query
+	return { select: mockEncountersSelect };
+});
+
+// the module memoises the stats blob at module scope, so each test imports a
+// fresh copy of the module
+async function importFetchSessionStats() {
+	vi.resetModules();
+	const { fetchSessionStats } = await import('../underlying-stats');
+	return fetchSessionStats;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	statsVersion = 100;
+	rpcPages = [
+		[
+			statsRow('Robin', '2024-09-15', 74),
+			statsRow('Robin', '2022-05-01', 30),
+			statsRow('Wren', '2022-05-01', 30)
+		]
+	];
+	sessionPages = [[{ visit_date: '2022-05-01' }, { visit_date: '2024-09-15' }]];
+	mockRpcOrder.mockReturnValue(paginatedRpcQueryBuilder);
+	mockRpcRange.mockImplementation((fromRow: number) =>
+		pageForRange(rpcPages, fromRow)
+	);
+	// Sessions from() chain
+	mockSessionsEq.mockReturnValue(sessionsQueryBuilder);
+	mockSessionsOrder.mockReturnValue(sessionsQueryBuilder);
+	mockSessionsRange.mockImplementation((fromRow: number) =>
+		pageForRange(sessionPages, fromRow)
+	);
+	// Encounters from() chain — version query
+	mockEncountersLimit.mockImplementation(() =>
+		Promise.resolve({ data: [{ id: statsVersion }], error: null })
+	);
+	mockGetAuthenticatedSupabaseClient.mockResolvedValue({
+		rpc: mockRpc,
+		from: mockFrom
+	});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('fetchSessionStats', () => {
+	it('fetches day-species stats and session dates for a group on a cold cache', async () => {
+		const fetchSessionStats = await importFetchSessionStats();
+
+		const stats = await fetchSessionStats(GROUP_ID);
+
+		expect(mockRpc).toHaveBeenCalledWith('stats_per_day_and_species', {
+			ringing_group_filter: GROUP_ID
+		});
+		expect(mockFrom).toHaveBeenCalledWith('Sessions');
+		expect(mockSessionsEq).toHaveBeenCalledWith('ringing_group_id', GROUP_ID);
+		expect(mockSessionsEq).toHaveBeenCalledWith('session_type', 'FULL_GROWN');
+		expect(stats.daySpeciesStats).toEqual(rpcPages[0]);
+		expect(stats.sessionDates).toEqual(['2022-05-01', '2024-09-15']);
+	});
+
+	it('returns the cached result on a second call when the stats version is unchanged', async () => {
+		const fetchSessionStats = await importFetchSessionStats();
+
+		await fetchSessionStats(GROUP_ID);
+		await fetchSessionStats(GROUP_ID);
+
+		expect(mockRpc).toHaveBeenCalledTimes(1);
+		// version query still runs on each call
+		expect(mockEncountersLimit).toHaveBeenCalledTimes(2);
+	});
+
+	it('re-fetches when the stats version (max Encounters.id) has advanced since the cached entry', async () => {
+		const fetchSessionStats = await importFetchSessionStats();
+
+		await fetchSessionStats(GROUP_ID);
+		statsVersion = 101;
+		await fetchSessionStats(GROUP_ID);
+
+		expect(mockRpc).toHaveBeenCalledTimes(2);
+	});
+
+	it('re-fetches when the cached entry has passed its TTL even if the version is unchanged', async () => {
+		const fetchSessionStats = await importFetchSessionStats();
+		const now = Date.now();
+		const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+		await fetchSessionStats(GROUP_ID);
+		dateNowSpy.mockReturnValue(now + TTL_MS + 1);
+		await fetchSessionStats(GROUP_ID);
+
+		expect(mockRpc).toHaveBeenCalledTimes(2);
+	});
+
+	it('paginates through fetchAllPaginatedRows results beyond a single page', async () => {
+		rpcPages = [
+			Array.from({ length: PAGE_SIZE }, (_, index) =>
+				statsRow(`Species ${index}`, '2022-05-01', 1)
+			),
+			[statsRow('Robin', '2024-09-15', 2000)]
+		];
+		sessionPages = [
+			[{ visit_date: '2022-05-01' }, { visit_date: '2024-09-15' }]
+		];
+		const fetchSessionStats = await importFetchSessionStats();
+
+		const stats = await fetchSessionStats(GROUP_ID);
+
+		expect(mockRpcRange).toHaveBeenCalledTimes(2);
+		expect(mockRpcRange).toHaveBeenNthCalledWith(
+			2,
+			PAGE_SIZE,
+			2 * PAGE_SIZE - 1
+		);
+		expect(stats.daySpeciesStats).toHaveLength(PAGE_SIZE + 1);
+	});
+
+	it('keeps separate cache entries per viewedGroupId', async () => {
+		const fetchSessionStats = await importFetchSessionStats();
+
+		await fetchSessionStats(GROUP_ID);
+		await fetchSessionStats(OTHER_GROUP_ID);
+
+		expect(mockRpc).toHaveBeenCalledTimes(2);
+		expect(mockRpc).toHaveBeenCalledWith('stats_per_day_and_species', {
+			ringing_group_filter: GROUP_ID
+		});
+		expect(mockRpc).toHaveBeenCalledWith('stats_per_day_and_species', {
+			ringing_group_filter: OTHER_GROUP_ID
+		});
+		// each group's version query is scoped by ringing_group_id
+		expect(mockEncountersEq).toHaveBeenCalledWith('ringing_group_id', GROUP_ID);
+		expect(mockEncountersEq).toHaveBeenCalledWith(
+			'ringing_group_id',
+			OTHER_GROUP_ID
+		);
+	});
+});

--- a/lib/underlying-stats.ts
+++ b/lib/underlying-stats.ts
@@ -1,0 +1,78 @@
+import { getAuthenticatedSupabaseClient } from './group-auth';
+import { fetchAllPaginatedRows } from './supabase';
+import type { SessionStatsData } from '@/app/models/session-highlights';
+import type { StatsPerDayAndSpeciesResult } from '@/app/models/db';
+
+// The stats blob only changes when new data is imported. The cache entry
+// carries a version token (max Encounters.id for the group) so that a new
+// import invalidates the cache immediately, even across lambda instances.
+// The 60-min TTL is retained as a backstop for rare in-place re-imports
+// that edit existing encounters without adding rows.
+//
+// This is a deliberate literal duplicate of the private fetchSessionStats in
+// app/actions/session-highlights.ts (own cache instance, unchanged logic) —
+// that module is slated for eventual deletion, so this shared module must
+// not import from it or share its cache.
+export const SESSION_STATS_CACHE_TTL_MS = 60 * 60 * 1000;
+export const sessionStatsCache = new Map<
+	number,
+	{ version: number; expiresAt: number; stats: SessionStatsData }
+>();
+
+export async function fetchStatsVersion(
+	supabase: Awaited<ReturnType<typeof getAuthenticatedSupabaseClient>>,
+	viewedGroupId: number
+): Promise<number> {
+	const { data } = await supabase
+		.from('Encounters')
+		.select('id')
+		.eq('ringing_group_id', viewedGroupId)
+		.order('id', { ascending: false })
+		.limit(1);
+	return data?.[0]?.id ?? 0;
+}
+
+export async function fetchSessionStats(
+	viewedGroupId: number
+): Promise<SessionStatsData> {
+	const supabase = await getAuthenticatedSupabaseClient();
+	const currentVersion = await fetchStatsVersion(supabase, viewedGroupId);
+	const cached = sessionStatsCache.get(viewedGroupId);
+	if (
+		cached &&
+		cached.version === currentVersion &&
+		cached.expiresAt > Date.now()
+	) {
+		return cached.stats;
+	}
+	const [daySpeciesStats, sessionRows] = await Promise.all([
+		fetchAllPaginatedRows<StatsPerDayAndSpeciesResult>((fromRow, toRow) =>
+			supabase
+				.rpc('stats_per_day_and_species', {
+					ringing_group_filter: viewedGroupId
+				})
+				.order('visit_date')
+				.order('species_name')
+				.range(fromRow, toRow)
+		),
+		fetchAllPaginatedRows<{ visit_date: string }>((fromRow, toRow) =>
+			supabase
+				.from('Sessions')
+				.select('visit_date')
+				.eq('ringing_group_id', viewedGroupId)
+				.eq('session_type', 'FULL_GROWN')
+				.order('visit_date')
+				.range(fromRow, toRow)
+		)
+	]);
+	const stats: SessionStatsData = {
+		daySpeciesStats,
+		sessionDates: sessionRows.map((row) => row.visit_date)
+	};
+	sessionStatsCache.set(viewedGroupId, {
+		version: currentVersion,
+		expiresAt: Date.now() + SESSION_STATS_CACHE_TTL_MS,
+		stats
+	});
+	return stats;
+}

--- a/lib/underlying-stats.ts
+++ b/lib/underlying-stats.ts
@@ -9,10 +9,10 @@ import type { StatsPerDayAndSpeciesResult } from '@/app/models/db';
 // The 60-min TTL is retained as a backstop for rare in-place re-imports
 // that edit existing encounters without adding rows.
 //
-// This is a deliberate literal duplicate of the private fetchSessionStats in
-// app/actions/session-highlights.ts (own cache instance, unchanged logic) —
-// that module is slated for eventual deletion, so this shared module must
-// not import from it or share its cache.
+// This is the single implementation of fetchSessionStats — app/actions/
+// session-highlights.ts imports it (and shares this cache instance) rather
+// than keeping its own copy, since importing a plain module from a
+// 'use server' file is fine.
 export const SESSION_STATS_CACHE_TTL_MS = 60 * 60 * 1000;
 export const sessionStatsCache = new Map<
 	number,


### PR DESCRIPTION
## Why

Tickets B/D/E and the year/month-stats follow-up (#509) need a shared, non-server-action home for the day-species stats fetch that currently lives only as a private helper inside `app/actions/session-highlights.ts`. That module is slated for eventual deletion as part of a longer-term rework, so new code must not depend on it.

## What

Adds `lib/underlying-stats.ts`, a plain module (no `'use server'`, matching `lib/group-slug.ts`'s precedent) exporting `fetchStatsVersion`, `sessionStatsCache`, `SESSION_STATS_CACHE_TTL_MS`, and `fetchSessionStats(viewedGroupId)`. `app/actions/session-highlights.ts` now imports `fetchSessionStats` from this module instead of keeping its own private copy, so there's a single implementation and a single shared cache instance.

## Details

- `SessionStatsData` is imported as a type-only import from `@/app/models/session-highlights` across the `app/models` → `lib` boundary, per the ticket.
- Internal `lib`→`lib` imports (`./group-auth`, `./supabase`) use relative paths, not the `@/` alias — `tsconfig.json`'s `include` list doesn't cover `lib/**`, so `vite-tsconfig-paths` can't resolve `@/lib/...` specifiers from within `lib/`; existing `lib/group-slug.ts` already follows this relative-import convention for the same reason.
- `app/actions/session-highlights.ts` is `'use server'`; importing a plain (non-`'use server'`) module from it is fine, so it imports `fetchSessionStats` directly with no re-export shim.
- Tests in `lib/__tests__/underlying-stats.test.ts` mirror `lib/__tests__/group-slug.test.ts`'s mocking pattern, covering: cold-cache fetch, cache hit when version unchanged, re-fetch on version bump, re-fetch on TTL expiry, pagination beyond one page, and per-group cache isolation. `app/actions/__tests__/session-highlights.test.ts`'s existing caching-behaviour tests continue to pass unmodified, now exercising the shared implementation through the import rather than a private copy.

## Out of scope

- `fetchYearStats`/`fetchMonthStats` (ticket F2 / #509, depends on this one).
- Wiring this into any other page or action beyond `session-highlights.ts` (tickets B/D/E).

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)
