### PR TITLE
fix: detect feedback in top-level PR comments in swarm_plan_batch

### DIFF
--- a/.claude/mcp/swarm-tools/tools/__tests__/swarm-plan-batch.test.ts
+++ b/.claude/mcp/swarm-tools/tools/__tests__/swarm-plan-batch.test.ts
@@ -8,10 +8,12 @@ import {
 	getModelLabel,
 	hasOutstandingReviewFeedback,
 	hasOutstandingInlineFeedback,
+	hasOutstandingIssueCommentFeedback,
 	rankMaintenanceCandidates,
 	rankTicketCandidates,
 	allocateBudget,
 	resolveMaintenanceCandidateModel,
+	findMaintenanceCandidates,
 	type MaintenanceCandidate,
 	type TicketCandidate,
 } from '../swarm-plan-batch';
@@ -179,6 +181,103 @@ describe('hasOutstandingInlineFeedback', () => {
 	// Edge
 	it('returns false for no comments', () => {
 		expect(hasOutstandingInlineFeedback([], headCommitDate)).toBe(false);
+	});
+});
+
+describe('hasOutstandingIssueCommentFeedback', () => {
+	const headCommitDate = '2026-01-05T00:00:00Z';
+
+	// Usual
+	it('flags a human top-level comment newer than the head commit as outstanding feedback', () => {
+		const comments = [{ user: { login: 'reviewer' }, body: 'please also edit this', created_at: '2026-01-06T00:00:00Z' }];
+		expect(hasOutstandingIssueCommentFeedback(comments, headCommitDate)).toBe(true);
+	});
+
+	// Structure
+	it('ignores bot-authored comments', () => {
+		const comments = [{ user: { login: 'github-actions[bot]' }, body: 'automated note', created_at: '2026-01-06T00:00:00Z' }];
+		expect(hasOutstandingIssueCommentFeedback(comments, headCommitDate)).toBe(false);
+	});
+
+	it('ignores mermaid-diff-bodied comments', () => {
+		const comments = [{ user: { login: 'wheresrhys' }, body: '```mermaid\nflowchart TB\n```', created_at: '2026-01-06T00:00:00Z' }];
+		expect(hasOutstandingIssueCommentFeedback(comments, headCommitDate)).toBe(false);
+	});
+
+	it('ignores comments with no body', () => {
+		const comments = [{ user: { login: 'reviewer' }, created_at: '2026-01-06T00:00:00Z' }];
+		expect(hasOutstandingIssueCommentFeedback(comments, headCommitDate)).toBe(false);
+	});
+
+	// Edge
+	it('returns false for a comment older than the head commit', () => {
+		const comments = [{ user: { login: 'reviewer' }, body: 'old note', created_at: '2026-01-01T00:00:00Z' }];
+		expect(hasOutstandingIssueCommentFeedback(comments, headCommitDate)).toBe(false);
+	});
+
+	it('returns false for an empty comments array', () => {
+		expect(hasOutstandingIssueCommentFeedback([], headCommitDate)).toBe(false);
+	});
+});
+
+describe('findMaintenanceCandidates', () => {
+	const mockGhJson = vi.mocked(ghJson);
+
+	afterEach(() => {
+		mockGhJson.mockReset();
+	});
+
+	const pr = {
+		number: 515,
+		title: 'Some PR',
+		headRefName: 'feature/515-x',
+		labels: [],
+		mergeable: 'MERGEABLE',
+		reviews: [],
+		commits: [{ committedDate: '2026-01-05T00:00:00Z' }],
+	};
+
+	// Usual
+	it('surfaces a PR whose only outstanding feedback is a top-level issue comment', async () => {
+		mockGhJson
+			.mockResolvedValueOnce([pr]) // pr list
+			.mockResolvedValueOnce([]) // inline comments
+			.mockResolvedValueOnce([
+				{ user: { login: 'wheresrhys' }, body: 'please also edit this', created_at: '2026-01-06T00:00:00Z' },
+			]); // issue comments
+
+		const candidates = await findMaintenanceCandidates();
+
+		expect(candidates).toEqual([
+			{ number: 515, title: 'Some PR', headRefName: 'feature/515-x', labels: [], reason: 'feedback' },
+		]);
+		expect(mockGhJson).toHaveBeenNthCalledWith(3, ['api', 'repos/{owner}/{repo}/issues/515/comments']);
+	});
+
+	// Structure
+	it('does not re-fetch issue comments when review or inline feedback already found it', async () => {
+		mockGhJson
+			.mockResolvedValueOnce([pr]) // pr list
+			.mockResolvedValueOnce([
+				{ id: 1, user: { login: 'wheresrhys' }, body: 'fix this', created_at: '2026-01-06T00:00:00Z' },
+			]); // inline comments
+
+		const candidates = await findMaintenanceCandidates();
+
+		expect(candidates).toHaveLength(1);
+		expect(mockGhJson).toHaveBeenCalledTimes(2);
+	});
+
+	// Edge
+	it('treats a failed issue-comments fetch as no feedback, matching the inline-comment fallback', async () => {
+		mockGhJson
+			.mockResolvedValueOnce([pr]) // pr list
+			.mockResolvedValueOnce([]) // inline comments
+			.mockRejectedValueOnce(new Error('gh error')); // issue comments
+
+		const candidates = await findMaintenanceCandidates();
+
+		expect(candidates).toEqual([]);
 	});
 });
 

