### PR TITLE
Add per-session links to the /highlights pages

### DIFF
--- a/app/(routes)/highlights/[year]/[month]/__tests__/page.test.tsx
+++ b/app/(routes)/highlights/[year]/[month]/__tests__/page.test.tsx
@@ -1,6 +1,13 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import Page from '../page';
+
+vi.mock('@/lib/underlying-stats', () => ({
+	fetchSessionStats: vi.fn().mockResolvedValue({
+		daySpeciesStats: [],
+		sessionDates: ['2026-07-30', '2026-08-01', '2026-08-15', '2026-09-01']
+	})
+}));
 
 describe('/highlights/[year]/[month]', () => {
 	afterEach(() => {
@@ -25,5 +32,33 @@ describe('/highlights/[year]/[month]', () => {
 		);
 		const heading = await screen.findByRole('heading', { level: 1 });
 		expect(heading.textContent).toBe('August 2026 highlights');
+	});
+
+	it('renders only links for dates within the given year and month', async () => {
+		render(
+			await Page({
+				params: Promise.resolve({ year: '2026', month: '08' })
+			})
+		);
+		await screen.findByRole('heading', { level: 1 });
+		const links = screen.getAllByRole('link');
+		expect(links.map((link) => link.getAttribute('href'))).toEqual([
+			'/group/1/session-temp/2026-08-01',
+			'/group/1/session-temp/2026-08-15'
+		]);
+	});
+
+	it('renders only links for dates within the given year and unpadded month', async () => {
+		render(
+			await Page({
+				params: Promise.resolve({ year: '2026', month: '8' })
+			})
+		);
+		await screen.findByRole('heading', { level: 1 });
+		const links = screen.getAllByRole('link');
+		expect(links.map((link) => link.getAttribute('href'))).toEqual([
+			'/group/1/session-temp/2026-08-01',
+			'/group/1/session-temp/2026-08-15'
+		]);
 	});
 });

--- a/app/(routes)/highlights/[year]/[month]/page.tsx
+++ b/app/(routes)/highlights/[year]/[month]/page.tsx
@@ -1,21 +1,43 @@
 import { BootstrapPageData } from '@/app/components/layout/BootstrapPageData';
+import { fetchSessionStats } from '@/lib/underlying-stats';
 import type { ViewedGroup } from '@/lib/group-slug';
 import { HighlightsPage as HighlightsPageContent } from '../../_shared';
 
 export type PageParams = { year: string; month: string };
 type PageProps = { params: Promise<PageParams> };
 
-export type PageData = { year: number; month: number };
+export type PageData = { year: number; month: number; sessionDates: string[] };
 
 export async function fetchYearMonthHighlightsData(
 	{ year, month }: PageParams,
-	_viewedGroupId: number
+	viewedGroupId: number
 ): Promise<PageData> {
-	return { year: Number(year), month: Number(month) };
+	const { sessionDates } = await fetchSessionStats(viewedGroupId);
+	const monthPrefix = `${year}-${String(Number(month)).padStart(2, '0')}`;
+	return {
+		year: Number(year),
+		month: Number(month),
+		sessionDates: sessionDates.filter(
+			(date) => date.slice(0, 7) === monthPrefix
+		)
+	};
 }
 
-function YearMonthHighlights({ data }: { data: PageData }) {
-	return <HighlightsPageContent year={data.year} month={data.month} />;
+function YearMonthHighlights({
+	data,
+	viewedGroup
+}: {
+	data: PageData;
+	viewedGroup: ViewedGroup;
+}) {
+	return (
+		<HighlightsPageContent
+			year={data.year}
+			month={data.month}
+			sessionDates={data.sessionDates}
+			viewedGroupId={viewedGroup.id}
+		/>
+	);
 }
 
 export default async function YearMonthHighlightsPage(

--- a/app/(routes)/highlights/[year]/__tests__/page.test.tsx
+++ b/app/(routes)/highlights/[year]/__tests__/page.test.tsx
@@ -1,6 +1,13 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import Page from '../page';
+
+vi.mock('@/lib/underlying-stats', () => ({
+	fetchSessionStats: vi.fn().mockResolvedValue({
+		daySpeciesStats: [],
+		sessionDates: ['2025-04-01', '2026-01-05', '2026-06-30']
+	})
+}));
 
 describe('/highlights/[year]', () => {
 	afterEach(() => {
@@ -17,5 +24,15 @@ describe('/highlights/[year]', () => {
 		render(await Page({ params: Promise.resolve({ year: '1901' }) }));
 		const heading = await screen.findByRole('heading', { level: 1 });
 		expect(heading.textContent).toBe('1901 highlights');
+	});
+
+	it('renders only links for dates within the given year', async () => {
+		render(await Page({ params: Promise.resolve({ year: '2026' }) }));
+		await screen.findByRole('heading', { level: 1 });
+		const links = screen.getAllByRole('link');
+		expect(links.map((link) => link.getAttribute('href'))).toEqual([
+			'/group/1/session-temp/2026-01-05',
+			'/group/1/session-temp/2026-06-30'
+		]);
 	});
 });

--- a/app/(routes)/highlights/[year]/page.tsx
+++ b/app/(routes)/highlights/[year]/page.tsx
@@ -1,21 +1,38 @@
 import { BootstrapPageData } from '@/app/components/layout/BootstrapPageData';
+import { fetchSessionStats } from '@/lib/underlying-stats';
 import type { ViewedGroup } from '@/lib/group-slug';
 import { HighlightsPage as HighlightsPageContent } from '../_shared';
 
 export type PageParams = { year: string };
 type PageProps = { params: Promise<PageParams> };
 
-export type PageData = { year: number };
+export type PageData = { year: number; sessionDates: string[] };
 
 export async function fetchYearHighlightsData(
 	{ year }: PageParams,
-	_viewedGroupId: number
+	viewedGroupId: number
 ): Promise<PageData> {
-	return { year: Number(year) };
+	const { sessionDates } = await fetchSessionStats(viewedGroupId);
+	return {
+		year: Number(year),
+		sessionDates: sessionDates.filter((date) => date.slice(0, 4) === year)
+	};
 }
 
-function YearHighlights({ data }: { data: PageData }) {
-	return <HighlightsPageContent year={data.year} />;
+function YearHighlights({
+	data,
+	viewedGroup
+}: {
+	data: PageData;
+	viewedGroup: ViewedGroup;
+}) {
+	return (
+		<HighlightsPageContent
+			year={data.year}
+			sessionDates={data.sessionDates}
+			viewedGroupId={viewedGroup.id}
+		/>
+	);
 }
 
 export default async function YearHighlightsPage(

--- a/app/(routes)/highlights/__tests__/page.test.tsx
+++ b/app/(routes)/highlights/__tests__/page.test.tsx
@@ -1,6 +1,13 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { render, screen, cleanup } from '@testing-library/react';
 import Page from '../page';
+
+vi.mock('@/lib/underlying-stats', () => ({
+	fetchSessionStats: vi.fn().mockResolvedValue({
+		daySpeciesStats: [],
+		sessionDates: ['2025-04-01', '2026-01-05']
+	})
+}));
 
 describe('/highlights (all-time)', () => {
 	afterEach(() => {
@@ -11,5 +18,11 @@ describe('/highlights (all-time)', () => {
 		render(await Page());
 		const heading = await screen.findByRole('heading', { level: 1 });
 		expect(heading.textContent).toBe('All time highlights');
+	});
+
+	it('renders a session link for every date returned by fetchSessionStats', async () => {
+		render(await Page());
+		await screen.findByRole('heading', { level: 1 });
+		expect(screen.getAllByRole('link')).toHaveLength(2);
 	});
 });

--- a/app/(routes)/highlights/_shared.tsx
+++ b/app/(routes)/highlights/_shared.tsx
@@ -3,17 +3,28 @@ import {
 	PageWrapper,
 	PrimaryHeading
 } from '@/app/components/shared/DesignSystem';
+import { SessionLinksList } from '@/app/components/SessionLinksList';
 
 export function HighlightsPage({
 	year,
-	month
+	month,
+	sessionDates = [],
+	viewedGroupId
 }: {
 	year?: number;
 	month?: number;
+	sessionDates?: string[];
+	viewedGroupId?: number;
 }) {
 	return (
 		<PageWrapper>
 			<PrimaryHeading>{buildHeading(year, month)}</PrimaryHeading>
+			{viewedGroupId !== undefined && (
+				<SessionLinksList
+					sessionDates={sessionDates}
+					viewedGroupId={viewedGroupId}
+				/>
+			)}
 		</PageWrapper>
 	);
 }

--- a/app/(routes)/highlights/page.tsx
+++ b/app/(routes)/highlights/page.tsx
@@ -1,15 +1,31 @@
 import { BootstrapPageData } from '@/app/components/layout/BootstrapPageData';
+import { fetchSessionStats } from '@/lib/underlying-stats';
 import type { ViewedGroup } from '@/lib/group-slug';
 import { HighlightsPage as HighlightsPageContent } from './_shared';
 
-export type PageData = Record<string, never>;
+export type PageData = { sessionDates: string[] };
 
-export async function fetchAllTimeHighlightsData(): Promise<PageData> {
-	return {};
+export async function fetchAllTimeHighlightsData(
+	_params: Record<string, string>,
+	viewedGroupId: number
+): Promise<PageData> {
+	const { sessionDates } = await fetchSessionStats(viewedGroupId);
+	return { sessionDates };
 }
 
-function AllTimeHighlights() {
-	return <HighlightsPageContent />;
+function AllTimeHighlights({
+	data,
+	viewedGroup
+}: {
+	data: PageData;
+	viewedGroup: ViewedGroup;
+}) {
+	return (
+		<HighlightsPageContent
+			sessionDates={data.sessionDates}
+			viewedGroupId={viewedGroup.id}
+		/>
+	);
 }
 
 export default async function HighlightsPage({

--- a/app/components/SessionLinksList.tsx
+++ b/app/components/SessionLinksList.tsx
@@ -1,0 +1,30 @@
+import { format as formatDate } from 'date-fns';
+import Link from 'next/link';
+import { BoxyList } from './shared/DesignSystem';
+
+export function SessionLinksList({
+	sessionDates,
+	viewedGroupId
+}: {
+	sessionDates: string[];
+	viewedGroupId: number;
+}) {
+	if (sessionDates.length === 0) {
+		return null;
+	}
+
+	return (
+		<BoxyList>
+			{sessionDates.map((date) => (
+				<li key={date}>
+					<Link
+						className="link"
+						href={`/group/${viewedGroupId}/session-temp/${date}`}
+					>
+						{formatDate(new Date(date), 'EEE do MMMM yyyy')}
+					</Link>
+				</li>
+			))}
+		</BoxyList>
+	);
+}

--- a/app/components/__tests__/SessionLinksList.test.tsx
+++ b/app/components/__tests__/SessionLinksList.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import { SessionLinksList } from '../SessionLinksList';
+
+afterEach(cleanup);
+
+const sessionDates = ['2026-01-05', '2026-03-17'];
+
+describe('SessionLinksList', () => {
+	it('renders one link per session date', () => {
+		render(
+			<SessionLinksList sessionDates={sessionDates} viewedGroupId={1} />
+		);
+		expect(screen.getAllByRole('link')).toHaveLength(2);
+	});
+
+	it('links to /group/{viewedGroupId}/session-temp/{date} for each date', () => {
+		render(
+			<SessionLinksList sessionDates={sessionDates} viewedGroupId={7} />
+		);
+		const links = screen.getAllByRole('link');
+		expect(links.map((link) => link.getAttribute('href'))).toEqual([
+			'/group/7/session-temp/2026-01-05',
+			'/group/7/session-temp/2026-03-17'
+		]);
+	});
+
+	it('formats each link text as "EEE do MMMM yyyy"', () => {
+		render(
+			<SessionLinksList sessionDates={sessionDates} viewedGroupId={1} />
+		);
+		const links = screen.getAllByRole('link');
+		expect(links.map((link) => link.textContent?.trim())).toEqual([
+			'Mon 5th January 2026',
+			'Tue 17th March 2026'
+		]);
+	});
+
+	it('renders links in the order sessionDates is given', () => {
+		render(
+			<SessionLinksList
+				sessionDates={['2026-03-17', '2026-01-05']}
+				viewedGroupId={1}
+			/>
+		);
+		const links = screen.getAllByRole('link');
+		expect(links.map((link) => link.textContent?.trim())).toEqual([
+			'Tue 17th March 2026',
+			'Mon 5th January 2026'
+		]);
+	});
+
+	it('renders nothing when sessionDates is empty', () => {
+		const { container } = render(
+			<SessionLinksList sessionDates={[]} viewedGroupId={1} />
+		);
+		expect(container.innerHTML).toBe('');
+	});
+});

--- a/app/components/__tests__/SessionLinksList.test.tsx
+++ b/app/components/__tests__/SessionLinksList.test.tsx
@@ -8,16 +8,12 @@ const sessionDates = ['2026-01-05', '2026-03-17'];
 
 describe('SessionLinksList', () => {
 	it('renders one link per session date', () => {
-		render(
-			<SessionLinksList sessionDates={sessionDates} viewedGroupId={1} />
-		);
+		render(<SessionLinksList sessionDates={sessionDates} viewedGroupId={1} />);
 		expect(screen.getAllByRole('link')).toHaveLength(2);
 	});
 
 	it('links to /group/{viewedGroupId}/session-temp/{date} for each date', () => {
-		render(
-			<SessionLinksList sessionDates={sessionDates} viewedGroupId={7} />
-		);
+		render(<SessionLinksList sessionDates={sessionDates} viewedGroupId={7} />);
 		const links = screen.getAllByRole('link');
 		expect(links.map((link) => link.getAttribute('href'))).toEqual([
 			'/group/7/session-temp/2026-01-05',
@@ -26,9 +22,7 @@ describe('SessionLinksList', () => {
 	});
 
 	it('formats each link text as "EEE do MMMM yyyy"', () => {
-		render(
-			<SessionLinksList sessionDates={sessionDates} viewedGroupId={1} />
-		);
+		render(<SessionLinksList sessionDates={sessionDates} viewedGroupId={1} />);
 		const links = screen.getAllByRole('link');
 		expect(links.map((link) => link.textContent?.trim())).toEqual([
 			'Mon 5th January 2026',


### PR DESCRIPTION
## Why

Ticket #510's three `/highlights` route variants (all-time, year, year/month) are heading-only stubs. Each should let a group jump from a highlights period straight into the individual sessions that make it up, via ticket #508's `/session-temp` route.

## What

Adds a shared `SessionLinksList` component and wires it into all three highlights pages, sourcing `sessionDates` from `fetchSessionStats()` (#507) and filtering by the page's year/month scope.

- `app/components/SessionLinksList.tsx` (new): renders a `BoxyList` of links to `/group/{viewedGroupId}/session-temp/{date}`, text formatted as `EEE do MMMM yyyy` (matches `SessionSummary`). Renders nothing when `sessionDates` is empty.
- `/highlights` (all-time): unfiltered `sessionDates`.
- `/highlights/[year]`: filtered where `date.slice(0, 4) === year`.
- `/highlights/[year]/[month]`: filtered where `date.slice(0, 7)` matches the zero-padded `year-month`.
- `viewedGroup.id`, already flowing through `BootstrapPageData` into each page's `PageComponent`, is threaded down to the new links list.

## Testing

- `SessionLinksList`: renders one link per date, correct href/text/order, renders nothing when empty.
- Each highlights page: session links render for the fetched/filtered dates, existing heading assertions untouched.
- `npm run qa` (lint, type-check, app tests — 808 passed) and the pre-push E2E safe suite (91 passed) both green.

Closes #512

🤖 Generated with [Claude Code](https://claude.com/claude-code)