--- a/.claude/mcp/swarm-tools/tools/swarm-plan-batch.ts
+++ b/.claude/mcp/swarm-tools/tools/swarm-plan-batch.ts
@@ -73,6 +73,27 @@ export function hasOutstandingInlineFeedback(comments: InlineCommentLike[], head
 	return false;
 }
 
+interface IssueCommentLike {
+	user?: { login?: string };
+	body?: string;
+	created_at?: string;
+}
+
+/**
+ * Flags a top-level PR conversation comment (`GET /issues/{n}/comments` — what both `gh pr
+ * comment` and the `mermaid-diff` skill write to) as outstanding feedback if it's human-authored,
+ * not a mermaid-diff comment, and newer than the PR's head commit. Issue comments are a flat
+ * list, not threaded like review comments, so unlike `hasOutstandingInlineFeedback` there's no
+ * reply-threading step — each comment is evaluated on its own.
+ */
+export function hasOutstandingIssueCommentFeedback(comments: IssueCommentLike[], headCommitDate: string): boolean {
+	return comments.some((comment) => {
+		if (isBotLogin(comment.user?.login)) return false;
+		if (!comment.body || isMermaidDiffComment(comment.body)) return false;
+		return Boolean(comment.created_at && comment.created_at > headCommitDate);
+	});
+}
+
 export interface MaintenanceCandidate {
 	number: number;
 	title: string;
@@ -175,7 +196,7 @@ interface GhIssueListItem {
 	blocking: { nodes: { state: string }[] };
 }
 
-async function findMaintenanceCandidates(): Promise<MaintenanceCandidate[]> {
+export async function findMaintenanceCandidates(): Promise<MaintenanceCandidate[]> {
 	const prs = await ghJson<GhPrListItem[]>([
 		'pr',
 		'list',
@@ -196,6 +217,13 @@ async function findMaintenanceCandidates(): Promise<MaintenanceCandidate[]> {
 				`repos/{owner}/{repo}/pulls/${pr.number}/comments`,
 			]).catch(() => []);
 			hasFeedback = hasOutstandingInlineFeedback(comments, headCommitDate);
+		}
+		if (!hasFeedback) {
+			const issueComments = await ghJson<IssueCommentLike[]>([
+				'api',
+				`repos/{owner}/{repo}/issues/${pr.number}/comments`,
+			]).catch(() => []);
+			hasFeedback = hasOutstandingIssueCommentFeedback(issueComments, headCommitDate);
 		}
 		if (!hasConflict && !hasFeedback) continue;
 		const reason: MaintenanceCandidate['reason'] =


### PR DESCRIPTION
## Why

`findMaintenanceCandidates` (`.claude/mcp/swarm-tools/tools/swarm-plan-batch.ts`) only checked
two feedback sources: PR reviews and inline diff-line comments. It never checked the PR's
top-level conversation thread. Both `gh pr comment` (how humans reply and how the `mermaid-diff`
skill posts) write to that endpoint, so any feedback given as a plain PR comment was invisible to
`swarm_plan_batch` every time — a structural gap, not an intermittent API delay. Discovered live:
PR #515 received real owner feedback that `prsNeedingMaintenance` silently missed on the next
`/swarm` re-scan.

## What

Adds `hasOutstandingIssueCommentFeedback(comments, headCommitDate)`, mirroring
`hasOutstandingInlineFeedback`'s bot/mermaid-diff/recency filtering rules but without the
reply-threading logic (issue comments are a flat list, not threaded). Wires it into
`findMaintenanceCandidates` as a third check, after the existing review and inline-comment checks
both come back negative, fetching `GET repos/{owner}/{repo}/issues/{n}/comments` via `ghJson`
with the same `.catch(() => [])` fallback pattern already used for the inline-comment call.

Exports `findMaintenanceCandidates` (previously module-private) so it can be exercised directly
in tests, since there was no prior integration-style coverage of its wiring.

## Details

- `hasOutstandingReviewFeedback` and `hasOutstandingInlineFeedback` are unchanged.
- No change to swarm's orchestration logic — this only fixes the underlying data
  `swarm_plan_batch` returns.
- No retrofit/backfill for feedback missed before this ships.

## Tests

Added to `.claude/mcp/swarm-tools/tools/__tests__/swarm-plan-batch.test.ts`:
- `hasOutstandingIssueCommentFeedback`: flags a fresh human top-level comment; ignores bot
  comments, mermaid-diff comments, and bodyless comments; returns false for a stale comment and
  for an empty array.
- `findMaintenanceCandidates`: surfaces a PR whose only outstanding feedback is a top-level issue
  comment; skips the issue-comments fetch once review/inline feedback already found something;
  treats a failed issue-comments fetch as no feedback.

`npm run qa` passes (785 app tests, 0 lint errors). Pre-push hook's diff-aware E2E selection ran
the safe suite (91 passed) — this change doesn't touch any `@mutates`-trigger path.

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)